### PR TITLE
Fix IndexOutOfBounds crash from stale IME composing range

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
@@ -113,7 +113,9 @@ internal fun TextEditorState.imePerformNewline() {
  * character index at which the inserted text starts.
  */
 private fun TextEditorState.replaceComposingOrInsert(text: String): Int {
-	val composing = composingRange
+	// A composing range that survived an out-of-pipeline edit can point past the
+	// current document; treating it as no-composition inserts safely at the cursor.
+	val composing = composingRange?.takeIf { isWithinDocument(it) }
 	return if (composing != null) {
 		val start = getCharacterIndex(composing.start)
 		// inheritStyle keeps autocorrect/composition from stripping bold/italic etc.
@@ -125,6 +127,14 @@ private fun TextEditorState.replaceComposingOrInsert(text: String): Int {
 		insertStringAtCursor(text)
 		start
 	}
+}
+
+/** True if [range] is well-ordered and both endpoints index into the current document. */
+private fun TextEditorState.isWithinDocument(range: TextEditorRange): Boolean {
+	if (!range.validate()) return false
+	if (range.start.line !in textLines.indices || range.end.line !in textLines.indices) return false
+	return range.start.char in 0..textLines[range.start.line].length &&
+			range.end.char in 0..textLines[range.end.line].length
 }
 
 /**

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
@@ -27,7 +27,8 @@ import com.darkrockstudios.texteditor.state.TextEditorState
 internal fun TextEditorState.imeCommitText(text: String, newCursorPosition: Int) {
 	val insertStart = replaceComposingOrInsert(text)
 	val insertEnd = insertStart + text.length
-	// replace / insertStringAtCursor don't touch composingRange — clear it explicitly.
+	// Commit semantics end the composition even when no mutation ran (empty text
+	// with nothing composing), so clear explicitly rather than rely on applyOperation.
 	clearComposingRange()
 	applyNewCursorPosition(insertStart, insertEnd, newCursorPosition)
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
@@ -40,6 +40,12 @@ class TextEditManager(private val state: TextEditorState) {
 		if (!isSpanOperation && state.selector.selection != null) {
 			state.selector.clearSelection()
 		}
+		// Composing offsets go equally stale when content shifts underneath them.
+		// The IME pipeline re-sets its range after each composition edit, so
+		// clearing here never drops a live composition's freshly set range.
+		if (!isSpanOperation && state.composingRange != null) {
+			state.clearComposingRange()
+		}
 
 		val metadata = when (operation) {
 			is TextEditOperation.Insert -> applyInsert(operation)

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/ImeEditLogicTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/ImeEditLogicTest.kt
@@ -2,7 +2,9 @@ package input
 
 import androidx.compose.ui.text.AnnotatedString
 import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.input.imeCommitText
+import com.darkrockstudios.texteditor.input.imeDeleteSurroundingText
 import com.darkrockstudios.texteditor.input.imeDeleteSurroundingTextInCodePoints
 import com.darkrockstudios.texteditor.input.imeFinishComposing
 import com.darkrockstudios.texteditor.input.imeSetComposingText
@@ -136,5 +138,57 @@ class ImeEditLogicTest {
 
 		assertEquals("abc", text(), "Text is kept as-is")
 		assertNull(state.composingRange, "Composing region is dropped")
+	}
+
+	@Test
+	fun `deleteSurroundingText behind the composing text then setComposingText does not crash`() {
+		// AnySoftKeyboard deletes through/behind the composing region with
+		// deleteSurroundingText mid-composition (hammer-editor #732).
+		state.setText("hello ")
+		moveCursorToCharIndex(6)
+		state.imeSetComposingText("wor", newCursorPosition = 1) // "hello wor"
+		state.imeDeleteSurroundingText(beforeLength = 5, afterLength = 0) // "hell"
+
+		state.imeSetComposingText("world", newCursorPosition = 1)
+
+		assertEquals("hellworld", text(), "Composition restarts at the cursor after the delete")
+		assertTrue(state.composingRange != null, "New composition should be active")
+	}
+
+	@Test
+	fun `backspace during composition then setComposingText does not crash`() {
+		// Some keyboards deliver backspace as a raw KEYCODE_DEL key event while a
+		// composition is active, bypassing the IME edit pipeline entirely.
+		state.imeSetComposingText("abc", newCursorPosition = 1)
+		state.backspaceAtCursor() // "ab"
+
+		state.imeSetComposingText("abcd", newCursorPosition = 1)
+
+		assertEquals("ababcd", text(), "Composition restarts at the cursor after the backspace")
+	}
+
+	@Test
+	fun `deleting a line during composition then setComposingText does not crash`() {
+		state.setText("line1\nline2")
+		moveCursorToCharIndex(11)
+		state.imeSetComposingText("xyz", newCursorPosition = 1) // "line1\nline2xyz"
+		state.delete(
+			TextEditorRange(CharLineOffset(0, 0), CharLineOffset(1, 0))
+		) // "line2xyz" — the composing region's line index no longer exists
+
+		state.imeSetComposingText("xy", newCursorPosition = 1)
+
+		assertEquals("xyline2xyz", text())
+	}
+
+	@Test
+	fun `out-of-bounds composing range is ignored instead of crashing`() {
+		state.setText("ab")
+		moveCursorToCharIndex(2)
+		state.composingRange = TextEditorRange(CharLineOffset(0, 5), CharLineOffset(0, 9))
+
+		state.imeSetComposingText("c", newCursorPosition = 1)
+
+		assertEquals("abc", text(), "Stale range is treated as no-composition")
 	}
 }


### PR DESCRIPTION
## Root cause

`TextEditorState.composingRange` stores line/char offsets and is only updated by the explicit IME calls in `ImeEditLogic.kt`. When text was mutated by any path outside the IME composing pipeline — e.g. AnySoftKeyboard's `deleteSurroundingText` during composition, or backspace delivered as a raw `KEYCODE_DEL` key event — the composing range was left pointing at text that no longer existed. The next `setComposingText`/`commitText` then called `replace()` with the stale range, which indexes `textLines` unclamped and threw `IndexOutOfBoundsException`.

## Fix

- `TextEditManager.applyOperation` now clears `composingRange` on every content mutation (span-only operations keep it), mirroring the existing stale-selection clearing. The IME pipeline re-sets its range after each composition edit, so composition edits never lose their own freshly set range.
- Belt-and-braces: `replaceComposingOrInsert` validates the composing range against the current document before replacing through it; an out-of-bounds range is treated as no-composition and the text is inserted at the cursor instead.

## Tests

New regression tests in `ImeEditLogicTest` covering: `deleteSurroundingText` through the composing text, raw backspace during composition, a multi-line deletion that removes the composing range's line, and a directly injected out-of-bounds range. All four reproduce the `IndexOutOfBoundsException` without the fix and pass with it. Full `:ComposeTextEditor:desktopTest` suite passes (475 tests).

Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)