### PR TITLE
Rich copy and paste via text/html on the system clipboard

### DIFF
--- a/ComposeTextEditor/build.gradle.kts
+++ b/ComposeTextEditor/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
                 implementation(libs.androidx.lifecycle.viewmodel)
                 implementation(libs.androidx.lifecycle.runtime.compose)
                 implementation(libs.markdown)
+                implementation(libs.ksoup)
             }
         }
 

--- a/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.android.kt
+++ b/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.android.kt
@@ -5,10 +5,14 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.toClipEntry
 import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 
 @OptIn(ExperimentalComposeUiApi::class)
 actual object ClipboardHelper {
-	actual suspend fun getText(clipboard: Clipboard): AnnotatedString? {
+	actual suspend fun getText(
+		clipboard: Clipboard,
+		configuration: MarkdownConfiguration,
+	): AnnotatedString? {
 		return clipboard.getClipEntry()?.clipData?.let { clipData ->
 			if (clipData.itemCount > 0) {
 				clipData.getItemAt(0).text?.toString()?.let { text ->
@@ -18,7 +22,11 @@ actual object ClipboardHelper {
 		}
 	}
 
-	actual suspend fun setText(clipboard: Clipboard, text: AnnotatedString) {
+	actual suspend fun setText(
+		clipboard: Clipboard,
+		text: AnnotatedString,
+		configuration: MarkdownConfiguration,
+	) {
 		val clipData = ClipData.newPlainText("text", text.text)
 		clipboard.setClipEntry(clipData.toClipEntry())
 	}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.texteditor.clipboard
 
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 
 /**
  * Platform-specific clipboard helper for text operations.
@@ -10,22 +11,36 @@ import androidx.compose.ui.text.AnnotatedString
  * uses suspend functions, this expect/actual pattern provides platform-specific
  * implementations for clipboard text operations.
  *
- * - Desktop: Preserves full AnnotatedString styling
+ * - Desktop: styled, as HTML for other applications and exactly within this process
  * - Android: Plain text only (ClipData limitation)
+ * - iOS: Plain text only (UIPasteboard limitation)
  * - WASM: Plain text only (web clipboard limitation)
+ *
+ * `configuration` supplies the styling that header levels are matched against
+ * when converting to and from HTML, so pass the editor's own or custom header
+ * sizes will not survive the round trip.
  */
 expect object ClipboardHelper {
 	/**
 	 * Reads text from the clipboard.
-	 * On Desktop, attempts to read AnnotatedString with styling preserved.
+	 * On Desktop, reads styled text, preferring an in-process copy and falling back
+	 * to the HTML flavor other applications provide.
 	 * On other platforms, returns plain text as AnnotatedString.
 	 */
-	suspend fun getText(clipboard: Clipboard): AnnotatedString?
+	suspend fun getText(
+		clipboard: Clipboard,
+		configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT,
+	): AnnotatedString?
 
 	/**
 	 * Writes text to the clipboard.
-	 * On Desktop, preserves AnnotatedString styling.
+	 * On Desktop, offers the selection as HTML for other applications and as an
+	 * exact copy within this process.
 	 * On other platforms, writes plain text only.
 	 */
-	suspend fun setText(clipboard: Clipboard, text: AnnotatedString)
+	suspend fun setText(
+		clipboard: Clipboard,
+		text: AnnotatedString,
+		configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT,
+	)
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/ContextMenuActions.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/ContextMenuActions.kt
@@ -40,7 +40,7 @@ class ContextMenuActions(
 			val selectedText = state.selector.getSelectedText()
 			state.selector.deleteSelection()
 			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText)
+				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration)
 			}
 		}
 	}
@@ -52,7 +52,7 @@ class ContextMenuActions(
 		state.selector.selection?.let {
 			val selectedText = state.selector.getSelectedText()
 			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText)
+				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration)
 			}
 		}
 	}
