### PR TITLE
End-to-end UI test harness and interaction suites

### DIFF
--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/ClipboardE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/ClipboardE2eTest.kt
@@ -1,0 +1,87 @@
+package e2e
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private val BOLD = SpanStyle(fontWeight = FontWeight.Bold)
+
+/** Copy, cut, and paste through real Ctrl+C/X/V against an isolated in-memory clipboard. */
+class ClipboardE2eTest {
+
+	@Test
+	fun `copy then paste at the end duplicates the selection`() = editorUiTest(
+		initialText = AnnotatedString("Hello World"),
+	) {
+		dragSelect(fromChar = 0, toChar = 5)
+		press(Key.C, ctrl = true)
+
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.V, ctrl = true)
+
+		assertEquals("Hello WorldHello", text)
+	}
+
+	@Test
+	fun `cut removes the selection and paste restores it elsewhere`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 4, toChar = 10)
+		press(Key.X, ctrl = true)
+		assertEquals("The brown fox", text)
+
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.V, ctrl = true)
+		assertEquals("The brown foxquick ", text)
+	}
+
+	@Test
+	fun `paste over a selection replaces it`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 0, toChar = 3)
+		press(Key.C, ctrl = true)
+
+		dragSelect(fromChar = 10, toChar = 15)
+		press(Key.V, ctrl = true)
+
+		assertEquals("The quick The fox", text)
+	}
+
+	@Test
+	fun `copy with no selection leaves the clipboard untouched`() = editorUiTest(
+		initialText = AnnotatedString("Hello"),
+	) {
+		clickAtCharacter(2)
+		press(Key.C, ctrl = true)
+
+		assertTrue(clipboard.isEmpty, "copy without a selection must not write to the clipboard")
+
+		press(Key.V, ctrl = true)
+		assertEquals("Hello", text, "paste from an empty clipboard must be a no-op")
+	}
+
+	@Test
+	fun `paste over a selection preserves character styling`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 4, toChar = 9)
+		state.addStyleSpan(state.selector.selection!!, BOLD)
+
+		dragSelect(fromChar = 4, toChar = 9)
+		press(Key.C, ctrl = true)
+		dragSelect(fromChar = 10, toChar = 15)
+		press(Key.V, ctrl = true)
+
+		assertEquals("The quick quick fox", text)
+		assertTrue(
+			stylesAt(12).contains(BOLD),
+			"pasted text must keep the bold span from the copied region",
+		)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/ClipboardE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/ClipboardE2eTest.kt
@@ -67,6 +67,25 @@ class ClipboardE2eTest {
 	}
 
 	@Test