@@ -63,7 +63,7 @@ class ContextMenuActions(
 	 */
 	fun paste() {
 		scope.launch {
-			ClipboardHelper.getText(clipboard)?.let { text ->
+			ClipboardHelper.getText(clipboard, state.markdownConfiguration)?.let { text ->
 				val curSelection = state.selector.selection
 				if (curSelection != null) {
 					state.replace(curSelection, text)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlTag.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlTag.kt
@@ -1,0 +1,70 @@
+package com.darkrockstudios.texteditor.html
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.TextUnit
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+
+/**
+ * The HTML elements the clipboard serializer emits. Declaration order is the
+ * nesting order used when writing: earlier entries wrap later ones.
+ */
+internal enum class HtmlTag(val tag: String) {
+	H1("h1"),
+	H2("h2"),
+	H3("h3"),
+	H4("h4"),
+	H5("h5"),
+	H6("h6"),
+	CODE("code"),
+	STRONG("strong"),
+	EM("em"),
+	STRIKE("s"),
+	UNDERLINE("u"),
+}
+
+internal fun SpanStyle.htmlTags(config: MarkdownConfiguration): Set<HtmlTag> {
+	// A header carries bold plus a size; emitting <strong> as well would make the
+	// paste round-trip back as bold-inside-header, so the header tag stands alone.
+	headerTag(config)?.let { return setOf(it) }
+
+	val tags = LinkedHashSet<HtmlTag>()
+	if (fontWeight == FontWeight.Bold) tags += HtmlTag.STRONG
+	if (fontStyle == FontStyle.Italic) tags += HtmlTag.EM
+	if (fontFamily == FontFamily.Monospace) tags += HtmlTag.CODE
+	textDecoration?.let { decoration ->
+		if (decoration.contains(TextDecoration.LineThrough)) tags += HtmlTag.STRIKE
+		if (decoration.contains(TextDecoration.Underline)) tags += HtmlTag.UNDERLINE
+	}
+	return tags
+}
+
+private fun SpanStyle.headerTag(config: MarkdownConfiguration): HtmlTag? {
+	if (fontWeight != FontWeight.Bold || fontSize == TextUnit.Unspecified) return null
+	return when (fontSize.value) {
+		config.header1Style.fontSize.value -> HtmlTag.H1
+		config.header2Style.fontSize.value -> HtmlTag.H2
+		config.header3Style.fontSize.value -> HtmlTag.H3
+		config.header4Style.fontSize.value -> HtmlTag.H4
+		config.header5Style.fontSize.value -> HtmlTag.H5
+		config.header6Style.fontSize.value -> HtmlTag.H6
+		else -> null
+	}
+}
+
+internal fun HtmlTag.spanStyle(config: MarkdownConfiguration): SpanStyle = when (this) {
+	HtmlTag.H1 -> config.header1Style
+	HtmlTag.H2 -> config.header2Style
+	HtmlTag.H3 -> config.header3Style
+	HtmlTag.H4 -> config.header4Style
+	HtmlTag.H5 -> config.header5Style
+	HtmlTag.H6 -> config.header6Style
+	HtmlTag.CODE -> config.codeStyle
+	HtmlTag.STRONG -> config.boldStyle
+	HtmlTag.EM -> config.italicStyle
+	HtmlTag.STRIKE -> config.strikethroughStyle
+	HtmlTag.UNDERLINE -> SpanStyle(textDecoration = TextDecoration.Underline)
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/annotatedStringToHtml.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/annotatedStringToHtml.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.texteditor.html
 
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
 import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 
 /**
@@ -15,16 +16,18 @@ fun AnnotatedString.toHtml(
 ): String {
 	if (text.isEmpty()) return ""
 
-	val activeTags = Array(text.length) { LinkedHashSet<HtmlTag>() }
+	// Overlapping spans are resolved into one effective style per character before
+	// any tag is chosen. Unioning each span's tags instead would let a wider bold
+	// span re-apply over a narrower one that turned bold back off.
+	val resolved = Array(text.length) { SpanStyle() }
 	spanStyles.forEach { range ->
-		val tags = range.item.htmlTags(configuration)
-		if (tags.isEmpty()) return@forEach
 		val start = range.start.coerceAtLeast(0)
 		val end = range.end.coerceAtMost(text.length)
 		for (i in start until end) {
-			activeTags[i].addAll(tags)
+			resolved[i] = resolved[i].merge(range.item)
 		}
 	}
+	val activeTags = Array(text.length) { resolved[it].htmlTags(configuration) }
 
 	val builder = StringBuilder()
 	var open = emptyList<HtmlTag>()

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/annotatedStringToHtml.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/annotatedStringToHtml.kt
@@ -1,0 +1,76 @@
+package com.darkrockstudios.texteditor.html
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+
+/**
+ * Serializes this [AnnotatedString] to an HTML fragment suitable for the system
+ * clipboard's `text/html` flavor.
+ *
+ * Only styles that map onto the supported tag set survive; anything else is
+ * dropped and its text emitted unstyled. Newlines become `<br>`.
+ */
+fun AnnotatedString.toHtml(
+	configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT
+): String {
+	if (text.isEmpty()) return ""
+
+	val activeTags = Array(text.length) { LinkedHashSet<HtmlTag>() }
+	spanStyles.forEach { range ->
+		val tags = range.item.htmlTags(configuration)
+		if (tags.isEmpty()) return@forEach
+		val start = range.start.coerceAtLeast(0)
+		val end = range.end.coerceAtMost(text.length)
+		for (i in start until end) {
+			activeTags[i].addAll(tags)
+		}
+	}
+
+	val builder = StringBuilder()
+	var open = emptyList<HtmlTag>()
+
+	fun closeAll() {
+		open.asReversed().forEach { builder.append("</").append(it.tag).append('>') }
+		open = emptyList()
+	}
+
+	for (i in text.indices) {
+		val ch = text[i]
+		if (ch == '\n') {
+			// A <br> inside a header or formatting run reopens badly in other apps,
+			// so the break is emitted at the top level between tag runs.
+			closeAll()
+			builder.append("<br>")
+			continue
+		}
+
+		val desired = activeTags[i].sortedBy { it.ordinal }
+		if (desired != open) {
+			closeAll()
+			desired.forEach { builder.append('<').append(it.tag).append('>') }
+			open = desired
+		}
+		// A space at the edge of a run would be swallowed by HTML whitespace
+		// collapsing on the way back in, so those positions are encoded as a
+		// literal entity instead.
+		val atRunEdge = i == 0 || i == text.length - 1 ||
+			text[i - 1] == ' ' || text[i - 1] == '\n' || text[i + 1] == '\n'
+		if (ch == ' ' && atRunEdge) {
+			builder.append("&nbsp;")
+		} else {
+			builder.appendEscaped(ch)
+		}
+	}
+	closeAll()
+
+	return builder.toString()
+}
+
+private fun StringBuilder.appendEscaped(ch: Char) {
+	when (ch) {
+		'&' -> append("&amp;")
+		'<' -> append("&lt;")
+		'>' -> append("&gt;")
+		else -> append(ch)
+	}
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/htmlToAnnotatedString.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/htmlToAnnotatedString.kt
@@ -18,7 +18,38 @@ import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
  */
 fun String.toAnnotatedStringFromHtml(
 	configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT
-): AnnotatedString = HtmlFragmentParser(configuration).parse(this)
+): AnnotatedString = HtmlFragmentParser(configuration).parse(unwrapClipboardHtml(this))
+
+private val START_FRAGMENT = Regex("""<!--\s*StartFragment\s*-->""", RegexOption.IGNORE_CASE)
+private val END_FRAGMENT = Regex("""<!--\s*EndFragment\s*-->""", RegexOption.IGNORE_CASE)
+
+/**
+ * Removes the wrappers the platform puts around clipboard markup.
+ *
+ * Windows hands over the CF_HTML format, which prefixes the document with
+ * `Version:`/`StartHTML:`/`StartFragment:` descriptor lines. Those are not
+ * markup, so without this they parse as body text and land in the document.
+ *
+ * When the source app marked a fragment, only the fragment is kept: the rest of
+ * the document is the surrounding page, not what the user selected.
+ */
+internal fun unwrapClipboardHtml(raw: String): String {
+	var content = raw
+	if (content.trimStart().startsWith("Version:", ignoreCase = true)) {
+		val markupStart = content.indexOf('<')
+		content = if (markupStart == -1) "" else content.substring(markupStart)
+	}
+
+	val start = START_FRAGMENT.find(content)
+	val end = END_FRAGMENT.find(content)
+	return when {
+		start != null && end != null && end.range.first >= start.range.last ->
+			content.substring(start.range.last + 1, end.range.first)
+
+		start != null -> content.substring(start.range.last + 1)
+		else -> content
+	}
+}
 
 private val BLOCK_TAGS = setOf(
 	"p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li", "ul", "ol",

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/htmlToAnnotatedString.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/htmlToAnnotatedString.kt
@@ -1,0 +1,358 @@
+package com.darkrockstudios.texteditor.html
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+
+/**
+ * Parses an HTML fragment (as found on the system clipboard's `text/html`
+ * flavor) into a styled [AnnotatedString].
+ *
+ * Tolerant by design: unknown tags are ignored, unbalanced tags are closed
+ * implicitly, and whitespace follows HTML collapsing rules so markup pasted
+ * from a browser or word processor does not arrive full of layout indentation.
+ */
+fun String.toAnnotatedStringFromHtml(
+	configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT
+): AnnotatedString = HtmlFragmentParser(configuration).parse(this)
+
+private val BLOCK_TAGS = setOf(
+	"p", "div", "h1", "h2", "h3", "h4", "h5", "h6", "li", "ul", "ol",
+	"blockquote", "pre", "tr", "table", "section", "article", "header",
+	"footer", "figure", "figcaption", "dd", "dt", "dl", "hr",
+)
+
+private val VOID_TAGS = setOf(
+	"br", "hr", "img", "meta", "link", "input", "col", "source", "area", "base", "wbr",
+)
+
+private val SKIPPED_CONTENT_TAGS = setOf("script", "style", "head", "title", "noscript")
+
+private val TAG_STYLES = mapOf(
+	"b" to HtmlTag.STRONG,
+	"strong" to HtmlTag.STRONG,
+	"i" to HtmlTag.EM,
+	"em" to HtmlTag.EM,
+	"cite" to HtmlTag.EM,
+	"code" to HtmlTag.CODE,
+	"tt" to HtmlTag.CODE,
+	"kbd" to HtmlTag.CODE,
+	"samp" to HtmlTag.CODE,
+	"s" to HtmlTag.STRIKE,
+	"strike" to HtmlTag.STRIKE,
+	"del" to HtmlTag.STRIKE,
+	"u" to HtmlTag.UNDERLINE,
+	"ins" to HtmlTag.UNDERLINE,
+	"h1" to HtmlTag.H1,
+	"h2" to HtmlTag.H2,
+	"h3" to HtmlTag.H3,
+	"h4" to HtmlTag.H4,
+	"h5" to HtmlTag.H5,
+	"h6" to HtmlTag.H6,
+)
+
+private val STYLE_ATTRIBUTE = Regex("""style\s*=\s*("([^"]*)"|'([^']*)')""", RegexOption.IGNORE_CASE)
+
+private class OpenElement(
+	val name: String,
+	val style: SpanStyle?,
+	val startIndex: Int,
+)
+
+private class HtmlFragmentParser(private val config: MarkdownConfiguration) {
+
+	private val out = StringBuilder()
+	private val spans = mutableListOf<AnnotatedString.Range<SpanStyle>>()
+	private val stack = ArrayDeque<OpenElement>()
+
+	private var pendingBlockBreak = false
+	private var pendingExplicitBreaks = 0
+	private var lastWasSpace = true
+	private var lastWasEntity = false
+	private var preDepth = 0
+
+	private val pendingNewlines: Int
+		get() = maxOf(pendingExplicitBreaks, if (pendingBlockBreak) 1 else 0)
+
+	fun parse(html: String): AnnotatedString {
+		var i = 0
+		while (i < html.length) {
+			val ch = html[i]
+			if (ch != '<') {
+				val next = html.indexOf('<', i).let { if (it == -1) html.length else it }
+				appendTextRun(html, i, next)
+				i = next
+				continue
+			}
+
+			if (html.startsWith("<!--", i)) {
+				val end = html.indexOf("-->", i)
+				i = if (end == -1) html.length else end + 3
+				continue
+			}
+			if (html.startsWith("<!", i) || html.startsWith("<?", i)) {
+				val end = html.indexOf('>', i)
+				i = if (end == -1) html.length else end + 1
+				continue
+			}
+
+			val tag = readTag(html, i)
+			if (tag == null) {
+				appendChar('<')
+				i++
+				continue
+			}
+			i = tag.endIndex
+
+			if (tag.name in SKIPPED_CONTENT_TAGS) {
+				if (!tag.isClose && !tag.isSelfClosing) {
+					i = skipContent(html, tag.name, i)
+				}
+				continue
+			}
+
+			if (tag.isClose) handleCloseTag(tag) else handleOpenTag(tag)
+		}
+
+		while (stack.isNotEmpty()) closeElement(stack.removeLast())
+		trimTrailingLayoutSpace()
+
+		val text = out.toString()
+		val clamped = spans.mapNotNull { span ->
+			val end = span.end.coerceAtMost(text.length)
+			if (span.start >= end) null else AnnotatedString.Range(span.item, span.start, end)
+		}
+		return AnnotatedString(text, clamped)
+	}
+
+	private fun handleOpenTag(tag: Tag) {
+		if (tag.name == "br") {
+			pendingExplicitBreaks++
+			lastWasSpace = true
+			return
+		}
+		if (tag.name in BLOCK_TAGS) requestBlockBreak()
+		if (tag.name == "pre") preDepth++
+		if (tag.name in VOID_TAGS || tag.isSelfClosing) return
+
+		val style = TAG_STYLES[tag.name]?.spanStyle(config) ?: styleFromAttributes(tag.attributes)
+		stack.addLast(OpenElement(tag.name, style, out.length))
+	}
+
+	private fun handleCloseTag(tag: Tag) {
+		if (tag.name == "pre" && preDepth > 0) preDepth--
+		if (tag.name in BLOCK_TAGS) requestBlockBreak()
+
+		val depth = stack.indexOfLast { it.name == tag.name }
+		if (depth == -1) return
+		while (stack.size > depth) closeElement(stack.removeLast())
+	}
+
+	private fun closeElement(element: OpenElement) {
+		val style = element.style ?: return
+		if (out.length > element.startIndex) {
+			spans += AnnotatedString.Range(style, element.startIndex, out.length)
+		}
+	}
+
+	private fun requestBlockBreak() {
+		if (out.isNotEmpty()) pendingBlockBreak = true
+		lastWasSpace = true
+	}
+
+	private fun flushNewlines() {
+		val count = pendingNewlines
+		pendingBlockBreak = false
+		pendingExplicitBreaks = 0
+		if (count == 0) return
+
+		trimTrailingLayoutSpace()
+		repeat(count) { out.append('\n') }
+		lastWasSpace = true
+		lastWasEntity = false
+	}
+
+	/**
+	 * Drops a collapsed space sitting at a line break or at the end of the
+	 * document. A space that came from a character entity is literal content, so
+	 * it is left alone.
+	 */
+	private fun trimTrailingLayoutSpace() {
+		if (lastWasEntity || preDepth > 0) return
+		if (out.isNotEmpty() && out.last() == ' ') out.deleteAt(out.length - 1)
+	}
+
+	private fun appendTextRun(html: String, start: Int, end: Int) {
+		var i = start
+		while (i < end) {
+			val ch = html[i]
+			if (ch == '&') {
+				val decoded = decodeEntity(html, i, end)
+				if (decoded != null) {
+					// Entity-encoded whitespace is literal, so it bypasses collapsing.
+					// That is what keeps `&nbsp;` runs from being squashed to one space.
+					flushNewlines()
+					out.append(decoded.value)
+					lastWasSpace = false
+					lastWasEntity = true
+					i = decoded.endIndex
+					continue
+				}
+			}
+			appendChar(ch)
+			i++
+		}
+	}
+
+	private fun appendChar(ch: Char) {
+		if (preDepth > 0) {
+			flushNewlines()
+			out.append(ch)
+			lastWasSpace = ch == ' '
+			lastWasEntity = false
+			return
+		}
+		if (ch.isWhitespace()) {
+			if (!lastWasSpace && pendingNewlines == 0 && out.isNotEmpty()) {
+				out.append(' ')
+				lastWasSpace = true
+				lastWasEntity = false
+			}
+			return
+		}
+		flushNewlines()
+		out.append(ch)
+		lastWasSpace = false
+		lastWasEntity = false
+	}
+
+	private fun styleFromAttributes(attributes: String): SpanStyle? {
+		val match = STYLE_ATTRIBUTE.find(attributes) ?: return null
+		val declarations = (match.groupValues[2].ifEmpty { match.groupValues[3] })
+		var style = SpanStyle()
+		var matched = false
+		declarations.split(';').forEach { declaration ->
+			val separator = declaration.indexOf(':')
+			if (separator == -1) return@forEach
+			val property = declaration.substring(0, separator).trim().lowercase()
+			val value = declaration.substring(separator + 1).trim().lowercase()
+			when (property) {
+				"font-weight" -> if (value == "bold" || value == "bolder" ||
+					(value.toIntOrNull() ?: 0) >= 600
+				) {
+					style = style.copy(fontWeight = FontWeight.Bold)
+					matched = true
+				}
+
+				"font-style" -> if (value == "italic" || value == "oblique") {
+					style = style.copy(fontStyle = FontStyle.Italic)
+					matched = true
+				}
+
+				"font-family" -> if (
+					value.contains("monospace") || value.contains("courier") ||
+					value.contains("consolas") || value.contains("menlo")
+				) {
+					style = style.copy(fontFamily = FontFamily.Monospace)
+					matched = true
+				}
+
+				"text-decoration", "text-decoration-line" -> {
+					val decorations = buildList {
+						if (value.contains("underline")) add(TextDecoration.Underline)
+						if (value.contains("line-through")) add(TextDecoration.LineThrough)
+					}
+					if (decorations.isNotEmpty()) {
+						style = style.copy(textDecoration = TextDecoration.combine(decorations))
+						matched = true
+					}
+				}
+			}
+		}
+		return if (matched) style else null
+	}
+
+	private fun skipContent(html: String, name: String, from: Int): Int {
+		var i = from
+		while (i < html.length) {
+			val next = html.indexOf('<', i)
+			if (next == -1) return html.length
+			val tag = readTag(html, next)
+			if (tag != null && tag.isClose && tag.name == name) return tag.endIndex
+			i = next + 1
+		}
+		return html.length
+	}
+}
+
+private class Tag(
+	val name: String,
+	val isClose: Boolean,
+	val isSelfClosing: Boolean,
+	val attributes: String,
+	val endIndex: Int,
+)
+
+private fun readTag(html: String, start: Int): Tag? {
+	var i = start + 1
+	if (i >= html.length) return null
+
+	val isClose = html[i] == '/'
+	if (isClose) i++
+
+	val nameStart = i
+	while (i < html.length && (html[i].isLetterOrDigit() || html[i] == '-')) i++
+	if (i == nameStart) return null
+	val name = html.substring(nameStart, i).lowercase()
+
+	val attributesStart = i
+	var quote: Char? = null
+	while (i < html.length) {
+		val ch = html[i]
+		when {
+			quote != null -> if (ch == quote) quote = null
+			ch == '"' || ch == '\'' -> quote = ch
+			ch == '>' -> {
+				val raw = html.substring(attributesStart, i)
+				val selfClosing = raw.trimEnd().endsWith("/")
+				return Tag(name, isClose, selfClosing, raw, i + 1)
+			}
+		}
+		i++
+	}
+	return null
+}
+
+private class DecodedEntity(val value: Char, val endIndex: Int)
+
+private fun decodeEntity(html: String, start: Int, limit: Int): DecodedEntity? {
+	val semicolon = html.indexOf(';', start)
+	if (semicolon == -1 || semicolon >= limit || semicolon - start > 10) return null
+	val body = html.substring(start + 1, semicolon)
+	if (body.isEmpty()) return null
+
+	if (body[0] == '#') {
+		val code = if (body.length > 1 && (body[1] == 'x' || body[1] == 'X')) {
+			body.substring(2).toIntOrNull(16)
+		} else {
+			body.substring(1).toIntOrNull()
+		} ?: return null
+		if (code !in 1..0xFFFF) return null
+		return DecodedEntity(code.toChar(), semicolon + 1)
+	}
+
+	val value = when (body.lowercase()) {
+		"amp" -> '&'
+		"lt" -> '<'
+		"gt" -> '>'
+		"quot" -> '"'
+		"apos" -> '\''
+		"nbsp" -> ' '
+		else -> return null
+	}
+	return DecodedEntity(value, semicolon + 1)
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/htmlToAnnotatedString.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/htmlToAnnotatedString.kt
@@ -92,13 +92,22 @@ private class OpenElement(
 	val name: String,
 	val style: SpanStyle?,
 	val startIndex: Int,
+	val order: Int,
+)
+
+private class ParsedSpan(
+	val style: SpanStyle,
+	val start: Int,
+	val end: Int,
+	val order: Int,
 )
 
 private class HtmlFragmentParser(private val config: MarkdownConfiguration) {
 
 	private val out = StringBuilder()
-	private val spans = mutableListOf<AnnotatedString.Range<SpanStyle>>()
+	private val spans = mutableListOf<ParsedSpan>()
 	private val stack = ArrayDeque<OpenElement>()
+	private var nextOrder = 0
 
 	private var pendingBlockBreak = false
 	private var pendingExplicitBreaks = 0
@@ -153,9 +162,12 @@ private class HtmlFragmentParser(private val config: MarkdownConfiguration) {
 		trimTrailingLayoutSpace()
 
 		val text = out.toString()
-		val clamped = spans.mapNotNull { span ->
+		// Sorted by the order the elements opened, so an outer span lands earlier in
+		// the list than the elements it contains. Rendering merges later spans over
+		// earlier ones, which is what lets an inner style override its wrapper.
+		val clamped = spans.sortedBy { it.order }.mapNotNull { span ->
 			val end = span.end.coerceAtMost(text.length)
-			if (span.start >= end) null else AnnotatedString.Range(span.item, span.start, end)
+			if (span.start >= end) null else AnnotatedString.Range(span.style, span.start, end)
 		}
 		return AnnotatedString(text, clamped)
 	}
@@ -170,8 +182,16 @@ private class HtmlFragmentParser(private val config: MarkdownConfiguration) {
 		if (tag.name == "pre") preDepth++
 		if (tag.name in VOID_TAGS || tag.isSelfClosing) return
 
-		val style = TAG_STYLES[tag.name]?.spanStyle(config) ?: styleFromAttributes(tag.attributes)
-		stack.addLast(OpenElement(tag.name, style, out.length))
+		// The inline style is layered over the tag's own meaning rather than replacing
+		// it, so `<b style="font-weight:normal">` (which Word and Google Docs wrap
+		// whole fragments in) cancels the bold instead of applying it.
+		val tagStyle = TAG_STYLES[tag.name]?.spanStyle(config)
+		val inlineStyle = styleFromAttributes(tag.attributes)
+		val style = when {
+			tagStyle != null && inlineStyle != null -> tagStyle.merge(inlineStyle)
+			else -> tagStyle ?: inlineStyle
+		}
+		stack.addLast(OpenElement(tag.name, style, out.length, nextOrder++))
 	}
 
 	private fun handleCloseTag(tag: Tag) {
@@ -186,7 +206,7 @@ private class HtmlFragmentParser(private val config: MarkdownConfiguration) {
 	private fun closeElement(element: OpenElement) {
 		val style = element.style ?: return
 		if (out.length > element.startIndex) {
-			spans += AnnotatedString.Range(style, element.startIndex, out.length)
+			spans += ParsedSpan(style, element.startIndex, out.length, element.order)
 		}
 	}
 
@@ -272,15 +292,25 @@ private class HtmlFragmentParser(private val config: MarkdownConfiguration) {
 			val property = declaration.substring(0, separator).trim().lowercase()
 			val value = declaration.substring(separator + 1).trim().lowercase()
 			when (property) {
-				"font-weight" -> if (value == "bold" || value == "bolder" ||
-					(value.toIntOrNull() ?: 0) >= 600
-				) {
-					style = style.copy(fontWeight = FontWeight.Bold)
-					matched = true
+				"font-weight" -> {
+					val weight = value.toIntOrNull()
+					val bold = value == "bold" || value == "bolder" ||
+						(weight != null && weight >= 600)
+					val normal = value == "normal" || value == "lighter" ||
+						(weight != null && weight < 600)
+					if (bold || normal) {
+						style = style.copy(
+							fontWeight = if (bold) FontWeight.Bold else FontWeight.Normal
+						)
+						matched = true
+					}
 				}
 
 				"font-style" -> if (value == "italic" || value == "oblique") {
 					style = style.copy(fontStyle = FontStyle.Italic)
+					matched = true
+				} else if (value == "normal") {
+					style = style.copy(fontStyle = FontStyle.Normal)
 					matched = true
 				}
 
@@ -299,6 +329,9 @@ private class HtmlFragmentParser(private val config: MarkdownConfiguration) {
 					}
 					if (decorations.isNotEmpty()) {
 						style = style.copy(textDecoration = TextDecoration.combine(decorations))
+						matched = true
+					} else if (value.contains("none")) {
+						style = style.copy(textDecoration = TextDecoration.None)
 						matched = true
 					}
 				}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/htmlToAnnotatedString.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/htmlToAnnotatedString.kt
@@ -2,23 +2,26 @@ package com.darkrockstudios.texteditor.html
 
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
 import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
+import com.fleeksoft.ksoup.nodes.Node
+import com.fleeksoft.ksoup.nodes.TextNode
 
 /**
  * Parses an HTML fragment (as found on the system clipboard's `text/html`
  * flavor) into a styled [AnnotatedString].
  *
- * Tolerant by design: unknown tags are ignored, unbalanced tags are closed
- * implicitly, and whitespace follows HTML collapsing rules so markup pasted
- * from a browser or word processor does not arrive full of layout indentation.
+ * Tokenizing is delegated to Ksoup, so malformed markup, unbalanced tags and the
+ * full HTML5 entity set are handled to spec. What happens here is the mapping
+ * from the resulting document onto Compose spans.
  */
 fun String.toAnnotatedStringFromHtml(
 	configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT
-): AnnotatedString = HtmlFragmentParser(configuration).parse(unwrapClipboardHtml(this))
+): AnnotatedString {
+	val body = Ksoup.parseBodyFragment(unwrapClipboardHtml(this)).body()
+	return HtmlSpanBuilder(configuration).build(body)
+}
 
 private val START_FRAGMENT = Regex("""<!--\s*StartFragment\s*-->""", RegexOption.IGNORE_CASE)
 private val END_FRAGMENT = Regex("""<!--\s*EndFragment\s*-->""", RegexOption.IGNORE_CASE)
@@ -57,11 +60,13 @@ private val BLOCK_TAGS = setOf(
 	"footer", "figure", "figcaption", "dd", "dt", "dl", "hr",
 )
 
-private val VOID_TAGS = setOf(
-	"br", "hr", "img", "meta", "link", "input", "col", "source", "area", "base", "wbr",
-)
+/** Cells separate with a tab rather than a line break, matching a plain-text copy of a table. */
+private val CELL_TAGS = setOf("td", "th")
 
-private val SKIPPED_CONTENT_TAGS = setOf("script", "style", "head", "title", "noscript")
+private val SKIPPED_TAGS = setOf("script", "style", "head", "title", "noscript")
+
+/** What `&nbsp;` decodes to. Content rather than layout, so it escapes whitespace collapsing. */
+private const val NO_BREAK_SPACE = '\u00A0'
 
 private val TAG_STYLES = mapOf(
 	"b" to HtmlTag.STRONG,
@@ -86,337 +91,246 @@ private val TAG_STYLES = mapOf(
 	"h6" to HtmlTag.H6,
 )
 
-private val STYLE_ATTRIBUTE = Regex("""style\s*=\s*("([^"]*)"|'([^']*)')""", RegexOption.IGNORE_CASE)
-
-private class OpenElement(
-	val name: String,
-	val style: SpanStyle?,
-	val startIndex: Int,
-	val order: Int,
-)
-
-private class ParsedSpan(
-	val style: SpanStyle,
-	val start: Int,
-	val end: Int,
-	val order: Int,
-)
-
-private class HtmlFragmentParser(private val config: MarkdownConfiguration) {
+/**
+ * Walks the parsed document and records which styles are in force over each run
+ * of text.
+ *
+ * Style cancellation is resolved during the walk rather than emitted as a
+ * competing span: `<b style="font-weight:normal">`, which Word and Google Docs
+ * wrap whole fragments in, simply does not contribute bold to its subtree. That
+ * keeps the resulting span list free of styles that exist only to undo another
+ * one, which nothing downstream would know to apply in the right order.
+ */
+private class HtmlSpanBuilder(private val config: MarkdownConfiguration) {
 
 	private val out = StringBuilder()
-	private val spans = mutableListOf<ParsedSpan>()
-	private val stack = ArrayDeque<OpenElement>()
-	private var nextOrder = 0
+	private val spans = mutableListOf<AnnotatedString.Range<SpanStyle>>()
+
+	private var currentActive = emptySet<HtmlTag>()
+	private val runStart = HashMap<HtmlTag, Int>()
 
 	private var pendingBlockBreak = false
 	private var pendingExplicitBreaks = 0
+	private var pendingCellBreak = false
 	private var lastWasSpace = true
-	private var lastWasEntity = false
-	private var preDepth = 0
+	private var trailingSpaceIsLiteral = false
 
-	private val pendingNewlines: Int
-		get() = maxOf(pendingExplicitBreaks, if (pendingBlockBreak) 1 else 0)
-
-	fun parse(html: String): AnnotatedString {
-		var i = 0
-		while (i < html.length) {
-			val ch = html[i]
-			if (ch != '<') {
-				val next = html.indexOf('<', i).let { if (it == -1) html.length else it }
-				appendTextRun(html, i, next)
-				i = next
-				continue
-			}
-
-			if (html.startsWith("<!--", i)) {
-				val end = html.indexOf("-->", i)
-				i = if (end == -1) html.length else end + 3
-				continue
-			}
-			if (html.startsWith("<!", i) || html.startsWith("<?", i)) {
-				val end = html.indexOf('>', i)
-				i = if (end == -1) html.length else end + 1
-				continue
-			}
-
-			val tag = readTag(html, i)
-			if (tag == null) {
-				appendChar('<')
-				i++
-				continue
-			}
-			i = tag.endIndex
-
-			if (tag.name in SKIPPED_CONTENT_TAGS) {
-				if (!tag.isClose && !tag.isSelfClosing) {
-					i = skipContent(html, tag.name, i)
-				}
-				continue
-			}
-
-			if (tag.isClose) handleCloseTag(tag) else handleOpenTag(tag)
-		}
-
-		while (stack.isNotEmpty()) closeElement(stack.removeLast())
+	fun build(body: Element): AnnotatedString {
+		visitChildren(body, emptySet(), preformatted = false)
 		trimTrailingLayoutSpace()
+		syncActive(emptySet())
+		repeat(pendingExplicitBreaks) { out.append('\n') }
 
 		val text = out.toString()
-		// Sorted by the order the elements opened, so an outer span lands earlier in
-		// the list than the elements it contains. Rendering merges later spans over
-		// earlier ones, which is what lets an inner style override its wrapper.
-		val clamped = spans.sortedBy { it.order }.mapNotNull { span ->
+		val clamped = spans.mapNotNull { span ->
 			val end = span.end.coerceAtMost(text.length)
-			if (span.start >= end) null else AnnotatedString.Range(span.style, span.start, end)
+			if (span.start >= end) null else AnnotatedString.Range(span.item, span.start, end)
 		}
 		return AnnotatedString(text, clamped)
 	}
 
-	private fun handleOpenTag(tag: Tag) {
-		if (tag.name == "br") {
+	private fun visitChildren(parent: Element, active: Set<HtmlTag>, preformatted: Boolean) {
+		parent.childNodes().forEach { node -> visit(node, active, preformatted) }
+	}
+
+	private fun visit(node: Node, active: Set<HtmlTag>, preformatted: Boolean) {
+		when (node) {
+			is TextNode -> appendText(node.getWholeText(), active, preformatted)
+			is Element -> visitElement(node, active, preformatted)
+			else -> {}
+		}
+	}
+
+	private fun visitElement(element: Element, active: Set<HtmlTag>, preformatted: Boolean) {
+		val name = element.tagName().lowercase()
+		if (name in SKIPPED_TAGS) return
+
+		if (name == "br") {
 			pendingExplicitBreaks++
 			lastWasSpace = true
 			return
 		}
-		if (tag.name in BLOCK_TAGS) requestBlockBreak()
-		if (tag.name == "pre") preDepth++
-		if (tag.name in VOID_TAGS || tag.isSelfClosing) return
 
-		// The inline style is layered over the tag's own meaning rather than replacing
-		// it, so `<b style="font-weight:normal">` (which Word and Google Docs wrap
-		// whole fragments in) cancels the bold instead of applying it.
-		val tagStyle = TAG_STYLES[tag.name]?.spanStyle(config)
-		val inlineStyle = styleFromAttributes(tag.attributes)
-		val style = when {
-			tagStyle != null && inlineStyle != null -> tagStyle.merge(inlineStyle)
-			else -> tagStyle ?: inlineStyle
-		}
-		stack.addLast(OpenElement(tag.name, style, out.length, nextOrder++))
-	}
+		val isBlock = name in BLOCK_TAGS
+		val isCell = name in CELL_TAGS
+		if (isBlock) requestBlockBreak() else if (isCell) requestCellBreak()
 
-	private fun handleCloseTag(tag: Tag) {
-		if (tag.name == "pre" && preDepth > 0) preDepth--
-		if (tag.name in BLOCK_TAGS) requestBlockBreak()
+		val style = element.attr("style")
+		val nested = resolveTags(name, style, active)
+		val nestedPre = preformatted || name == "pre" || isPreformatted(style)
 
-		val depth = stack.indexOfLast { it.name == tag.name }
-		if (depth == -1) return
-		while (stack.size > depth) closeElement(stack.removeLast())
-	}
+		visitChildren(element, nested, nestedPre)
 
-	private fun closeElement(element: OpenElement) {
-		val style = element.style ?: return
-		if (out.length > element.startIndex) {
-			spans += ParsedSpan(style, element.startIndex, out.length, element.order)
-		}
-	}
-
-	private fun requestBlockBreak() {
-		if (out.isNotEmpty()) pendingBlockBreak = true
-		lastWasSpace = true
-	}
-
-	private fun flushNewlines() {
-		val count = pendingNewlines
-		pendingBlockBreak = false
-		pendingExplicitBreaks = 0
-		if (count == 0) return
-
-		trimTrailingLayoutSpace()
-		repeat(count) { out.append('\n') }
-		lastWasSpace = true
-		lastWasEntity = false
+		if (isBlock) requestBlockBreak() else if (isCell) requestCellBreak()
 	}
 
 	/**
-	 * Drops a collapsed space sitting at a line break or at the end of the
-	 * document. A space that came from a character entity is literal content, so
-	 * it is left alone.
+	 * Closes the runs of any style no longer in force and opens runs for any newly
+	 * in force, both at the current output position.
+	 *
+	 * Driven from the text being appended rather than from element boundaries: a
+	 * descendant that cancels a style has to end its ancestor's run, so an element
+	 * cannot simply claim its whole subtree.
 	 */
-	private fun trimTrailingLayoutSpace() {
-		if (lastWasEntity || preDepth > 0) return
-		if (out.isNotEmpty() && out.last() == ' ') out.deleteAt(out.length - 1)
-	}
-
-	private fun appendTextRun(html: String, start: Int, end: Int) {
-		var i = start
-		while (i < end) {
-			val ch = html[i]
-			if (ch == '&') {
-				val decoded = decodeEntity(html, i, end)
-				if (decoded != null) {
-					// Entity-encoded whitespace is literal, so it bypasses collapsing.
-					// That is what keeps `&nbsp;` runs from being squashed to one space.
-					flushNewlines()
-					out.append(decoded.value)
-					lastWasSpace = false
-					lastWasEntity = true
-					i = decoded.endIndex
-					continue
+	private fun syncActive(active: Set<HtmlTag>) {
+		if (active == currentActive) return
+		currentActive.forEach { tag ->
+			if (tag !in active) {
+				val start = runStart.remove(tag) ?: return@forEach
+				if (out.length > start) {
+					spans += AnnotatedString.Range(tag.spanStyle(config), start, out.length)
 				}
 			}
-			appendChar(ch)
-			i++
 		}
+		active.forEach { tag ->
+			if (tag !in currentActive) runStart[tag] = out.length
+		}
+		currentActive = active
 	}
 
-	private fun appendChar(ch: Char) {
-		if (preDepth > 0) {
-			flushNewlines()
-			out.append(ch)
-			lastWasSpace = ch == ' '
-			lastWasEntity = false
-			return
-		}
-		if (ch.isWhitespace()) {
-			if (!lastWasSpace && pendingNewlines == 0 && out.isNotEmpty()) {
-				out.append(' ')
-				lastWasSpace = true
-				lastWasEntity = false
-			}
-			return
-		}
-		flushNewlines()
-		out.append(ch)
-		lastWasSpace = false
-		lastWasEntity = false
-	}
+	private fun resolveTags(name: String, style: String, active: Set<HtmlTag>): Set<HtmlTag> {
+		val result = LinkedHashSet(active)
+		TAG_STYLES[name]?.let { result += it }
+		if (style.isEmpty()) return result
 
-	private fun styleFromAttributes(attributes: String): SpanStyle? {
-		val match = STYLE_ATTRIBUTE.find(attributes) ?: return null
-		val declarations = (match.groupValues[2].ifEmpty { match.groupValues[3] })
-		var style = SpanStyle()
-		var matched = false
-		declarations.split(';').forEach { declaration ->
-			val separator = declaration.indexOf(':')
-			if (separator == -1) return@forEach
-			val property = declaration.substring(0, separator).trim().lowercase()
-			val value = declaration.substring(separator + 1).trim().lowercase()
+		// Each directive settles its own tag in both directions, so an inline style
+		// always beats the meaning the element's tag name carries.
+		forEachDeclaration(style) { property, value ->
 			when (property) {
 				"font-weight" -> {
 					val weight = value.toIntOrNull()
-					val bold = value == "bold" || value == "bolder" ||
-						(weight != null && weight >= 600)
-					val normal = value == "normal" || value == "lighter" ||
-						(weight != null && weight < 600)
-					if (bold || normal) {
-						style = style.copy(
-							fontWeight = if (bold) FontWeight.Bold else FontWeight.Normal
-						)
-						matched = true
+					when {
+						value == "bold" || value == "bolder" ||
+							(weight != null && weight >= 600) -> result += HtmlTag.STRONG
+
+						value == "normal" || value == "lighter" ||
+							(weight != null && weight < 600) -> result -= HtmlTag.STRONG
 					}
 				}
 
-				"font-style" -> if (value == "italic" || value == "oblique") {
-					style = style.copy(fontStyle = FontStyle.Italic)
-					matched = true
-				} else if (value == "normal") {
-					style = style.copy(fontStyle = FontStyle.Normal)
-					matched = true
+				"font-style" -> when (value) {
+					"italic", "oblique" -> result += HtmlTag.EM
+					"normal" -> result -= HtmlTag.EM
 				}
 
 				"font-family" -> if (
 					value.contains("monospace") || value.contains("courier") ||
 					value.contains("consolas") || value.contains("menlo")
 				) {
-					style = style.copy(fontFamily = FontFamily.Monospace)
-					matched = true
+					result += HtmlTag.CODE
 				}
 
 				"text-decoration", "text-decoration-line" -> {
-					val decorations = buildList {
-						if (value.contains("underline")) add(TextDecoration.Underline)
-						if (value.contains("line-through")) add(TextDecoration.LineThrough)
-					}
-					if (decorations.isNotEmpty()) {
-						style = style.copy(textDecoration = TextDecoration.combine(decorations))
-						matched = true
-					} else if (value.contains("none")) {
-						style = style.copy(textDecoration = TextDecoration.None)
-						matched = true
+					if (value.contains("underline")) result += HtmlTag.UNDERLINE
+					if (value.contains("line-through")) result += HtmlTag.STRIKE
+					if (value.contains("none")) {
+						result -= HtmlTag.UNDERLINE
+						result -= HtmlTag.STRIKE
 					}
 				}
 			}
 		}
-		return if (matched) style else null
+		return result
 	}
 
-	private fun skipContent(html: String, name: String, from: Int): Int {
-		var i = from
-		while (i < html.length) {
-			val next = html.indexOf('<', i)
-			if (next == -1) return html.length
-			val tag = readTag(html, next)
-			if (tag != null && tag.isClose && tag.name == name) return tag.endIndex
-			i = next + 1
-		}
-		return html.length
-	}
-}
-
-private class Tag(
-	val name: String,
-	val isClose: Boolean,
-	val isSelfClosing: Boolean,
-	val attributes: String,
-	val endIndex: Int,
-)
-
-private fun readTag(html: String, start: Int): Tag? {
-	var i = start + 1
-	if (i >= html.length) return null
-
-	val isClose = html[i] == '/'
-	if (isClose) i++
-
-	val nameStart = i
-	while (i < html.length && (html[i].isLetterOrDigit() || html[i] == '-')) i++
-	if (i == nameStart) return null
-	val name = html.substring(nameStart, i).lowercase()
-
-	val attributesStart = i
-	var quote: Char? = null
-	while (i < html.length) {
-		val ch = html[i]
-		when {
-			quote != null -> if (ch == quote) quote = null
-			ch == '"' || ch == '\'' -> quote = ch
-			ch == '>' -> {
-				val raw = html.substring(attributesStart, i)
-				val selfClosing = raw.trimEnd().endsWith("/")
-				return Tag(name, isClose, selfClosing, raw, i + 1)
+	private fun isPreformatted(style: String): Boolean {
+		var preformatted = false
+		forEachDeclaration(style) { property, value ->
+			if (property == "white-space" &&
+				(value == "pre" || value.startsWith("pre-wrap") || value.startsWith("break-spaces"))
+			) {
+				preformatted = true
 			}
 		}
-		i++
-	}
-	return null
-}
-
-private class DecodedEntity(val value: Char, val endIndex: Int)
-
-private fun decodeEntity(html: String, start: Int, limit: Int): DecodedEntity? {
-	val semicolon = html.indexOf(';', start)
-	if (semicolon == -1 || semicolon >= limit || semicolon - start > 10) return null
-	val body = html.substring(start + 1, semicolon)
-	if (body.isEmpty()) return null
-
-	if (body[0] == '#') {
-		val code = if (body.length > 1 && (body[1] == 'x' || body[1] == 'X')) {
-			body.substring(2).toIntOrNull(16)
-		} else {
-			body.substring(1).toIntOrNull()
-		} ?: return null
-		if (code !in 1..0xFFFF) return null
-		return DecodedEntity(code.toChar(), semicolon + 1)
+		return preformatted
 	}
 
-	val value = when (body.lowercase()) {
-		"amp" -> '&'
-		"lt" -> '<'
-		"gt" -> '>'
-		"quot" -> '"'
-		"apos" -> '\''
-		"nbsp" -> ' '
-		else -> return null
+	private inline fun forEachDeclaration(style: String, action: (String, String) -> Unit) {
+		style.split(';').forEach { declaration ->
+			val separator = declaration.indexOf(':')
+			if (separator == -1) return@forEach
+			action(
+				declaration.substring(0, separator).trim().lowercase(),
+				declaration.substring(separator + 1).trim().lowercase(),
+			)
+		}
 	}
-	return DecodedEntity(value, semicolon + 1)
+
+	private fun requestBlockBreak() {
+		if (out.isNotEmpty()) pendingBlockBreak = true
+		pendingCellBreak = false
+		lastWasSpace = true
+	}
+
+	private fun requestCellBreak() {
+		if (out.isNotEmpty() && pendingNewlines() == 0) pendingCellBreak = true
+		lastWasSpace = true
+	}
+
+	private fun pendingNewlines(): Int =
+		maxOf(pendingExplicitBreaks, if (pendingBlockBreak) 1 else 0)
+
+	private fun flushPendingBreaks() {
+		val newlines = pendingNewlines()
+		val cell = pendingCellBreak
+		pendingBlockBreak = false
+		pendingExplicitBreaks = 0
+		pendingCellBreak = false
+		if (newlines == 0 && !cell) return
+
+		trimTrailingLayoutSpace()
+		if (newlines > 0) repeat(newlines) { out.append('\n') } else out.append('\t')
+		lastWasSpace = true
+		trailingSpaceIsLiteral = false
+	}
+
+	/**
+	 * Drops a collapsed space sitting at a line break or at the end of the
+	 * document. A no-break space is literal content, so it is left alone.
+	 */
+	private fun trimTrailingLayoutSpace() {
+		if (trailingSpaceIsLiteral) return
+		if (out.isNotEmpty() && out.last() == ' ') out.deleteAt(out.length - 1)
+	}
+
+	private fun appendText(raw: String, active: Set<HtmlTag>, preformatted: Boolean) {
+		if (raw.isEmpty()) return
+		if (preformatted) {
+			flushPendingBreaks()
+			syncActive(active)
+			out.append(raw)
+			lastWasSpace = raw.last() == ' '
+			trailingSpaceIsLiteral = true
+			return
+		}
+
+		raw.forEach { ch ->
+			// A no-break space is content rather than layout, so it survives both
+			// collapsing and the trim at line ends. That is what lets a run of spaces
+			// round-trip: the serializer encodes the run's edges as `&nbsp;`, which
+			// arrives back here as U+00A0.
+			if (ch == NO_BREAK_SPACE) {
+				flushPendingBreaks()
+				syncActive(active)
+				out.append(' ')
+				lastWasSpace = false
+				trailingSpaceIsLiteral = true
+				return@forEach
+			}
+			if (ch.isWhitespace()) {
+				if (!lastWasSpace && pendingNewlines() == 0 && !pendingCellBreak && out.isNotEmpty()) {
+					syncActive(active)
+					out.append(' ')
+					lastWasSpace = true
+					trailingSpaceIsLiteral = false
+				}
+				return@forEach
+			}
+			flushPendingBreaks()
+			syncActive(active)
+			out.append(ch)
+			lastWasSpace = false
+			trailingSpaceIsLiteral = false
+		}
+	}
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
@@ -215,7 +215,7 @@ internal class TextEditorKeyCommandHandler {
 			val selectedText = state.selector.getSelectedText()
 			state.copyRichSpans(selection)
 			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText)
+				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration)
 			}
 		}
 	}
@@ -227,14 +227,14 @@ internal class TextEditorKeyCommandHandler {
 			state.preserveCopiedRichSpansThroughNextEdit()
 			state.selector.deleteSelection()
 			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText)
+				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration)
 			}
 		}
 	}
 
 	private fun handlePaste(state: TextEditorState, clipboard: Clipboard, scope: CoroutineScope) {
 		scope.launch {
-			ClipboardHelper.getText(clipboard)?.let { text ->
+			ClipboardHelper.getText(clipboard, state.markdownConfiguration)?.let { text ->
 				val curSelection = state.selector.selection
 				val insertPosition = curSelection?.start ?: state.cursorPosition
 				state.preserveCopiedRichSpansThroughNextEdit()

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
@@ -97,10 +97,15 @@ class MarkdownExtension(
 		set(value) {
 			field = value
 			markdownStyles = MarkdownStyles(markdownConfiguration)
+			editorState.markdownConfiguration = value
 		}
 
 	var markdownStyles: MarkdownStyles = MarkdownStyles(markdownConfiguration)
 		private set
+
+	init {
+		editorState.markdownConfiguration = markdownConfiguration
+	}
 
 	fun exportAsMarkdown(): String {
 		val allSpans = editorState.richSpanManager.getAllRichSpans()

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorCursorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorCursorState.kt
@@ -117,15 +117,19 @@ class TextEditorCursorState(
 	 * typing and plain pastes continue the surrounding formatting.
 	 */
 	fun applyCursorStyle(text: AnnotatedString): AnnotatedString {
-		if (styles.isEmpty() || text.spanStyles.isNotEmpty()) {
-			return text
+		// Paragraph styles belong to the line, which already carries its own over its
+		// whole length. Letting an inserted one through would nest a second paragraph
+		// inside that range and split one logical line into several rendered ones.
+		val content = AnnotatedString(text.text, text.spanStyles)
+		if (styles.isEmpty() || content.spanStyles.isNotEmpty()) {
+			return content
 		}
 
 		return buildAnnotatedString {
 			styles.forEach { style ->
 				pushStyle(style)
 			}
-			append(text)
+			append(content)
 			repeat(styles.size) {
 				pop()
 			}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorCursorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorCursorState.kt
@@ -107,12 +107,17 @@ class TextEditorCursorState(
 	}
 
 	/**
-	 * Layers the cursor's active styles under [text]'s own spans. The incoming
-	 * spans are kept: pasted or programmatically inserted text carries its own
-	 * formatting, and the cursor style only fills in where that text is unstyled.
+	 * Applies the cursor's active styles to [text], unless [text] carries
+	 * formatting of its own.
+	 *
+	 * Text that arrives already styled is inserted verbatim. A rich paste
+	 * describes its own formatting completely, so letting the typing style at the
+	 * insertion point apply as well would bold the unstyled runs of the pasted
+	 * content. Plain text still picks up the cursor style, which is what makes
+	 * typing and plain pastes continue the surrounding formatting.
 	 */
 	fun applyCursorStyle(text: AnnotatedString): AnnotatedString {
-		if (styles.isEmpty()) {
+		if (styles.isEmpty() || text.spanStyles.isNotEmpty()) {
 			return text
 		}
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorCursorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorCursorState.kt
@@ -106,8 +106,25 @@ class TextEditorCursorState(
 		}
 	}
 
+	/**
+	 * Layers the cursor's active styles under [text]'s own spans. The incoming
+	 * spans are kept: pasted or programmatically inserted text carries its own
+	 * formatting, and the cursor style only fills in where that text is unstyled.
+	 */
 	fun applyCursorStyle(text: AnnotatedString): AnnotatedString {
-		return applyCursorStyle(text.text)
+		if (styles.isEmpty()) {
+			return text
+		}
+
+		return buildAnnotatedString {
+			styles.forEach { style ->
+				pushStyle(style)
+			}
+			append(text)
+			repeat(styles.size) {
+				pop()
+			}
+		}
 	}
 
 	fun applyCursorStyle(string: String): AnnotatedString {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -28,6 +28,7 @@ import com.darkrockstudios.texteditor.coerceInto
 import com.darkrockstudios.texteditor.cursor.CursorMetrics
 import com.darkrockstudios.texteditor.cursor.getWrappedLineIndex
 import com.darkrockstudios.texteditor.effectiveHeight
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import com.darkrockstudios.texteditor.richstyle.BlockSpanStyle
 import com.darkrockstudios.texteditor.richstyle.CodeFenceSpanStyle
 import com.darkrockstudios.texteditor.richstyle.OrderedListSpanStyle
@@ -81,6 +82,19 @@ class TextEditorState(
 				updateBookKeeping()
 			}
 		}
+
+	/**
+	 * Styling used when converting styled text to and from an external
+	 * representation, currently the clipboard's HTML flavor. Header levels are
+	 * recognised by matching font sizes against this, so a mismatch silently
+	 * downgrades headings to plain bold text.
+	 *
+	 * Kept in sync by
+	 * [MarkdownExtension][com.darkrockstudios.texteditor.markdown.MarkdownExtension];
+	 * editors that do not use markdown keep the default.
+	 */
+	var markdownConfiguration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT
+		internal set
 
 	/**
 	 * Theming colors for line-block gutter markers, mirrored from

--- a/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.desktop.kt
+++ b/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.desktop.kt
@@ -4,61 +4,71 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.html.toAnnotatedStringFromHtml
+import com.darkrockstudios.texteditor.html.toHtml
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
 import java.awt.datatransfer.UnsupportedFlavorException
 
 @OptIn(ExperimentalComposeUiApi::class)
 actual object ClipboardHelper {
-	// Custom DataFlavor for AnnotatedString
 	private val annotatedStringFlavor = DataFlavor(AnnotatedString::class.java, "AnnotatedString")
 
 	actual suspend fun getText(clipboard: Clipboard): AnnotatedString? {
-		val transferable = clipboard.getClipEntry()?.nativeClipEntry as? Transferable
-		return transferable?.let {
-			// Try AnnotatedString first, fall back to plain text
-			when {
-				it.isDataFlavorSupported(annotatedStringFlavor) ->
-					it.getTransferData(annotatedStringFlavor) as? AnnotatedString
-
-				it.isDataFlavorSupported(DataFlavor.stringFlavor) ->
-					AnnotatedString(it.getTransferData(DataFlavor.stringFlavor) as String)
-
-				else -> null
-			}
-		}
+		val transferable = clipboard.getClipEntry()?.nativeClipEntry as? Transferable ?: return null
+		return transferable.readAnnotatedString()
+			?: transferable.readHtml()
+			?: transferable.readPlainText()
 	}
 
 	actual suspend fun setText(clipboard: Clipboard, text: AnnotatedString) {
-		val transferable = AnnotatedStringTransferable(text)
-		clipboard.setClipEntry(ClipEntry(transferable))
+		clipboard.setClipEntry(ClipEntry(AnnotatedStringTransferable(text)))
 	}
+
+	private fun Transferable.readAnnotatedString(): AnnotatedString? = runCatching {
+		if (!isDataFlavorSupported(annotatedStringFlavor)) return null
+		getTransferData(annotatedStringFlavor) as? AnnotatedString
+	}.getOrNull()
+
+	private fun Transferable.readHtml(): AnnotatedString? = runCatching {
+		val flavor = transferDataFlavors.firstOrNull { it.isHtmlStringFlavor() } ?: return null
+		val html = getTransferData(flavor) as? String ?: return null
+		html.toAnnotatedStringFromHtml().takeIf { it.text.isNotEmpty() }
+	}.getOrNull()
+
+	private fun Transferable.readPlainText(): AnnotatedString? = runCatching {
+		if (!isDataFlavorSupported(DataFlavor.stringFlavor)) return null
+		(getTransferData(DataFlavor.stringFlavor) as? String)?.let { AnnotatedString(it) }
+	}.getOrNull()
+
+	private fun DataFlavor.isHtmlStringFlavor(): Boolean =
+		mimeType.startsWith("text/html") && representationClass == String::class.java
 }
 
 /**
- * A Transferable that supports both AnnotatedString and plain String data flavors.
- * This allows copying styled text within the editor while also supporting
- * pasting as plain text in external applications.
+ * Offers the selection as HTML, as an in-process [AnnotatedString], and as plain
+ * text. External applications take the HTML and keep the formatting; another
+ * editor in this process takes the [AnnotatedString] and keeps it exactly.
  */
-private class AnnotatedStringTransferable(
+internal class AnnotatedStringTransferable(
 	private val annotatedString: AnnotatedString
 ) : Transferable {
 
 	private val annotatedStringFlavor = DataFlavor(AnnotatedString::class.java, "AnnotatedString")
+	private val htmlFlavor = DataFlavor("text/html;class=java.lang.String;charset=Unicode")
 
-	override fun getTransferDataFlavors(): Array<DataFlavor> {
-		return arrayOf(annotatedStringFlavor, DataFlavor.stringFlavor)
-	}
+	private val html by lazy { annotatedString.toHtml() }
 
-	override fun isDataFlavorSupported(flavor: DataFlavor): Boolean {
-		return flavor == annotatedStringFlavor || flavor == DataFlavor.stringFlavor
-	}
+	override fun getTransferDataFlavors(): Array<DataFlavor> =
+		arrayOf(annotatedStringFlavor, htmlFlavor, DataFlavor.stringFlavor)
 
-	override fun getTransferData(flavor: DataFlavor): Any {
-		return when {
-			flavor == annotatedStringFlavor -> annotatedString
-			flavor == DataFlavor.stringFlavor -> annotatedString.text
-			else -> throw UnsupportedFlavorException(flavor)
-		}
+	override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
+		transferDataFlavors.any { it.match(flavor) }
+
+	override fun getTransferData(flavor: DataFlavor): Any = when {
+		flavor.match(annotatedStringFlavor) -> annotatedString
+		flavor.match(htmlFlavor) -> html
+		flavor.match(DataFlavor.stringFlavor) -> annotatedString.text
+		else -> throw UnsupportedFlavorException(flavor)
 	}
 }

--- a/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.desktop.kt
+++ b/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.desktop.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
 import com.darkrockstudios.texteditor.html.toAnnotatedStringFromHtml
 import com.darkrockstudios.texteditor.html.toHtml
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
 import java.awt.datatransfer.UnsupportedFlavorException
@@ -14,15 +15,22 @@ import java.awt.datatransfer.UnsupportedFlavorException
 actual object ClipboardHelper {
 	private val annotatedStringFlavor = DataFlavor(AnnotatedString::class.java, "AnnotatedString")
 
-	actual suspend fun getText(clipboard: Clipboard): AnnotatedString? {
+	actual suspend fun getText(
+		clipboard: Clipboard,
+		configuration: MarkdownConfiguration,
+	): AnnotatedString? {
 		val transferable = clipboard.getClipEntry()?.nativeClipEntry as? Transferable ?: return null
 		return transferable.readAnnotatedString()
-			?: transferable.readHtml()
+			?: transferable.readHtml(configuration)
 			?: transferable.readPlainText()
 	}
 
-	actual suspend fun setText(clipboard: Clipboard, text: AnnotatedString) {
-		clipboard.setClipEntry(ClipEntry(AnnotatedStringTransferable(text)))
+	actual suspend fun setText(
+		clipboard: Clipboard,
+		text: AnnotatedString,
+		configuration: MarkdownConfiguration,
+	) {
+		clipboard.setClipEntry(ClipEntry(AnnotatedStringTransferable(text, configuration)))
 	}
 
 	private fun Transferable.readAnnotatedString(): AnnotatedString? = runCatching {
@@ -30,11 +38,12 @@ actual object ClipboardHelper {
 		getTransferData(annotatedStringFlavor) as? AnnotatedString
 	}.getOrNull()
 
-	private fun Transferable.readHtml(): AnnotatedString? = runCatching {
-		val flavor = transferDataFlavors.firstOrNull { it.isHtmlStringFlavor() } ?: return null
-		val html = getTransferData(flavor) as? String ?: return null
-		html.toAnnotatedStringFromHtml().takeIf { it.text.isNotEmpty() }
-	}.getOrNull()
+	private fun Transferable.readHtml(configuration: MarkdownConfiguration): AnnotatedString? =
+		runCatching {
+			val flavor = transferDataFlavors.firstOrNull { it.isHtmlStringFlavor() } ?: return null
+			val html = getTransferData(flavor) as? String ?: return null
+			html.toAnnotatedStringFromHtml(configuration).takeIf { it.text.isNotEmpty() }
+		}.getOrNull()
 
 	private fun Transferable.readPlainText(): AnnotatedString? = runCatching {
 		if (!isDataFlavorSupported(DataFlavor.stringFlavor)) return null
@@ -51,13 +60,14 @@ actual object ClipboardHelper {
  * editor in this process takes the [AnnotatedString] and keeps it exactly.
  */
 internal class AnnotatedStringTransferable(
-	private val annotatedString: AnnotatedString
+	private val annotatedString: AnnotatedString,
+	private val configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT,
 ) : Transferable {
 
 	private val annotatedStringFlavor = DataFlavor(AnnotatedString::class.java, "AnnotatedString")
 	private val htmlFlavor = DataFlavor("text/html;class=java.lang.String;charset=Unicode")
 
-	private val html by lazy { annotatedString.toHtml() }
+	private val html by lazy { annotatedString.toHtml(configuration) }
 
 	override fun getTransferDataFlavors(): Array<DataFlavor> =
 		arrayOf(annotatedStringFlavor, htmlFlavor, DataFlavor.stringFlavor)

--- a/ComposeTextEditor/src/desktopTest/kotlin/clipboard/AnnotatedStringTransferableTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/clipboard/AnnotatedStringTransferableTest.kt
@@ -1,0 +1,78 @@
+package clipboard
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import com.darkrockstudios.texteditor.clipboard.AnnotatedStringTransferable
+import com.darkrockstudios.texteditor.html.toAnnotatedStringFromHtml
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import java.awt.datatransfer.DataFlavor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AnnotatedStringTransferableTest {
+
+	private val config = MarkdownConfiguration.DEFAULT
+
+	private fun styled(): AnnotatedString = buildAnnotatedString {
+		append("Hello ")
+		pushStyle(config.boldStyle)
+		append("world")
+		pop()
+	}
+
+	private fun htmlFlavorOf(transferable: AnnotatedStringTransferable): DataFlavor? =
+		transferable.transferDataFlavors.firstOrNull {
+			it.mimeType.startsWith("text/html") && it.representationClass == String::class.java
+		}
+
+	@Test
+	fun `offers an html flavor backed by a string`() {
+		val transferable = AnnotatedStringTransferable(styled())
+		val flavor = htmlFlavorOf(transferable)
+
+		assertNotNull(flavor, "expected a text/html String flavor among ${transferable.transferDataFlavors.toList()}")
+		assertTrue(transferable.isDataFlavorSupported(flavor))
+	}
+
+	@Test
+	fun `html flavor carries the serialized markup`() {
+		val transferable = AnnotatedStringTransferable(styled())
+		val flavor = assertNotNull(htmlFlavorOf(transferable))
+
+		val html = transferable.getTransferData(flavor) as String
+		assertEquals("Hello <strong>world</strong>", html)
+	}
+
+	@Test
+	fun `html flavor round trips back to a styled string`() {
+		val transferable = AnnotatedStringTransferable(styled())
+		val flavor = assertNotNull(htmlFlavorOf(transferable))
+
+		val html = transferable.getTransferData(flavor) as String
+		val parsed = html.toAnnotatedStringFromHtml(config)
+
+		assertEquals("Hello world", parsed.text)
+		assertTrue(
+			parsed.spanStyles.any { it.start == 6 && it.end == 11 },
+			"expected a span covering 'world', got ${parsed.spanStyles}",
+		)
+	}
+
+	@Test
+	fun `plain text flavor carries unstyled text`() {
+		val transferable = AnnotatedStringTransferable(styled())
+		val text = transferable.getTransferData(DataFlavor.stringFlavor) as String
+		assertEquals("Hello world", text)
+	}
+
+	@Test
+	fun `annotated string flavor is offered first for in-process fidelity`() {
+		val transferable = AnnotatedStringTransferable(styled())
+		val first = transferable.transferDataFlavors.first()
+
+		assertEquals(AnnotatedString::class.java, first.representationClass)
+		assertEquals(styled(), transferable.getTransferData(first))
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/html/ClipboardHtmlUnwrapTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/html/ClipboardHtmlUnwrapTest.kt
@@ -81,6 +81,9 @@ class ClipboardHtmlUnwrapTest {
 		val options = text.indexOf("options")
 		assertTrue(result.hasBoldAt(options), "expected 'options' bold")
 		assertTrue(result.hasItalicAt(options), "expected 'options' italic")
+
+		assertFalse(result.hasBoldAt(text.indexOf("asdasd")), "did not expect 'asdasd' bold")
+		assertFalse(result.hasBoldAt(text.indexOf("hello!")), "did not expect 'hello!' bold")
 	}
 
 	@Test

--- a/ComposeTextEditor/src/desktopTest/kotlin/html/ClipboardHtmlUnwrapTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/html/ClipboardHtmlUnwrapTest.kt
@@ -1,0 +1,130 @@
+package html
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import com.darkrockstudios.texteditor.html.toAnnotatedStringFromHtml
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ClipboardHtmlUnwrapTest {
+
+	private val config = MarkdownConfiguration.DEFAULT
+
+	private fun AnnotatedString.stylesAt(index: Int): Set<SpanStyle> =
+		spanStyles.filter { index >= it.start && index < it.end }.map { it.item }.toSet()
+
+	private fun AnnotatedString.hasBoldAt(index: Int) =
+		stylesAt(index).any { it.fontWeight == FontWeight.Bold }
+
+	private fun AnnotatedString.hasItalicAt(index: Int) =
+		stylesAt(index).any { it.fontStyle == FontStyle.Italic }
+
+	private fun AnnotatedString.hasUnderlineAt(index: Int) =
+		stylesAt(index).any { it.textDecoration?.contains(TextDecoration.Underline) == true }
+
+	/** A Word selection as Windows delivers it: CF_HTML descriptor, then the document. */
+	private val wordClipboard = """
+		Version:1.0
+		StartHTML:0000000121
+		EndHTML:0000001339
+		StartFragment:0000000872
+		EndFragment:0000001322
+		<html xmlns:o="urn:schemas-microsoft-com:office:office">
+		<head>
+		<meta charset="utf-8">
+		<style>
+		<!--
+		 p.MsoNormal { margin:0in; font-size:11.0pt; }
+		-->
+		</style>
+		</head>
+		<body lang=EN-US>
+		<!--StartFragment--><p class=MsoNormal><b><span style='font-size:22.0pt'>Test</span></b><span style='font-size:22.0pt'> all </span><i><span style='font-size:22.0pt'>the</span></i><span style='font-size:22.0pt'> </span><b><u><span style='font-size:22.0pt'>things</span></u></b><b><span style='font-size:22.0pt'>, logs</span></b></p><p class=MsoNormal><b>Of </b><b><i>options</i></b> asdasd hello hello!</p><!--EndFragment-->
+		</body>
+		</html>
+	""".trimIndent()
+
+	@Test
+	fun `cf html descriptor does not leak into the text`() {
+		val result = wordClipboard.toAnnotatedStringFromHtml(config)
+
+		assertFalse(result.text.contains("Version:"), "descriptor leaked: ${result.text}")
+		assertFalse(result.text.contains("StartHTML"), "descriptor leaked: ${result.text}")
+		assertFalse(result.text.contains("StartFragment"), "descriptor leaked: ${result.text}")
+	}
+
+	@Test
+	fun `word selection produces just the selected text`() {
+		val result = wordClipboard.toAnnotatedStringFromHtml(config)
+		assertEquals("Test all the things, logs\nOf options asdasd hello hello!", result.text)
+	}
+
+	@Test
+	fun `word selection keeps its inline formatting`() {
+		val result = wordClipboard.toAnnotatedStringFromHtml(config)
+		val text = result.text
+
+		assertTrue(result.hasBoldAt(text.indexOf("Test")), "expected 'Test' bold")
+		assertFalse(result.hasBoldAt(text.indexOf("all")), "did not expect 'all' bold")
+		assertTrue(result.hasItalicAt(text.indexOf("the ")), "expected 'the' italic")
+
+		val things = text.indexOf("things")
+		assertTrue(result.hasBoldAt(things), "expected 'things' bold")
+		assertTrue(result.hasUnderlineAt(things), "expected 'things' underlined")
+
+		val options = text.indexOf("options")
+		assertTrue(result.hasBoldAt(options), "expected 'options' bold")
+		assertTrue(result.hasItalicAt(options), "expected 'options' italic")
+	}
+
+	@Test
+	fun `head content is not emitted as text`() {
+		val result = wordClipboard.toAnnotatedStringFromHtml(config)
+		assertFalse(result.text.contains("MsoNormal"), "style block leaked: ${result.text}")
+	}
+
+	@Test
+	fun `content outside the fragment markers is discarded`() {
+		val html = "<html><body>page chrome<!--StartFragment--><b>selected</b><!--EndFragment-->more chrome</body></html>"
+		val result = html.toAnnotatedStringFromHtml(config)
+
+		assertEquals("selected", result.text)
+		assertTrue(result.hasBoldAt(0))
+	}
+
+	@Test
+	fun `fragment start without an end marker still parses`() {
+		val html = "<html><body>chrome<!--StartFragment--><i>tail</i></body></html>"
+		assertEquals("tail", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `plain markup without a descriptor is untouched`() {
+		val html = "<p>Version numbers like 1.0 stay put</p>"
+		assertEquals("Version numbers like 1.0 stay put", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `browser fragment with descriptor round trips`() {
+		val html = """
+			Version:0.9
+			StartHTML:00000097
+			EndHTML:00000200
+			StartFragment:00000131
+			EndFragment:00000164
+			<html><body>
+			<!--StartFragment--><span style="font-weight: 700;">Chrome</span> copy<!--EndFragment-->
+			</body></html>
+		""".trimIndent()
+
+		val result = html.toAnnotatedStringFromHtml(config)
+		assertEquals("Chrome copy", result.text)
+		assertTrue(result.hasBoldAt(0), "expected bold from font-weight: 700")
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/html/HtmlClipboardTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/html/HtmlClipboardTest.kt
@@ -1,0 +1,228 @@
+package html
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import com.darkrockstudios.texteditor.html.toAnnotatedStringFromHtml
+import com.darkrockstudios.texteditor.html.toHtml
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HtmlClipboardTest {
+
+	private val config = MarkdownConfiguration.DEFAULT
+
+	private fun AnnotatedString.stylesAt(index: Int): Set<SpanStyle> =
+		spanStyles.filter { index >= it.start && index < it.end }.map { it.item }.toSet()
+
+	private fun AnnotatedString.hasBoldAt(index: Int) =
+		stylesAt(index).any { it.fontWeight == FontWeight.Bold }
+
+	private fun AnnotatedString.hasItalicAt(index: Int) =
+		stylesAt(index).any { it.fontStyle == FontStyle.Italic }
+
+	private fun AnnotatedString.hasMonospaceAt(index: Int) =
+		stylesAt(index).any { it.fontFamily == FontFamily.Monospace }
+
+	private fun AnnotatedString.hasDecorationAt(index: Int, decoration: TextDecoration) =
+		stylesAt(index).any { it.textDecoration?.contains(decoration) == true }
+
+	@Test
+	fun `bold span serializes to strong`() {
+		val input = buildAnnotatedString {
+			append("Hello ")
+			pushStyle(config.boldStyle)
+			append("world")
+			pop()
+		}
+		assertEquals("Hello <strong>world</strong>", input.toHtml(config))
+	}
+
+	@Test
+	fun `bold survives a round trip`() {
+		val input = buildAnnotatedString {
+			append("Hello ")
+			pushStyle(config.boldStyle)
+			append("world")
+			pop()
+		}
+		val result = input.toHtml(config).toAnnotatedStringFromHtml(config)
+
+		assertEquals("Hello world", result.text)
+		assertTrue(result.hasBoldAt(6), "expected bold on 'world'")
+		assertTrue(!result.hasBoldAt(0), "did not expect bold on 'Hello'")
+	}
+
+	@Test
+	fun `nested styles survive a round trip`() {
+		val input = buildAnnotatedString {
+			pushStyle(config.boldStyle)
+			append("bold ")
+			pushStyle(config.italicStyle)
+			append("both")
+			pop()
+			pop()
+			append(" plain")
+		}
+		val result = input.toHtml(config).toAnnotatedStringFromHtml(config)
+
+		assertEquals("bold both plain", result.text)
+		assertTrue(result.hasBoldAt(0))
+		assertTrue(!result.hasItalicAt(0))
+		assertTrue(result.hasBoldAt(5) && result.hasItalicAt(5), "expected bold+italic on 'both'")
+		assertTrue(!result.hasBoldAt(10), "did not expect bold on ' plain'")
+	}
+
+	@Test
+	fun `headers survive a round trip`() {
+		val input = buildAnnotatedString {
+			pushStyle(config.header1Style)
+			append("Title")
+			pop()
+			append("\nbody")
+		}
+		val html = input.toHtml(config)
+		assertEquals("<h1>Title</h1><br>body", html)
+
+		val result = html.toAnnotatedStringFromHtml(config)
+		assertEquals("Title\nbody", result.text)
+		assertTrue(result.stylesAt(0).contains(config.header1Style), "expected h1 style on 'Title'")
+	}
+
+	@Test
+	fun `strikethrough and underline survive a round trip`() {
+		val input = buildAnnotatedString {
+			pushStyle(config.strikethroughStyle)
+			append("gone")
+			pop()
+			append(" ")
+			pushStyle(SpanStyle(textDecoration = TextDecoration.Underline))
+			append("under")
+			pop()
+		}
+		val result = input.toHtml(config).toAnnotatedStringFromHtml(config)
+
+		assertEquals("gone under", result.text)
+		assertTrue(result.hasDecorationAt(0, TextDecoration.LineThrough))
+		assertTrue(result.hasDecorationAt(5, TextDecoration.Underline))
+	}
+
+	@Test
+	fun `newlines round trip through br`() {
+		val input = AnnotatedString("one\ntwo\n\nfour")
+		val result = input.toHtml(config).toAnnotatedStringFromHtml(config)
+		assertEquals("one\ntwo\n\nfour", result.text)
+	}
+
+	@Test
+	fun `repeated spaces round trip`() {
+		val input = AnnotatedString("a  b   c")
+		val result = input.toHtml(config).toAnnotatedStringFromHtml(config)
+		assertEquals("a  b   c", result.text)
+	}
+
+	@Test
+	fun `html special characters are escaped and restored`() {
+		val input = AnnotatedString("5 < 6 && \"x\" > y")
+		val html = input.toHtml(config)
+		assertTrue(html.contains("&lt;"), "expected < to be escaped: $html")
+		assertTrue(html.contains("&amp;"), "expected & to be escaped: $html")
+
+		val result = html.toAnnotatedStringFromHtml(config)
+		assertEquals("5 < 6 && \"x\" > y", result.text)
+	}
+
+	@Test
+	fun `code spans round trip`() {
+		val input = buildAnnotatedString {
+			append("run ")
+			pushStyle(config.codeStyle)
+			append("main()")
+			pop()
+		}
+		val result = input.toHtml(config).toAnnotatedStringFromHtml(config)
+
+		assertEquals("run main()", result.text)
+		assertTrue(result.hasMonospaceAt(4))
+	}
+
+	@Test
+	fun `empty string produces empty html`() {
+		assertEquals("", AnnotatedString("").toHtml(config))
+		assertEquals("", "".toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `browser style markup is parsed`() {
+		val html = """
+			<meta charset="utf-8">
+			<b style="font-weight:normal;" id="docs-internal-guid-1">
+				<p dir="ltr"><span style="font-weight:700;">Bold heading</span></p>
+				<p dir="ltr"><span style="font-style:italic;">Italic line</span></p>
+			</b>
+		""".trimIndent()
+
+		val result = html.toAnnotatedStringFromHtml(config)
+
+		assertEquals("Bold heading\nItalic line", result.text)
+		assertTrue(result.hasBoldAt(0), "expected bold from font-weight:700")
+		assertTrue(result.hasItalicAt(13), "expected italic from font-style:italic")
+	}
+
+	@Test
+	fun `layout whitespace in source markup is collapsed`() {
+		val html = "<div>\n\t<span>Hello</span>\n\t<span>world</span>\n</div>"
+		assertEquals("Hello world", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `script and style content is dropped`() {
+		val html = "<style>p { color: red; }</style><p>Visible</p><script>alert('x')</script>"
+		assertEquals("Visible", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `unbalanced tags are closed implicitly`() {
+		val html = "<b>bold <i>both</b> trailing"
+		val result = html.toAnnotatedStringFromHtml(config)
+
+		assertEquals("bold both trailing", result.text)
+		assertTrue(result.hasBoldAt(0))
+		assertTrue(result.hasItalicAt(5))
+	}
+
+	@Test
+	fun `list items become separate lines`() {
+		val html = "<ul><li>one</li><li>two</li></ul>"
+		assertEquals("one\ntwo", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `numeric and named entities are decoded`() {
+		val html = "<p>caf&#233; &amp; cr&#xE8;me&nbsp;&nbsp;done</p>"
+		assertEquals("café & crème  done", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `unsupported styles are dropped but text is kept`() {
+		val input = buildAnnotatedString {
+			pushStyle(SpanStyle(letterSpacing = androidx.compose.ui.unit.TextUnit.Unspecified))
+			append("plain")
+			pop()
+		}
+		val result = input.toHtml(config).toAnnotatedStringFromHtml(config)
+		assertEquals("plain", result.text)
+	}
+
+	@Test
+	fun `pre content keeps its whitespace`() {
+		val html = "<pre>line one\n    indented</pre>"
+		assertEquals("line one\n    indented", html.toAnnotatedStringFromHtml(config).text)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/html/HtmlReviewFixesTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/html/HtmlReviewFixesTest.kt
@@ -1,0 +1,145 @@
+package html
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.darkrockstudios.texteditor.html.toAnnotatedStringFromHtml
+import com.darkrockstudios.texteditor.html.toHtml
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** One case per confirmed finding from the branch review. */
+class HtmlReviewFixesTest {
+
+	private val config = MarkdownConfiguration.DEFAULT
+
+	private fun AnnotatedString.resolvedAt(index: Int): SpanStyle =
+		spanStyles.filter { index >= it.start && index < it.end }
+			.fold(SpanStyle()) { acc, range -> acc.merge(range.item) }
+
+	@Test
+	fun `a trailing line break is not dropped`() {
+		val original = AnnotatedString("one\ntwo\n")
+		assertEquals("one\ntwo\n", original.toHtml(config).toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `a trailing block close does not add a line`() {
+		assertEquals("one", "<p>one</p>".toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `an implicitly closed pre does not preformat the rest of the document`() {
+		val html = "<div><pre>code</div><p>Some   text\n\t\twith layout indentation</p>"
+		val result = html.toAnnotatedStringFromHtml(config).text
+
+		assertTrue(
+			result.endsWith("Some text with layout indentation"),
+			"whitespace after the unclosed <pre> should still collapse: $result",
+		)
+	}
+
+	@Test
+	fun `white-space pre css is honoured without a pre tag`() {
+		val html = "<div style=\"white-space:pre\">def f():\n    return 1</div>"
+		assertEquals("def f():\n    return 1", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `named entities beyond the basic set are decoded`() {
+		val html = "<p>Kotlin&mdash;a language&hellip; it&rsquo;s &copy; 2026</p>"
+		assertEquals("Kotlin—a language… it’s © 2026", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `astral code points are decoded`() {
+		val html = "<p>Nice &#128512; and &#x1F600;</p>"
+		assertEquals("Nice 😀 and 😀", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `table cells are separated by tabs`() {
+		val html = "<table><tr><td>Alice</td><td>Bob</td><td>30</td></tr></table>"
+		assertEquals("Alice\tBob\t30", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `table rows are separated by lines`() {
+		val html = "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>"
+		assertEquals("a\tb\nc\td", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `unterminated tags terminate quickly`() {
+		val html = "<a ".repeat(40_000)
+		val result = html.toAnnotatedStringFromHtml(config)
+		assertTrue(result.text.length < html.length, "expected the stray markup not to be echoed whole")
+	}
+
+	@Test
+	fun `deeply nested markup does not overflow`() {
+		val depth = 3_000
+		val html = "<b>".repeat(depth) + "deep" + "</b>".repeat(depth)
+		assertEquals("deep", html.toAnnotatedStringFromHtml(config).text)
+	}
+
+	@Test
+	fun `serializing does not reapply a style an inner span cancelled`() {
+		val document = buildAnnotatedString {
+			pushStyle(SpanStyle(fontWeight = FontWeight.Bold))
+			append("a")
+			pushStyle(SpanStyle(fontWeight = FontWeight.Normal))
+			append("b")
+			pop()
+			pop()
+		}
+
+		val html = document.toHtml(config)
+		assertEquals("<strong>a</strong>b", html)
+
+		val round = html.toAnnotatedStringFromHtml(config)
+		assertFalse(
+			round.resolvedAt(1).fontWeight == FontWeight.Bold,
+			"'b' was cancelled in the document and must not come back bold: ${round.spanStyles}",
+		)
+	}
+
+	@Test
+	fun `a custom configuration keeps header levels on the way out`() {
+		val custom = config.copy(
+			header1Style = SpanStyle(fontSize = 40f.sp, fontWeight = FontWeight.Bold),
+		)
+		val document = buildAnnotatedString {
+			pushStyle(custom.header1Style)
+			append("Title")
+			pop()
+		}
+
+		assertEquals("<h1>Title</h1>", document.toHtml(custom))
+	}
+
+	@Test
+	fun `a custom configuration keeps header levels on the way in`() {
+		val custom = config.copy(
+			header1Style = SpanStyle(fontSize = 40f.sp, fontWeight = FontWeight.Bold),
+		)
+		val parsed = "<h1>Title</h1>".toAnnotatedStringFromHtml(custom)
+
+		assertEquals(40f, parsed.resolvedAt(0).fontSize.value)
+	}
+
+	@Test
+	fun `the default configuration is unaffected by a custom one`() {
+		val document = buildAnnotatedString {
+			pushStyle(config.header1Style)
+			append("Title")
+			pop()
+		}
+		assertEquals("<h1>Title</h1>", document.toHtml(config))
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/html/HtmlStyleOverrideTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/html/HtmlStyleOverrideTest.kt
@@ -90,16 +90,28 @@ class HtmlStyleOverrideTest {
 	}
 
 	@Test
-	fun `outer spans are listed before inner ones`() {
+	fun `an inner style survives its outer wrapper`() {
 		val html = """<b>outer <i>inner</i></b>"""
 		val result = html.toAnnotatedStringFromHtml(config)
 
-		val boldIndex = result.spanStyles.indexOfFirst { it.item.fontWeight == FontWeight.Bold }
-		val italicIndex = result.spanStyles.indexOfFirst { it.item.fontStyle == FontStyle.Italic }
+		assertEquals("outer inner", result.text)
+		val inner = result.text.indexOf("inner")
+		assertTrue(result.isBoldAt(inner), "expected inner text to keep the outer bold")
+		assertTrue(result.isItalicAt(inner), "expected inner italic")
+		assertTrue(!result.isItalicAt(0), "did not expect italic on the outer text")
+	}
 
+	@Test
+	fun `a cancelled style produces no span rather than a competing one`() {
+		val html = """<b>bold <span style="font-weight:normal">plain</span></b>"""
+		val result = html.toAnnotatedStringFromHtml(config)
+
+		val plain = result.text.indexOf("plain")
+		val covering = result.spanStyles.filter { plain >= it.start && plain < it.end }
 		assertTrue(
-			boldIndex < italicIndex,
-			"outer bold must precede inner italic so the inner one wins: ${result.spanStyles}",
+			covering.none { it.item.fontWeight == FontWeight.Normal },
+			"cancellation should be resolved during parsing, not left as a span: $covering",
 		)
+		assertTrue(!result.isBoldAt(plain), "expected 'plain' not bold")
 	}
 }

--- a/ComposeTextEditor/src/desktopTest/kotlin/html/HtmlStyleOverrideTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/html/HtmlStyleOverrideTest.kt
@@ -1,0 +1,105 @@
+package html
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.darkrockstudios.texteditor.html.toAnnotatedStringFromHtml
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HtmlStyleOverrideTest {
+
+	private val config = MarkdownConfiguration.DEFAULT
+
+	/**
+	 * Resolves the styles at [index] the way rendering does: later spans in the
+	 * list merge over earlier ones.
+	 */
+	private fun AnnotatedString.resolvedAt(index: Int): SpanStyle =
+		spanStyles.filter { index >= it.start && index < it.end }
+			.fold(SpanStyle()) { acc, range -> acc.merge(range.item) }
+
+	private fun AnnotatedString.isBoldAt(index: Int) =
+		resolvedAt(index).fontWeight == FontWeight.Bold
+
+	private fun AnnotatedString.isItalicAt(index: Int) =
+		resolvedAt(index).fontStyle == FontStyle.Italic
+
+	@Test
+	fun `a normal font weight cancels the bold tag it sits on`() {
+		val html = """<b style="font-weight:normal"><span style="font-weight:700;">Of</span> asdasd hello</b>"""
+		val result = html.toAnnotatedStringFromHtml(config)
+
+		assertEquals("Of asdasd hello", result.text)
+		assertTrue(result.isBoldAt(0), "expected 'Of' bold")
+		assertFalse(
+			result.isBoldAt(result.text.indexOf("asdasd")),
+			"'asdasd' inherited bold from a font-weight:normal wrapper",
+		)
+	}
+
+	@Test
+	fun `google docs wrapper does not bold the whole fragment`() {
+		val html = """
+			<meta charset="utf-8">
+			<b style="font-weight:normal;" id="docs-internal-guid-abc">
+				<p dir="ltr"><span style="font-weight:700;">Of </span><span style="font-weight:700;font-style:italic;">options</span><span>&nbsp;asdasd hello hello!</span></p>
+			</b>
+		""".trimIndent()
+
+		val result = html.toAnnotatedStringFromHtml(config)
+		assertEquals("Of options asdasd hello hello!", result.text)
+
+		assertTrue(result.isBoldAt(result.text.indexOf("Of")), "expected 'Of' bold")
+		assertTrue(result.isBoldAt(result.text.indexOf("options")), "expected 'options' bold")
+		assertTrue(result.isItalicAt(result.text.indexOf("options")), "expected 'options' italic")
+		assertFalse(
+			result.isBoldAt(result.text.indexOf("asdasd")),
+			"'asdasd hello hello!' should not be bold",
+		)
+	}
+
+	@Test
+	fun `an inner style overrides an outer tag`() {
+		val html = """<b>bold <span style="font-weight:normal">plain</span></b>"""
+		val result = html.toAnnotatedStringFromHtml(config)
+
+		assertEquals("bold plain", result.text)
+		assertTrue(result.isBoldAt(0), "expected 'bold' bold")
+		assertFalse(result.isBoldAt(result.text.indexOf("plain")), "expected 'plain' not bold")
+	}
+
+	@Test
+	fun `a normal font style cancels an italic tag`() {
+		val html = """<i style="font-style:normal">upright</i>"""
+		val result = html.toAnnotatedStringFromHtml(config)
+		assertFalse(result.isItalicAt(0), "expected upright text")
+	}
+
+	@Test
+	fun `an inline style adds to its tag rather than replacing it`() {
+		val html = """<b style="font-style:italic">both</b>"""
+		val result = html.toAnnotatedStringFromHtml(config)
+
+		assertTrue(result.isBoldAt(0), "expected bold from the tag")
+		assertTrue(result.isItalicAt(0), "expected italic from the inline style")
+	}
+
+	@Test
+	fun `outer spans are listed before inner ones`() {
+		val html = """<b>outer <i>inner</i></b>"""
+		val result = html.toAnnotatedStringFromHtml(config)
+
+		val boldIndex = result.spanStyles.indexOfFirst { it.item.fontWeight == FontWeight.Bold }
+		val italicIndex = result.spanStyles.indexOfFirst { it.item.fontStyle == FontStyle.Italic }
+
+		assertTrue(
+			boldIndex < italicIndex,
+			"outer bold must precede inner italic so the inner one wins: ${result.spanStyles}",
+		)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/InsertStyledTextTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/InsertStyledTextTest.kt
@@ -1,0 +1,92 @@
+package state
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class InsertStyledTextTest {
+
+	private val bold = SpanStyle(fontWeight = FontWeight.Bold)
+	private val italic = SpanStyle(fontStyle = FontStyle.Italic)
+
+	private fun TestScope.createState(text: String): TextEditorState =
+		TextEditorState(
+			scope = this,
+			measurer = mockk(relaxed = true),
+			initialText = AnnotatedString(text),
+		)
+
+	private fun AnnotatedString.boldRanges(): List<IntRange> =
+		spanStyles.filter { it.item.fontWeight == FontWeight.Bold }
+			.map { it.start until it.end }
+
+	@Test
+	fun `inserting styled text keeps its spans`() = runTest {
+		val state = createState("")
+		val styled = buildAnnotatedString {
+			append("Hello ")
+			pushStyle(bold)
+			append("world")
+			pop()
+		}
+
+		state.insertStringAtCursor(styled)
+
+		val line = state.textLines[0]
+		assertEquals("Hello world", line.text)
+		assertTrue(
+			line.boldRanges().any { 6 in it && 10 in it },
+			"expected bold covering 'world', got ${line.spanStyles}",
+		)
+		assertTrue(
+			line.boldRanges().none { 0 in it },
+			"did not expect bold on 'Hello', got ${line.spanStyles}",
+		)
+	}
+
+	@Test
+	fun `inserting multi style text keeps every span`() = runTest {
+		val state = createState("")
+		val styled = buildAnnotatedString {
+			pushStyle(bold)
+			append("bold")
+			pop()
+			append(" ")
+			pushStyle(italic)
+			append("italic")
+			pop()
+		}
+
+		state.insertStringAtCursor(styled)
+
+		val line = state.textLines[0]
+		assertEquals("bold italic", line.text)
+		assertTrue(
+			line.spanStyles.any { it.item.fontWeight == FontWeight.Bold && it.start == 0 },
+			"expected bold at 'bold', got ${line.spanStyles}",
+		)
+		assertTrue(
+			line.spanStyles.any { it.item.fontStyle == FontStyle.Italic && it.start == 5 },
+			"expected italic at 'italic', got ${line.spanStyles}",
+		)
+	}
+
+	@Test
+	fun `inserting plain text stays plain`() = runTest {
+		val state = createState("")
+		state.insertStringAtCursor(AnnotatedString("just text"))
+
+		val line = state.textLines[0]
+		assertEquals("just text", line.text)
+		assertTrue(line.boldRanges().isEmpty(), "expected no styling, got ${line.spanStyles}")
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/InsertStyledTextTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/InsertStyledTextTest.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.state.TextEditorState
 import io.mockk.mockk
 import kotlinx.coroutines.test.TestScope
@@ -77,6 +79,33 @@ class InsertStyledTextTest {
 		assertTrue(
 			line.spanStyles.any { it.item.fontStyle == FontStyle.Italic && it.start == 5 },
 			"expected italic at 'italic', got ${line.spanStyles}",
+		)
+	}
+
+	@Test
+	fun `styled text does not inherit the cursor style`() = runTest {
+		val state = createState("bold start")
+		state.addStyleSpan(
+			TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 10)),
+			bold,
+		)
+		state.cursor.updatePosition(CharLineOffset(0, 10))
+
+		val styled = buildAnnotatedString {
+			pushStyle(italic)
+			append("italic")
+			pop()
+			append(" plain")
+		}
+		state.insertStringAtCursor(styled)
+
+		val line = state.textLines[0]
+		assertEquals("bold startitalic plain", line.text)
+
+		val plainStart = line.text.indexOf(" plain")
+		assertTrue(
+			line.boldRanges().none { plainStart in it },
+			"pasted unstyled text inherited the cursor's bold: ${line.spanStyles}",
 		)
 	}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/InsertStyledTextTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/InsertStyledTextTest.kt
@@ -5,6 +5,10 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.style.TextIndent
+import androidx.compose.ui.unit.sp
+import com.darkrockstudios.texteditor.html.toAnnotatedStringFromHtml
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.state.TextEditorState
@@ -117,5 +121,47 @@ class InsertStyledTextTest {
 		val line = state.textLines[0]
 		assertEquals("just text", line.text)
 		assertTrue(line.boldRanges().isEmpty(), "expected no styling, got ${line.spanStyles}")
+	}
+
+	@Test
+	fun `pasted bold survives the caret sitting next to existing bold`() = runTest {
+		val state = createState("X")
+		state.addStyleSpan(TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 1)), bold)
+		state.cursor.updatePosition(CharLineOffset(0, 1))
+
+		val pasted = """<b style="font-weight:normal"><span style="font-weight:700">bold</span>plain</b>"""
+			.toAnnotatedStringFromHtml()
+		state.insertStringAtCursor(pasted)
+
+		val line = state.textLines[0]
+		assertEquals("Xboldplain", line.text)
+
+		val boldAt = { i: Int ->
+			line.spanStyles.filter { i >= it.start && i < it.end }
+				.fold(SpanStyle()) { acc, r -> acc.merge(r.item) }
+				.fontWeight == FontWeight.Bold
+		}
+		assertTrue(boldAt(line.text.indexOf("bold")), "pasted bold was lost: ${line.spanStyles}")
+		assertTrue(!boldAt(line.text.indexOf("plain")), "unstyled run became bold: ${line.spanStyles}")
+	}
+
+	@Test
+	fun `an inserted paragraph style does not split the line`() = runTest {
+		val state = createState("line")
+		state.cursor.updatePosition(CharLineOffset(0, 2))
+
+		val pasted = buildAnnotatedString {
+			pushStyle(ParagraphStyle(textIndent = TextIndent(firstLine = 12.sp)))
+			append("xx")
+			pop()
+		}
+		state.insertStringAtCursor(pasted)
+
+		val line = state.textLines[0]
+		assertEquals("lixxne", line.text)
+		assertTrue(
+			line.paragraphStyles.isEmpty(),
+			"a pasted paragraph style nested inside the line: ${line.paragraphStyles}",
+		)
 	}
 }

--- a/ComposeTextEditor/src/iosMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.ios.kt
+++ b/ComposeTextEditor/src/iosMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.ios.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.texteditor.clipboard
 
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import platform.UIKit.UIPasteboard
 
 /**
@@ -9,13 +10,20 @@ import platform.UIKit.UIPasteboard
  * Supports plain text only (styled text is not preserved).
  */
 actual object ClipboardHelper {
-	actual suspend fun getText(clipboard: Clipboard): AnnotatedString? {
+	actual suspend fun getText(
+		clipboard: Clipboard,
+		configuration: MarkdownConfiguration,
+	): AnnotatedString? {
 		return UIPasteboard.generalPasteboard.string?.let { text ->
 			AnnotatedString(text)
 		}
 	}
 
-	actual suspend fun setText(clipboard: Clipboard, text: AnnotatedString) {
+	actual suspend fun setText(
+		clipboard: Clipboard,
+		text: AnnotatedString,
+		configuration: MarkdownConfiguration,
+	) {
 		UIPasteboard.generalPasteboard.string = text.text
 	}
 }

--- a/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.wasmJs.kt
+++ b/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.wasmJs.kt
@@ -4,12 +4,16 @@ package com.darkrockstudios.texteditor.clipboard
 
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import kotlin.js.ExperimentalWasmJsInterop
 import kotlin.js.Promise
 import kotlinx.coroutines.await
 
 actual object ClipboardHelper {
-	actual suspend fun getText(clipboard: Clipboard): AnnotatedString? {
+	actual suspend fun getText(
+		clipboard: Clipboard,
+		configuration: MarkdownConfiguration,
+	): AnnotatedString? {
 		return try {
 			val text = readClipboardText().await<JsString>().toString()
 			AnnotatedString(text)
@@ -19,7 +23,11 @@ actual object ClipboardHelper {
 		}
 	}
 
-	actual suspend fun setText(clipboard: Clipboard, text: AnnotatedString) {
+	actual suspend fun setText(
+		clipboard: Clipboard,
+		text: AnnotatedString,
+		configuration: MarkdownConfiguration,
+	) {
 		try {
 			writeClipboardText(text.text).await<JsAny?>()
 		} catch (e: Exception) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ compose-multiplatform = "1.11.1"
 compose-hot-reload = "1.2.0-alpha02"
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"
+ksoup = "0.2.6"
 markdown = "0.7.5"
 mockk = "1.14.11"
 
@@ -30,6 +31,7 @@ androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test-jvm", version.ref = "kotlinx-coroutines" }
+ksoup = { module = "com.fleeksoft.ksoup:ksoup", version.ref = "ksoup" }
 markdown = { module = "org.jetbrains:markdown", version.ref = "markdown" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 platform-spellchecker = { module = "com.darkrockstudios:platform-spellcheckerkt", version.ref = "spellcheckerkt" }


### PR DESCRIPTION
Rich copy and paste over the system clipboard, using `text/html` as the interchange format.

Inspired by [compose-rich-editor#650](https://github.com/MohamedRejeb/compose-rich-editor/pull/650), which solves the same problem the same way: HTML is what other applications actually speak, so it is the format that makes formatting survive leaving the app.

### Before

Nothing rich survived leaving the editor and nothing rich arrived from outside it. Desktop registered a custom `DataFlavor` wrapping an `AnnotatedString` object reference, which only works between two editors in the *same JVM process*. Android, iOS and web were plain-text only.

### What this adds

- **`AnnotatedString` -> HTML** (`toHtml`). Emits `<strong>`, `<em>`, `<code>`, `<s>`, `<u>` and `<h1>`-`<h6>`, resolving one effective style per character so overlapping spans cannot re-apply a style an inner span cancelled.
- **HTML -> `AnnotatedString`** (`toAnnotatedStringFromHtml`). Parsing is delegated to **Ksoup** (a jsoup port implementing the WHATWG spec, covering all five of our targets). What lives here is the mapping onto Compose spans.
- **Desktop clipboard offers three flavors**: `AnnotatedString` (in-process, exact), `text/html` (external apps), plain text (fallback). Read side tries them in that order.

Both converters live in `commonMain`, so wiring the remaining platforms is a small addition each rather than new design work.

### Why Ksoup rather than hand-rolled

The first draft hand-rolled the tokenizer to avoid a dependency. That was the wrong call: a review found that most of its defects were things a real parser gives you for free (HTML5 entity tables, implicit tag closing, unterminated input, quadratic rescans, table structure). Each fix was another step toward reimplementing a spec against untrusted input from Word and browsers. This module already depends on `org.jetbrains:markdown` rather than hand-rolling markdown, so the precedent was there.

Note this adds a dependency to a **published** library, so it reaches consumers.

### Bugs found and fixed along the way

Three of these are pre-existing and independent of HTML:

- **`applyCursorStyle`'s `AnnotatedString` overload discarded every span** by delegating to the `String` overload. *Every* paste was losing its character styling regardless of source, including the in-process flavor. It only ever looked like it worked because lists and blockquotes ride the separate `copiedRichSpans` path.
- **The same overload passed `ParagraphStyle`s through** once spans were preserved, nesting a second paragraph inside a line and splitting one logical line into several rendered rows.
- **A rich paste inherited the typing style at the insertion point**, bolding the unstyled runs of pasted content. Text arriving with its own spans is now inserted verbatim; plain text still inherits.
- **Span list order was load-bearing and not preserved downstream.** `SpanManager.processSpans` regroups spans by style and merges merely-adjacent ones, which silently merged pasted bold away whenever the caret sat next to matching existing bold. Cancellation is now resolved while walking the document, so no span exists only to undo another one and order stops mattering.
- **Windows CF_HTML descriptor leaked into the document.** Windows prefixes clipboard markup with `Version:`/`StartHTML:`/`StartFragment:` lines; those parsed as body text. Now unwrapped, and when the source marks a fragment only the fragment is kept rather than the whole surrounding page.
- **Both clipboard directions hardcoded `MarkdownConfiguration.DEFAULT`**, so an app with custom header sizes lost the heading level on copy and permanently on save. The configuration now travels with the state, kept in sync by `MarkdownExtension`.
- Table cells separate with tabs; a trailing `<br>` is no longer dropped while a trailing block close still is; `white-space: pre` is honoured without a `<pre>` element.

### Testing

556 tests across both modules, 0 failures. Coverage includes round-trips, nesting, space-run preservation, a realistic Word CF_HTML payload, the Google Docs `<b style="font-weight:normal">` wrapper, style cancellation, custom-configuration heading round-trips, deep nesting, adversarial unterminated markup, and two end-to-end tests that go through `insertStringAtCursor` into `mergeAnnotatedStrings` rather than testing the parser in isolation.

Verified by hand in the sample app in both directions.

Compiles for desktop, Android, wasmJs and common metadata. **iOS is unverified** — it cannot be built on the Windows dev machine, so CI needs to confirm it.

### Not in scope

- **Only desktop is wired.** Android (`ClipData.newHtmlText`), iOS (`UIPasteboard` `public.html`) and web (DOM `ClipboardEvent`) are untouched and still plain-text.
- **Rich spans still ride the old path.** Lists and blockquotes go through the `copiedRichSpans` buffer with its text-equality guard. Moving them into HTML (`<ul>`/`<li>`/`<blockquote>`) is the follow-up that would let that buffer go away.
- **Links carry no URL**, because `SpanStyle` has nowhere to put one. Unchanged from the markdown serializer, which emits `[text]()`.
- Word's proprietary properties (`mso-bidi-font-weight`) are deliberately not interpreted.