+	fun `paste at the cursor preserves character styling`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 4, toChar = 9)
+		state.addStyleSpan(state.selector.selection!!, BOLD)
+
+		dragSelect(fromChar = 4, toChar = 9)
+		press(Key.C, ctrl = true)
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.V, ctrl = true)
+
+		assertEquals("The quick brown foxquick", text)
+		assertTrue(
+			stylesAt(20).contains(BOLD),
+			"text pasted at a plain cursor must keep the bold span from the copied region",
+		)
+	}
+
+	@Test
 	fun `paste over a selection preserves character styling`() = editorUiTest(
 		initialText = AnnotatedString("The quick brown fox"),
 	) {

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/EditorEdgeCasesE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/EditorEdgeCasesE2eTest.kt
@@ -1,0 +1,165 @@
+package e2e
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
+import com.darkrockstudios.texteditor.state.SpanClickType
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Boundary conditions, disabled state, unicode, rich span clicks, and scrolling. */
+@OptIn(ExperimentalTestApi::class)
+class EditorEdgeCasesE2eTest {
+
+	@Test
+	fun `disabled editor ignores typing and deletion`() = editorUiTest(
+		initialText = AnnotatedString("Hello"),
+		enabled = false,
+	) {
+		clickAtCharacter(2)
+		typeText("XYZ")
+		press(Key.Backspace)
+		press(Key.Delete)
+
+		assertEquals("Hello", text)
+	}
+
+	@Test
+	fun `disabled editor still allows selection`() = editorUiTest(
+		initialText = AnnotatedString("Hello World"),
+		enabled = false,
+	) {
+		clickAtCharacter(2)
+		press(Key.A, ctrl = true)
+
+		assertEquals("Hello World", selectedText)
+	}
+
+	@Test
+	fun `empty document survives deletion and navigation keys`() = editorUiTest {
+		press(Key.Backspace)
+		press(Key.Delete)
+		press(Key.DirectionLeft)
+		press(Key.DirectionRight)
+		press(Key.DirectionUp)
+		press(Key.DirectionDown)
+		press(Key.MoveHome)
+		press(Key.MoveEnd)
+
+		assertEquals("", text)
+
+		typeText("still works")
+		assertEquals("still works", text)
+	}
+
+	@Test
+	fun `click far beyond the line end places the cursor at the line end`() = editorUiTest(
+		initialText = AnnotatedString("short"),
+	) {
+		clickAt(Offset(350f, 10f))
+
+		assertEquals(CharLineOffset(0, 5), state.cursorPosition)
+	}
+
+	@Test
+	fun `click below the last line lands on the last line`() = editorUiTest(
+		initialText = AnnotatedString("first\nlast"),
+	) {
+		clickAt(Offset(10f, 250f))
+
+		assertEquals(1, state.cursorPosition.line)
+	}
+
+	@Test
+	fun `typing accented characters produces the exact text`() = editorUiTest {
+		typeText("héllö wörld ünïcodé")
+
+		assertEquals("héllö wörld ünïcodé", text)
+	}
+
+	@Test
+	fun `typing surrogate pair emoji arrives intact`() = editorUiTest {
+		typeText("hi 🎉")
+
+		assertEquals("hi 🎉", text)
+	}
+
+	@Test
+	fun `emoji inserted via semantics text input arrives intact`() = editorUiTest {
+		test.onNode(hasSetTextAction()).performTextInput("🎉👍")
+		waitForIdle()
+
+		assertEquals("🎉👍", text)
+	}
+
+	@Test
+	fun `left-clicking a rich span fires the click callback`() {
+		var clickedType: SpanClickType? = null
+		editorUiTest(
+			initialText = AnnotatedString("The quick brown fox"),
+			onRichSpanClick = { _, type, _ ->
+				clickedType = type
+				true
+			},
+		) {
+			state.addRichSpan(4, 9, HighlightSpanStyle(Color.Yellow))
+			waitForIdle()
+
+			clickAtCharacter(6)
+
+			assertEquals(SpanClickType.PRIMARY_CLICK, clickedType)
+		}
+	}
+
+	@Test
+	fun `clicking outside the rich span does not fire the callback`() {
+		var clicks = 0
+		editorUiTest(
+			initialText = AnnotatedString("The quick brown fox"),
+			onRichSpanClick = { _, _, _ ->
+				clicks++
+				true
+			},
+		) {
+			state.addRichSpan(4, 9, HighlightSpanStyle(Color.Yellow))
+			waitForIdle()
+
+			clickAtCharacter(14)
+
+			assertEquals(0, clicks)
+		}
+	}
+
+	@Test
+	fun `ctrl+end on a tall document scrolls the viewport down`() = editorUiTest(
+		initialText = AnnotatedString((1..80).joinToString("\n") { "line number $it" }),
+	) {
+		clickAtCharacter(0)
+		press(Key.MoveEnd, ctrl = true)
+
+		assertEquals(79, state.cursorPosition.line)
+		assertTrue(
+			state.scrollState.value > 0,
+			"moving the cursor to the end must scroll the viewport, scroll=${state.scrollState.value}",
+		)
+	}
+
+	@Test
+	fun `typing at the bottom of a tall document keeps the document intact`() = editorUiTest(
+		initialText = AnnotatedString((1..80).joinToString("\n") { "line number $it" }),
+	) {
+		press(Key.MoveEnd, ctrl = true)
+		typeText(" appended")
+
+		assertEquals("line number 80 appended", lines.last())
+		assertEquals(80, lines.size)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/EditorEndToEndPocTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/EditorEndToEndPocTest.kt
@@ -1,0 +1,142 @@
+package e2e
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PixelMap
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.texteditor.BasicTextEditor
+import com.darkrockstudios.texteditor.TextEditorStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.state.rememberTextEditorState
+import utils.typeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Proof-of-concept for end-to-end editor tests: real composable, synthetic
+ * input events, assertions on both state and rendered pixels.
+ */
+@OptIn(ExperimentalTestApi::class)
+class EditorEndToEndPocTest {
+
+	@Test
+	fun `typing via AWT key events inserts characters`() = runSkikoComposeUiTest {
+		lateinit var state: TextEditorState
+		setContent {
+			state = rememberTextEditorState()
+			BasicTextEditor(
+				state = state,
+				modifier = Modifier.size(width = 400.dp, height = 200.dp),
+				autoFocus = true,
+			)
+		}
+		waitForIdle()
+
+		typeText("Hello, World!")
+
+		assertEquals("Hello, World!", state.getAllText().text)
+	}
+
+	@Test
+	fun `typing via semantics text input inserts text`() = runSkikoComposeUiTest {
+		lateinit var state: TextEditorState
+		setContent {
+			state = rememberTextEditorState()
+			BasicTextEditor(
+				state = state,
+				modifier = Modifier.size(width = 400.dp, height = 200.dp),
+				autoFocus = true,
+			)
+		}
+		waitForIdle()
+
+		onNode(hasSetTextAction()).performTextInput("Hello, world")
+		waitForIdle()
+
+		assertEquals("Hello, world", state.getAllText().text)
+	}
+
+	@Test
+	fun `click positions cursor then backspace deletes at that position`() = runSkikoComposeUiTest {
+		lateinit var state: TextEditorState
+		setContent {
+			state = rememberTextEditorState(
+				initialText = AnnotatedString("Hello World")
+			)
+			BasicTextEditor(
+				state = state,
+				modifier = Modifier.size(width = 400.dp, height = 200.dp),
+				autoFocus = true,
+			)
+		}
+		waitForIdle()
+
+		// Click far to the right of the single line: cursor goes to end of text.
+		onRoot().performMouseInput { click(Offset(300f, 10f)) }
+		waitForIdle()
+
+		onRoot().performKeyInput { pressKey(Key.Backspace) }
+		waitForIdle()
+
+		assertEquals("Hello Worl", state.getAllText().text)
+	}
+
+	@Test
+	fun `typed text produces visible glyph pixels`() = runSkikoComposeUiTest {
+		lateinit var state: TextEditorState
+		setContent {
+			state = rememberTextEditorState()
+			BasicTextEditor(
+				state = state,
+				modifier = Modifier.size(width = 200.dp, height = 100.dp),
+				style = TextEditorStyle(
+					textColor = Color.Black,
+					backgroundColor = Color.White,
+					cursorColor = Color.White,
+				),
+				autoFocus = true,
+			)
+		}
+		waitForIdle()
+
+		val before = onRoot().captureToImage().toPixelMap()
+		val beforeDark = countDarkPixels(before)
+
+		typeText("Hello")
+
+		val after = onRoot().captureToImage().toPixelMap()
+		val afterDark = countDarkPixels(after)
+
+		assertTrue(
+			afterDark > beforeDark + 50,
+			"expected glyph pixels after typing: before=$beforeDark after=$afterDark",
+		)
+	}
+
+	private fun countDarkPixels(pixels: PixelMap): Int {
+		var count = 0
+		for (y in 0 until pixels.height) {
+			for (x in 0 until pixels.width) {
+				val c = pixels[x, y]
+				if (c.red < 0.5f && c.green < 0.5f && c.blue < 0.5f) count++
+			}
+		}
+		return count
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/EditorInteractionE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/EditorInteractionE2eTest.kt
@@ -1,0 +1,122 @@
+package e2e
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private val BOLD = SpanStyle(fontWeight = FontWeight.Bold)
+
+/**
+ * End-to-end interaction specs: simulated keyboard and mouse input against a
+ * real [com.darkrockstudios.texteditor.BasicTextEditor], verified at the data
+ * level (document text, selection, span styles).
+ */
+class EditorInteractionE2eTest {
+
+	@Test
+	fun `drag selection then bold shows up in the span data`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 4, toChar = 9)
+		assertEquals("quick", selectedText)
+
+		val selection = state.selector.selection
+		assertNotNull(selection)
+		state.addStyleSpan(selection, BOLD)
+
+		assertTrue(stylesAt(6).contains(BOLD), "middle of 'quick' must be bold")
+		assertFalse(stylesAt(2).contains(BOLD), "'The' must not be bold")
+		assertFalse(stylesAt(12).contains(BOLD), "'brown' must not be bold")
+	}
+
+	@Test
+	fun `double click selects the word under the pointer`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		doubleClickAtCharacter(6)
+		assertEquals("quick", selectedText)
+	}
+
+	@Test
+	fun `select all then typing replaces the whole document`() = editorUiTest(
+		initialText = AnnotatedString("Hello World"),
+	) {
+		press(Key.A, ctrl = true)
+		assertEquals("Hello World", selectedText)
+
+		typeText("x")
+		assertEquals("x", text)
+	}
+
+	@Test
+	fun `toggling bold at the cursor makes typed text bold in the data`() = editorUiTest {
+		typeText("plain ")
+		state.cursor.toggleStyle(BOLD)
+		typeText("bold")
+
+		assertEquals("plain bold", text)
+		assertFalse(stylesAt(2).contains(BOLD), "'plain' must not be bold")
+		assertTrue(stylesAt(7).contains(BOLD), "'bold' must be bold")
+		assertTrue(stylesAt(9).contains(BOLD), "last typed char must be bold")
+	}
+
+	@Test
+	fun `undo and redo shortcuts revert and restore typed text`() = editorUiTest {
+		typeText("Hello")
+		assertEquals("Hello", text)
+
+		press(Key.Z, ctrl = true)
+		assertTrue(text.length < "Hello".length, "undo must remove typed text, was '$text'")
+
+		while (text.isNotEmpty()) press(Key.Z, ctrl = true)
+		assertEquals("", text)
+
+		while (text != "Hello") {
+			val before = text
+			press(Key.Y, ctrl = true)
+			if (text == before) break
+		}
+		assertEquals("Hello", text)
+	}
+
+	@Test
+	fun `shift+click extends selection and cut removes it via keyboard`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		clickAtCharacter(4)
+		clickAtCharacter(15, shift = true)
+		assertEquals("quick brown", selectedText)
+
+		press(Key.Delete)
+		assertEquals("The  fox", text)
+	}
+
+	@Test
+	fun `cursor inherits bold style from the character it lands on`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 4, toChar = 9)
+		val selection = state.selector.selection
+		assertNotNull(selection)
+		state.addStyleSpan(selection, BOLD)
+
+		clickAtCharacter(7)
+		assertTrue(
+			state.cursor.styles.contains(BOLD),
+			"cursor inside a bold run must carry the bold style for the next typed char",
+		)
+
+		clickAtCharacter(1)
+		assertFalse(
+			state.cursor.styles.contains(BOLD),
+			"cursor in plain text must not carry bold",
+		)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/NavigationE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/NavigationE2eTest.kt
@@ -1,0 +1,154 @@
+package e2e
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Cursor movement via arrow keys, Home/End, word jumps, and page keys. */
+class NavigationE2eTest {
+
+	@Test
+	fun `right and left arrows move the cursor by one character`() = editorUiTest(
+		initialText = AnnotatedString("Hello"),
+	) {
+		clickAtCharacter(0)
+		press(Key.DirectionRight)
+		press(Key.DirectionRight)
+		assertEquals(2, cursorIndex)
+
+		press(Key.DirectionLeft)
+		assertEquals(1, cursorIndex)
+	}
+
+	@Test
+	fun `left arrow at document start is a no-op`() = editorUiTest(
+		initialText = AnnotatedString("Hello"),
+	) {
+		clickAtCharacter(0)
+		press(Key.DirectionLeft)
+		press(Key.DirectionLeft)
+
+		assertEquals(0, cursorIndex)
+	}
+
+	@Test
+	fun `right arrow at document end is a no-op`() = editorUiTest(
+		initialText = AnnotatedString("Hi"),
+	) {
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.DirectionRight)
+		press(Key.DirectionRight)
+
+		assertEquals(2, cursorIndex)
+	}
+
+	@Test
+	fun `left arrow at line start wraps to the end of the previous line`() = editorUiTest(
+		initialText = AnnotatedString("Hello\nWorld"),
+	) {
+		clickAtCharacter(6)
+		press(Key.DirectionLeft)
+
+		assertEquals(CharLineOffset(0, 5), state.cursorPosition)
+	}
+
+	@Test
+	fun `down arrow keeps the column and up arrow returns`() = editorUiTest(
+		initialText = AnnotatedString("first line\nsecond line"),
+	) {
+		clickAtCharacter(3)
+		press(Key.DirectionDown)
+		assertEquals(CharLineOffset(1, 3), state.cursorPosition)
+
+		press(Key.DirectionUp)
+		assertEquals(CharLineOffset(0, 3), state.cursorPosition)
+	}
+
+	@Test
+	fun `down arrow to a shorter line clamps to its end`() = editorUiTest(
+		initialText = AnnotatedString("a much longer line\nabc"),
+	) {
+		clickAtCharacter(10)
+		press(Key.DirectionDown)
+
+		assertEquals(CharLineOffset(1, 3), state.cursorPosition)
+	}
+
+	@Test
+	fun `up on the first line and down on the last line are no-ops`() = editorUiTest(
+		initialText = AnnotatedString("Hello\nWorld"),
+	) {
+		clickAtCharacter(2)
+		press(Key.DirectionUp)
+		assertEquals(CharLineOffset(0, 2), state.cursorPosition)
+
+		clickAtCharacter(8)
+		press(Key.DirectionDown)
+		assertEquals(CharLineOffset(1, 2), state.cursorPosition)
+	}
+
+	@Test
+	fun `home and end move within the current line only`() = editorUiTest(
+		initialText = AnnotatedString("first\nsecond\nthird"),
+	) {
+		clickAtCharacter(9)
+		press(Key.MoveHome)
+		assertEquals(CharLineOffset(1, 0), state.cursorPosition)
+
+		press(Key.MoveEnd)
+		assertEquals(CharLineOffset(1, 6), state.cursorPosition)
+	}
+
+	@Test
+	fun `ctrl+home and ctrl+end jump to the document boundaries`() = editorUiTest(
+		initialText = AnnotatedString("first\nsecond\nthird"),
+	) {
+		clickAtCharacter(9)
+		press(Key.MoveHome, ctrl = true)
+		assertEquals(CharLineOffset(0, 0), state.cursorPosition)
+
+		press(Key.MoveEnd, ctrl = true)
+		assertEquals(CharLineOffset(2, 5), state.cursorPosition)
+	}
+
+	@Test
+	fun `ctrl+right jumps word by word`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		clickAtCharacter(0)
+		press(Key.DirectionRight, ctrl = true)
+		assertEquals(4, cursorIndex, "first jump lands on 'quick'")
+
+		press(Key.DirectionRight, ctrl = true)
+		assertEquals(10, cursorIndex, "second jump lands on 'brown'")
+	}
+
+	@Test
+	fun `ctrl+left jumps back to the previous word start`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		clickAtCharacter(10)
+		press(Key.DirectionLeft, ctrl = true)
+		assertEquals(4, cursorIndex)
+
+		press(Key.DirectionLeft, ctrl = true)
+		assertEquals(0, cursorIndex)
+	}
+
+	@Test
+	fun `page down moves the cursor far down a tall document`() = editorUiTest(
+		initialText = AnnotatedString((1..80).joinToString("\n") { "line number $it" }),
+	) {
+		clickAtCharacter(0)
+		press(Key.PageDown)
+
+		assertTrue(
+			state.cursorPosition.line > 5,
+			"page down must move more than a few lines, was line ${state.cursorPosition.line}",
+		)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/SelectionE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/SelectionE2eTest.kt
@@ -1,0 +1,153 @@
+package e2e
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Building, extending, and clearing selections with keyboard and mouse. */
+class SelectionE2eTest {
+
+	@Test
+	fun `shift+right extends the selection one character at a time`() = editorUiTest(
+		initialText = AnnotatedString("Hello"),
+	) {
+		clickAtCharacter(0)
+		press(Key.DirectionRight, shift = true)
+		assertEquals("H", selectedText)
+
+		press(Key.DirectionRight, shift = true)
+		assertEquals("He", selectedText)
+	}
+
+	@Test
+	fun `shift+left selects backwards from the cursor`() = editorUiTest(
+		initialText = AnnotatedString("Hello"),
+	) {
+		clickAtCharacter(5)
+		press(Key.DirectionLeft, shift = true)
+		press(Key.DirectionLeft, shift = true)
+
+		assertEquals("lo", selectedText)
+	}
+
+	@Test
+	fun `ctrl+shift+right selects to the next word start`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		clickAtCharacter(0)
+		press(Key.DirectionRight, ctrl = true, shift = true)
+
+		assertEquals("The ", selectedText)
+	}
+
+	@Test
+	fun `shift+end selects to the end of the line`() = editorUiTest(
+		initialText = AnnotatedString("Hello World\nsecond"),
+	) {
+		clickAtCharacter(6)
+		press(Key.MoveEnd, shift = true)
+
+		assertEquals("World", selectedText)
+	}
+
+	@Test
+	fun `shift+home selects back to the start of the line`() = editorUiTest(
+		initialText = AnnotatedString("Hello World"),
+	) {
+		clickAtCharacter(5)
+		press(Key.MoveHome, shift = true)
+
+		assertEquals("Hello", selectedText)
+	}
+
+	@Test
+	fun `ctrl+shift+end selects to the end of the document across lines`() = editorUiTest(
+		initialText = AnnotatedString("first\nsecond\nthird"),
+	) {
+		clickAtCharacter(2)
+		press(Key.MoveEnd, ctrl = true, shift = true)
+
+		assertEquals("rst\nsecond\nthird", selectedText)
+	}
+
+	@Test
+	fun `shift+down selects across a line boundary`() = editorUiTest(
+		initialText = AnnotatedString("abcdef\nghijkl"),
+	) {
+		clickAtCharacter(2)
+		press(Key.DirectionDown, shift = true)
+
+		assertEquals("cdef\ngh", selectedText)
+	}
+
+	@Test
+	fun `dragging across lines selects the spanned text`() = editorUiTest(
+		initialText = AnnotatedString("line one\nline two"),
+	) {
+		dragSelect(fromChar = 5, toChar = 13)
+
+		assertEquals("one\nline", selectedText)
+	}
+
+	@Test
+	fun `plain click clears an existing selection`() = editorUiTest(
+		initialText = AnnotatedString("Hello World"),
+	) {
+		press(Key.A, ctrl = true)
+		assertEquals("Hello World", selectedText)
+
+		clickAtCharacter(3)
+		assertNull(state.selector.selection)
+	}
+
+	@Test
+	fun `unshifted arrow clears an existing selection`() = editorUiTest(
+		initialText = AnnotatedString("Hello World"),
+	) {
+		dragSelect(fromChar = 0, toChar = 5)
+		assertEquals("Hello", selectedText)
+
+		press(Key.DirectionRight)
+		assertNull(state.selector.selection)
+	}
+
+	@Test
+	fun `ctrl+a selects a multi-line document entirely`() = editorUiTest(
+		initialText = AnnotatedString("first\nsecond\nthird"),
+	) {
+		clickAtCharacter(8)
+		press(Key.A, ctrl = true)
+
+		assertEquals("first\nsecond\nthird", selectedText)
+	}
+
+	@Test
+	fun `double click does not include adjacent punctuation`() = editorUiTest(
+		initialText = AnnotatedString("Hello, world!"),
+	) {
+		doubleClickAtCharacter(2)
+		assertEquals("Hello", selectedText)
+
+		doubleClickAtCharacter(9)
+		assertEquals("world", selectedText)
+	}
+
+	@Test
+	fun `selection survives extending in both directions with keyboard`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		clickAtCharacter(4)
+		press(Key.DirectionRight, ctrl = true, shift = true)
+		assertEquals("quick ", selectedText)
+
+		press(Key.DirectionRight, ctrl = true, shift = true)
+		assertEquals("quick brown ", selectedText)
+
+		press(Key.DirectionLeft, ctrl = true, shift = true)
+		assertTrue(selectedText.startsWith("quick"), "shrinking must keep the anchor, was '$selectedText'")
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/StylingSpansE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/StylingSpansE2eTest.kt
@@ -1,0 +1,132 @@
+package e2e
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private val BOLD = SpanStyle(fontWeight = FontWeight.Bold)
+private val ITALIC = SpanStyle(fontStyle = FontStyle.Italic)
+
+/** Character styles and rich spans interacting with real editing input. */
+class StylingSpansE2eTest {
+
+	private fun utils.EditorUiTestScope.boldWord(fromChar: Int, toChar: Int) {
+		dragSelect(fromChar, toChar)
+		state.addStyleSpan(state.selector.selection!!, BOLD)
+		clickAtCharacter(0)
+	}
+
+	@Test
+	fun `typing at the end of a bold run extends the bold span`() = editorUiTest(
+		initialText = AnnotatedString("bold plain"),
+	) {
+		boldWord(0, 4)
+
+		clickAtCharacter(4)
+		typeText("er")
+
+		assertEquals("bolder plain", text)
+		assertTrue(stylesAt(4).contains(BOLD), "first typed char must join the bold run")
+		assertTrue(stylesAt(5).contains(BOLD), "second typed char must join the bold run")
+		assertFalse(stylesAt(7).contains(BOLD), "'plain' must stay unstyled")
+	}
+
+	@Test
+	fun `typing before a bold run stays plain`() = editorUiTest(
+		initialText = AnnotatedString("plain bold"),
+	) {
+		boldWord(6, 10)
+
+		clickAtCharacter(6)
+		typeText("x")
+
+		assertEquals("plain xbold", text)
+		assertFalse(stylesAt(6).contains(BOLD), "char typed at the run boundary must match the preceding plain text")
+		assertTrue(stylesAt(7).contains(BOLD), "the bold run must shift right intact")
+	}
+
+	@Test
+	fun `backspace inside a bold run keeps the remainder bold`() = editorUiTest(
+		initialText = AnnotatedString("The quick fox"),
+	) {
+		boldWord(4, 9)
+
+		clickAtCharacter(9)
+		press(Key.Backspace)
+		press(Key.Backspace)
+
+		assertEquals("The qui fox", text)
+		assertTrue(stylesAt(4).contains(BOLD))
+		assertTrue(stylesAt(6).contains(BOLD))
+	}
+
+	@Test
+	fun `splitting a bold word with enter keeps both halves bold`() = editorUiTest(
+		initialText = AnnotatedString("boldword"),
+	) {
+		boldWord(0, 8)
+
+		clickAtCharacter(4)
+		press(Key.Enter)
+
+		assertEquals(listOf("bold", "word"), lines)
+		assertTrue(stylesAt(1).contains(BOLD), "first half must stay bold")
+		assertTrue(stylesAt(6).contains(BOLD), "second half must stay bold")
+	}
+
+	@Test
+	fun `removeStyleSpan unbolds the selected range only`() = editorUiTest(
+		initialText = AnnotatedString("aabbbaa"),
+	) {
+		dragSelect(fromChar = 0, toChar = 7)
+		state.addStyleSpan(state.selector.selection!!, BOLD)
+
+		dragSelect(fromChar = 2, toChar = 5)
+		state.removeStyleSpan(state.selector.selection!!, BOLD)
+
+		assertTrue(stylesAt(0).contains(BOLD))
+		assertFalse(stylesAt(3).contains(BOLD), "middle must be unbolded")
+		assertTrue(stylesAt(6).contains(BOLD))
+	}
+
+	@Test
+	fun `overlapping bold and italic both cover the intersection`() = editorUiTest(
+		initialText = AnnotatedString("abcdefgh"),
+	) {
+		dragSelect(fromChar = 0, toChar = 5)
+		state.addStyleSpan(state.selector.selection!!, BOLD)
+
+		dragSelect(fromChar = 3, toChar = 8)
+		state.addStyleSpan(state.selector.selection!!, ITALIC)
+
+		assertTrue(stylesAt(4).contains(BOLD) && stylesAt(4).contains(ITALIC))
+		assertTrue(stylesAt(1).contains(BOLD) && !stylesAt(1).contains(ITALIC))
+		assertTrue(!stylesAt(6).contains(BOLD) && stylesAt(6).contains(ITALIC))
+	}
+
+	@Test
+	fun `rich span shifts right when text is inserted before it`() = editorUiTest(
+		initialText = AnnotatedString("The quick fox"),
+	) {
+		state.addRichSpan(4, 9, HighlightSpanStyle(Color.Yellow))
+		val before = state.richSpanManager.getAllRichSpans().single()
+		assertEquals(4, state.getCharacterIndex(before.range.start))
+
+		clickAtCharacter(0)
+		typeText("xy")
+
+		val after = state.richSpanManager.getAllRichSpans().single()
+		assertEquals("xyThe quick fox", text)
+		assertEquals(6, state.getCharacterIndex(after.range.start), "span must shift with the inserted text")
+		assertEquals(11, state.getCharacterIndex(after.range.end))
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/TypingAndDeletionE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/TypingAndDeletionE2eTest.kt
@@ -1,0 +1,142 @@
+package e2e
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Text entry, line splitting/merging, and deletion driven by real input events. */
+class TypingAndDeletionE2eTest {
+
+	@Test
+	fun `typing with newlines creates multiple lines`() = editorUiTest {
+		typeText("first line\nsecond line\nthird line")
+
+		assertEquals(listOf("first line", "second line", "third line"), lines)
+		assertEquals("first line\nsecond line\nthird line", text)
+	}
+
+	@Test
+	fun `enter mid-line splits the line at the cursor`() = editorUiTest(
+		initialText = AnnotatedString("HelloWorld"),
+	) {
+		clickAtCharacter(5)
+		press(Key.Enter)
+
+		assertEquals(listOf("Hello", "World"), lines)
+		assertEquals(6, cursorIndex, "cursor must sit at the start of the new line")
+	}
+
+	@Test
+	fun `backspace at line start merges with the previous line`() = editorUiTest(
+		initialText = AnnotatedString("Hello\nWorld"),
+	) {
+		clickAtCharacter(6)
+		press(Key.Backspace)
+
+		assertEquals("HelloWorld", text)
+		assertEquals(5, cursorIndex, "cursor must sit at the merge point")
+	}
+
+	@Test
+	fun `delete at line end pulls the next line up`() = editorUiTest(
+		initialText = AnnotatedString("Hello\nWorld"),
+	) {
+		clickAtCharacter(5)
+		press(Key.Delete)
+
+		assertEquals("HelloWorld", text)
+		assertEquals(5, cursorIndex)
+	}
+
+	@Test
+	fun `ctrl+backspace deletes the previous word`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown"),
+	) {
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.Backspace, ctrl = true)
+
+		assertEquals("The quick ", text)
+	}
+
+	@Test
+	fun `ctrl+delete deletes the next word`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown"),
+	) {
+		press(Key.MoveHome, ctrl = true)
+		press(Key.Delete, ctrl = true)
+
+		assertEquals("quick brown", text)
+	}
+
+	@Test
+	fun `typing inserts at the clicked position`() = editorUiTest(
+		initialText = AnnotatedString("HelloWorld"),
+	) {
+		clickAtCharacter(5)
+		typeText(", ")
+
+		assertEquals("Hello, World", text)
+	}
+
+	@Test
+	fun `typing over a drag selection replaces it`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 4, toChar = 9)
+		typeText("slow")
+
+		assertEquals("The slow brown fox", text)
+	}
+
+	@Test
+	fun `backspace deletes only the selection when one exists`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 4, toChar = 10)
+		press(Key.Backspace)
+
+		assertEquals("The brown fox", text)
+	}
+
+	@Test
+	fun `enter over a selection replaces it with a line break`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 3, toChar = 15)
+		press(Key.Enter)
+
+		assertEquals(listOf("The", " fox"), lines)
+	}
+
+	@Test
+	fun `tab indents the current line with spaces`() = editorUiTest(
+		initialText = AnnotatedString("Hello"),
+	) {
+		clickAtCharacter(0)
+		press(Key.Tab)
+
+		assertEquals("    Hello", text)
+	}
+
+	@Test
+	fun `shift+tab outdents the current line`() = editorUiTest(
+		initialText = AnnotatedString("    Hello"),
+	) {
+		clickAtCharacter(6)
+		press(Key.Tab, shift = true)
+
+		assertEquals("Hello", text)
+	}
+
+	@Test
+	fun `tab with a multi-line selection indents every selected line`() = editorUiTest(
+		initialText = AnnotatedString("one\ntwo\nthree"),
+	) {
+		dragSelect(fromChar = 1, toChar = 10)
+		press(Key.Tab)
+
+		assertEquals(listOf("    one", "    two", "    three"), lines)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/UndoRedoE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/UndoRedoE2eTest.kt
@@ -1,0 +1,100 @@
+package e2e
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private val BOLD = SpanStyle(fontWeight = FontWeight.Bold)
+
+/** Undo/redo history driven entirely through keyboard shortcuts. */
+class UndoRedoE2eTest {
+
+	@Test
+	fun `undo restores a deleted selection`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 4, toChar = 10)
+		press(Key.Delete)
+		assertEquals("The brown fox", text)
+
+		press(Key.Z, ctrl = true)
+		assertEquals("The quick brown fox", text)
+	}
+
+	@Test
+	fun `undo reverts a line split and redo reapplies it`() = editorUiTest(
+		initialText = AnnotatedString("HelloWorld"),
+	) {
+		clickAtCharacter(5)
+		press(Key.Enter)
+		assertEquals(listOf("Hello", "World"), lines)
+
+		press(Key.Z, ctrl = true)
+		assertEquals("HelloWorld", text)
+
+		press(Key.Z, ctrl = true, shift = true)
+		assertEquals(listOf("Hello", "World"), lines)
+	}
+
+	@Test
+	fun `undo removes an applied style span`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+	) {
+		dragSelect(fromChar = 4, toChar = 9)
+		state.addStyleSpan(state.selector.selection!!, BOLD)
+		assertTrue(stylesAt(6).contains(BOLD))
+
+		press(Key.Z, ctrl = true)
+		assertFalse(stylesAt(6).contains(BOLD), "undo must remove the bold span")
+	}
+
+	@Test
+	fun `a new edit after undo clears the redo history`() = editorUiTest(
+		initialText = AnnotatedString("Hello"),
+	) {
+		press(Key.MoveEnd, ctrl = true)
+		typeText("!")
+		assertEquals("Hello!", text)
+
+		press(Key.Z, ctrl = true)
+		assertEquals("Hello", text)
+
+		typeText("?")
+		assertEquals("Hello?", text)
+
+		press(Key.Y, ctrl = true)
+		assertEquals("Hello?", text, "redo after a fresh edit must be a no-op")
+	}
+
+	@Test
+	fun `undo reverts a paste`() = editorUiTest(
+		initialText = AnnotatedString("Hello World"),
+	) {
+		dragSelect(fromChar = 0, toChar = 5)
+		press(Key.C, ctrl = true)
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.V, ctrl = true)
+		assertEquals("Hello WorldHello", text)
+
+		press(Key.Z, ctrl = true)
+		assertEquals("Hello World", text)
+	}
+
+	@Test
+	fun `undo reverts a multi-line indent in one step`() = editorUiTest(
+		initialText = AnnotatedString("one\ntwo"),
+	) {
+		press(Key.A, ctrl = true)
+		press(Key.Tab)
+		assertEquals(listOf("    one", "    two"), lines)
+
+		press(Key.Z, ctrl = true)
+		assertEquals(listOf("one", "two"), lines)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
@@ -1,9 +1,11 @@
 package utils
 
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SkikoComposeUiTest
 import androidx.compose.ui.test.click
@@ -18,6 +20,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.texteditor.BasicTextEditor
+import com.darkrockstudios.texteditor.RichSpanClickListener
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.rememberTextEditorState
 
@@ -26,40 +29,55 @@ import com.darkrockstudios.texteditor.state.rememberTextEditorState
  * drives it with synthetic keyboard/mouse events, and exposes [state] for
  * data-level assertions. Character-index-based helpers ([clickAtCharacter],
  * [dragSelect]) resolve pixel positions through the editor's own layout, so
- * tests never hard-code coordinates.
+ * tests never hard-code coordinates. Clipboard operations go through an
+ * isolated [InMemoryClipboard], never the OS clipboard.
  */
 @OptIn(ExperimentalTestApi::class)
 fun editorUiTest(
 	initialText: AnnotatedString = AnnotatedString(""),
 	width: Dp = 400.dp,
 	height: Dp = 300.dp,
+	enabled: Boolean = true,
+	onRichSpanClick: RichSpanClickListener? = null,
 	block: EditorUiTestScope.() -> Unit,
 ) = runSkikoComposeUiTest {
+	val clipboard = InMemoryClipboard()
 	lateinit var state: TextEditorState
 	setContent {
 		state = rememberTextEditorState(initialText = initialText)
-		BasicTextEditor(
-			state = state,
-			modifier = Modifier.size(width, height),
-			autoFocus = true,
-		)
+		CompositionLocalProvider(LocalClipboard provides clipboard) {
+			BasicTextEditor(
+				state = state,
+				modifier = Modifier.size(width, height),
+				enabled = enabled,
+				autoFocus = enabled,
+				onRichSpanClick = onRichSpanClick,
+			)
+		}
 	}
 	waitForIdle()
-	EditorUiTestScope(this, state).block()
+	EditorUiTestScope(this, state, clipboard).block()
 }
 
 @OptIn(ExperimentalTestApi::class)
 class EditorUiTestScope(
 	val test: SkikoComposeUiTest,
 	val state: TextEditorState,
+	val clipboard: InMemoryClipboard,
 ) {
 	/** Plain text of the whole document. */
 	val text: String get() = state.getAllText().text
 
+	/** Plain text of each line of the document. */
+	val lines: List<String> get() = state.textLines.map { it.text }
+
 	/** Plain text of the current selection, or empty when there is none. */
 	val selectedText: String get() = state.selector.getSelectedText().text
 
-	/** Types printable characters through real desktop key events. */
+	/** The cursor position as a flat character index into [text]. */
+	val cursorIndex: Int get() = state.getCharacterIndex(state.cursorPosition)
+
+	/** Types printable characters through real desktop key events; `\n` and `\t` become Enter/Tab. */
 	fun typeText(text: String) = test.typeText(text)
 
 	/** Presses [key] with optional modifiers held, e.g. `press(Key.Z, ctrl = true)`. */
@@ -78,20 +96,28 @@ class EditorUiTestScope(
 
 	/** Left-clicks the character at flat index [charIndex]. */
 	fun clickAtCharacter(charIndex: Int, shift: Boolean = false) {
+		clickAt(positionOfCharacter(charIndex), shift)
+	}
+
+	/** Left-clicks an arbitrary pixel [position], optionally with shift held. */
+	fun clickAt(position: Offset, shift: Boolean = false) {
+		defeatMultiClickDetection()
 		if (shift) test.onRoot().performKeyInput { keyDown(Key.ShiftLeft) }
-		test.onRoot().performMouseInput { click(positionOfCharacter(charIndex)) }
+		test.onRoot().performMouseInput { click(position) }
 		if (shift) test.onRoot().performKeyInput { keyUp(Key.ShiftLeft) }
 		test.waitForIdle()
 	}
 
 	/** Double-clicks the character at flat index [charIndex] (word select). */
 	fun doubleClickAtCharacter(charIndex: Int) {
+		defeatMultiClickDetection()
 		test.onRoot().performMouseInput { doubleClick(positionOfCharacter(charIndex)) }
 		test.waitForIdle()
 	}
 
 	/** Presses at [fromChar], drags to [toChar], and releases. */
 	fun dragSelect(fromChar: Int, toChar: Int) {
+		defeatMultiClickDetection()
 		val from = positionOfCharacter(fromChar)
 		val to = positionOfCharacter(toChar)
 		test.onRoot().performMouseInput {
@@ -101,6 +127,13 @@ class EditorUiTestScope(
 			release()
 		}
 		test.waitForIdle()
+	}
+
+	// The editor's double/triple-click detection compares wall-clock timestamps
+	// (Clock.System.now, 300ms window), not the virtual test clock, so gestures
+	// issued back-to-back by a fast test read as multi-clicks and word-select.
+	private fun defeatMultiClickDetection() {
+		Thread.sleep(350)
 	}
 
 	/** Pixel position of the character at flat index [charIndex], vertically centered on its line. */

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
@@ -1,0 +1,119 @@
+package utils
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.doubleClick
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.texteditor.BasicTextEditor
+import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.state.rememberTextEditorState
+
+/**
+ * Harness for end-to-end editor tests: composes a real [BasicTextEditor],
+ * drives it with synthetic keyboard/mouse events, and exposes [state] for
+ * data-level assertions. Character-index-based helpers ([clickAtCharacter],
+ * [dragSelect]) resolve pixel positions through the editor's own layout, so
+ * tests never hard-code coordinates.
+ */
+@OptIn(ExperimentalTestApi::class)
+fun editorUiTest(
+	initialText: AnnotatedString = AnnotatedString(""),
+	width: Dp = 400.dp,
+	height: Dp = 300.dp,
+	block: EditorUiTestScope.() -> Unit,
+) = runSkikoComposeUiTest {
+	lateinit var state: TextEditorState
+	setContent {
+		state = rememberTextEditorState(initialText = initialText)
+		BasicTextEditor(
+			state = state,
+			modifier = Modifier.size(width, height),
+			autoFocus = true,
+		)
+	}
+	waitForIdle()
+	EditorUiTestScope(this, state).block()
+}
+
+@OptIn(ExperimentalTestApi::class)
+class EditorUiTestScope(
+	val test: SkikoComposeUiTest,
+	val state: TextEditorState,
+) {
+	/** Plain text of the whole document. */
+	val text: String get() = state.getAllText().text
+
+	/** Plain text of the current selection, or empty when there is none. */
+	val selectedText: String get() = state.selector.getSelectedText().text
+
+	/** Types printable characters through real desktop key events. */
+	fun typeText(text: String) = test.typeText(text)
+
+	/** Presses [key] with optional modifiers held, e.g. `press(Key.Z, ctrl = true)`. */
+	fun press(key: Key, ctrl: Boolean = false, shift: Boolean = false, alt: Boolean = false) {
+		test.onRoot().performKeyInput {
+			if (ctrl) keyDown(Key.CtrlLeft)
+			if (shift) keyDown(Key.ShiftLeft)
+			if (alt) keyDown(Key.AltLeft)
+			pressKey(key)
+			if (alt) keyUp(Key.AltLeft)
+			if (shift) keyUp(Key.ShiftLeft)
+			if (ctrl) keyUp(Key.CtrlLeft)
+		}
+		test.waitForIdle()
+	}
+
+	/** Left-clicks the character at flat index [charIndex]. */
+	fun clickAtCharacter(charIndex: Int, shift: Boolean = false) {
+		if (shift) test.onRoot().performKeyInput { keyDown(Key.ShiftLeft) }
+		test.onRoot().performMouseInput { click(positionOfCharacter(charIndex)) }
+		if (shift) test.onRoot().performKeyInput { keyUp(Key.ShiftLeft) }
+		test.waitForIdle()
+	}
+
+	/** Double-clicks the character at flat index [charIndex] (word select). */
+	fun doubleClickAtCharacter(charIndex: Int) {
+		test.onRoot().performMouseInput { doubleClick(positionOfCharacter(charIndex)) }
+		test.waitForIdle()
+	}
+
+	/** Presses at [fromChar], drags to [toChar], and releases. */
+	fun dragSelect(fromChar: Int, toChar: Int) {
+		val from = positionOfCharacter(fromChar)
+		val to = positionOfCharacter(toChar)
+		test.onRoot().performMouseInput {
+			moveTo(from)
+			press()
+			moveTo(to)
+			release()
+		}
+		test.waitForIdle()
+	}
+
+	/** Pixel position of the character at flat index [charIndex], vertically centered on its line. */
+	fun positionOfCharacter(charIndex: Int): Offset {
+		val metrics = state.getPositionForOffset(state.getOffsetAtCharacter(charIndex))
+		return Offset(metrics.position.x, metrics.position.y + metrics.height / 2f)
+	}
+
+	/** All [SpanStyle]s covering the character at flat index [charIndex]. */
+	fun stylesAt(charIndex: Int): List<SpanStyle> =
+		state.getAllText().spanStyles
+			.filter { charIndex >= it.start && charIndex < it.end }
+			.map { it.item }
+
+	fun waitForIdle() = test.waitForIdle()
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/InMemoryClipboard.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/InMemoryClipboard.kt
@@ -1,0 +1,25 @@
+package utils
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.NativeClipboard
+
+/**
+ * Isolated in-memory [Clipboard] for tests. Keeps copy/paste specs off the real
+ * OS clipboard, which is shared global state and flaky in headless CI.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class InMemoryClipboard : Clipboard {
+	private var entry: ClipEntry? = null
+
+	override suspend fun getClipEntry(): ClipEntry? = entry
+
+	override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+		entry = clipEntry
+	}
+
+	override val nativeClipboard: NativeClipboard = java.awt.datatransfer.Clipboard("in-memory-test")
+
+	val isEmpty: Boolean get() = entry == null
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/UiTestTyping.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/UiTestTyping.kt
@@ -14,20 +14,28 @@ import androidx.compose.ui.test.SkikoComposeUiTest
  * only synthesizes KeyDown/KeyUp, and on desktop printable characters are
  * consumed exclusively from the KEY_TYPED event (see
  * PlatformCharacterInput.desktop.kt).
+ *
+ * `\n` and `\t` are typed as Enter and Tab keystrokes, matching how those
+ * characters actually enter the editor (handled on KeyDown, with the KEY_TYPED
+ * control character filtered out).
  */
 @OptIn(ExperimentalTestApi::class, InternalComposeUiApi::class)
 fun SkikoComposeUiTest.typeText(text: String) {
 	for (ch in text) {
-		val keyCode = java.awt.event.KeyEvent.getExtendedKeyCodeForChar(ch.code)
+		val key = when (ch) {
+			'\n' -> Key.Enter
+			'\t' -> Key.Tab
+			else -> Key(java.awt.event.KeyEvent.getExtendedKeyCodeForChar(ch.code))
+		}
 		runOnUiThread {
 			scene.sendKeyEvent(
-				KeyEvent(key = Key(keyCode), type = KeyEventType.KeyDown, codePoint = ch.code)
+				KeyEvent(key = key, type = KeyEventType.KeyDown, codePoint = ch.code)
 			)
 			scene.sendKeyEvent(
 				KeyEvent(key = Key.Unknown, type = KeyEventType.Unknown, codePoint = ch.code)
 			)
 			scene.sendKeyEvent(
-				KeyEvent(key = Key(keyCode), type = KeyEventType.KeyUp, codePoint = ch.code)
+				KeyEvent(key = key, type = KeyEventType.KeyUp, codePoint = ch.code)
 			)
 		}
 	}

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/UiTestTyping.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/UiTestTyping.kt
@@ -1,0 +1,35 @@
+package utils
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+
+/**
+ * Types [text] into the focused editor by replaying the event sequence a real
+ * desktop keystroke produces: KeyDown, then a KEY_TYPED-style Unknown event
+ * carrying the character, then KeyUp. `performKeyInput` cannot do this — it
+ * only synthesizes KeyDown/KeyUp, and on desktop printable characters are
+ * consumed exclusively from the KEY_TYPED event (see
+ * PlatformCharacterInput.desktop.kt).
+ */
+@OptIn(ExperimentalTestApi::class, InternalComposeUiApi::class)
+fun SkikoComposeUiTest.typeText(text: String) {
+	for (ch in text) {
+		val keyCode = java.awt.event.KeyEvent.getExtendedKeyCodeForChar(ch.code)
+		runOnUiThread {
+			scene.sendKeyEvent(
+				KeyEvent(key = Key(keyCode), type = KeyEventType.KeyDown, codePoint = ch.code)
+			)
+			scene.sendKeyEvent(
+				KeyEvent(key = Key.Unknown, type = KeyEventType.Unknown, codePoint = ch.code)
+			)
+			scene.sendKeyEvent(
+				KeyEvent(key = Key(keyCode), type = KeyEventType.KeyUp, codePoint = ch.code)
+			)
+		}
+	}
+	waitForIdle()
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end test harness that composes a real `BasicTextEditor` headless (Compose UI test on Skia), drives it with synthetic keyboard and mouse events, and verifies behavior at the data level: document text, lines, selection, cursor position, span styles, rich spans, and scroll state. 80 specs across 9 files, all passing.

## Harness (`desktopTest/utils`)

- `editorUiTest { }` DSL: composes the editor and exposes `state` plus `text` / `lines` / `selectedText` / `cursorIndex` / `stylesAt(n)` accessors.
- `typeText()`: real per-character key event sequences (KeyDown, KEY_TYPED-style event, KeyUp). `performKeyInput` alone cannot type on desktop because printable characters are only consumed from the KEY_TYPED event. `\n` and `\t` become Enter/Tab keystrokes.
- Mouse helpers addressed by character index (`clickAtCharacter`, `dragSelect`, `doubleClickAtCharacter`), with pixel positions resolved through the editor's own layout.
- `InMemoryClipboard` injected via `LocalClipboard`, so clipboard specs never touch the shared OS clipboard.
- A real-time gap before each mouse gesture, because the editor detects double/triple clicks with wall-clock timestamps that back-to-back synthetic gestures would otherwise trip.

## Coverage

- Typing, line split/merge, forward/backward word deletion, indent/outdent (single and multi-line)
- Navigation: arrows with boundary no-ops, line wrap-around, column clamping, Home/End, Ctrl+Home/End, word jumps, PageDown
- Selection: shift+arrows, shift+word-jumps, shift+Home/End, multi-line drags, double-click word select, selection clearing
- Clipboard: copy/cut/paste round trips, paste over selection, empty-selection no-op, styled paste both at a plain cursor and over a selection
- Undo/redo of deletes, line splits, style spans, pastes, and multi-line indents; redo invalidation on fresh edits
- Styling: bold runs extending under typing, span splitting on Enter, partial unbold, overlapping bold+italic, rich spans shifting with edits and click callbacks
- Edge cases: disabled editor, empty document, clicks beyond text bounds, accented and surrogate-pair input, tall-document scrolling

## Note

An earlier revision of this branch documented a real bug it caught: paste at a plain cursor dropped the copied text styling via `applyCursorStyle`. That was independently fixed on main by #38, and after rebasing this branch pins the fixed behavior with a dedicated regression spec.