### PR TITLE
Platform-aware key bindings: macOS uses Cmd/Option

### DIFF
--- a/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.android.kt
+++ b/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.android.kt
@@ -1,0 +1,3 @@
+package com.darkrockstudios.texteditor.input
+
+internal actual fun platformKeyBindings(): KeyBindings = CtrlKeyBindings

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
@@ -45,6 +45,7 @@ import com.darkrockstudios.texteditor.contextmenu.TextEditorContextMenuProvider
 import com.darkrockstudios.texteditor.contextmenu.TextEditorContextMenuState
 import com.darkrockstudios.texteditor.cursor.DrawCursor
 import com.darkrockstudios.texteditor.input.CaptureViewForIme
+import com.darkrockstudios.texteditor.input.LocalKeyBindings
 import com.darkrockstudios.texteditor.input.TextEditorInputModifierElement
 import com.darkrockstudios.texteditor.input.selectionAsTextRange
 import com.darkrockstudios.texteditor.richstyle.BlockSpanStyle
@@ -100,8 +101,10 @@ fun BasicTextEditor(
 	val density = LocalDensity.current
 	val layoutDirection = LocalLayoutDirection.current
 
-	val inputModifierElement = remember(state, clipboard, enabled) {
-		TextEditorInputModifierElement(state, clipboard, enabled)
+	val keyBindings = LocalKeyBindings.current
+
+	val inputModifierElement = remember(state, clipboard, enabled, keyBindings) {
+		TextEditorInputModifierElement(state, clipboard, enabled, keyBindings)
 	}
 
 	val horizontalPadding = remember(contentPadding, layoutDirection) {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
@@ -34,9 +34,10 @@ import com.darkrockstudios.texteditor.state.TextEditorState
  * cards without the editor chrome.
  *
  * When [isSelectable] is true, users can select text (mouse drag / double-click word /
- * triple-click line / long-press on touch), copy to the clipboard via Ctrl+C / Cmd+C, select
- * all via Ctrl+A, and open a right-click "Copy / Select All" context menu. The text cursor
- * caret is still never drawn — only selection.
+ * triple-click line / long-press on touch), copy to the clipboard, select all, and open a
+ * right-click "Copy / Select All" context menu. The copy and select-all shortcuts follow the
+ * host platform: Ctrl+C / Ctrl+A on Windows and Linux, Cmd+C / Cmd+A on macOS and iOS. The
+ * text cursor caret is still never drawn — only selection.
  *
  * The caller owns the [TextEditorState] and is responsible for seeding it with content
  * (e.g. via `rememberTextEditorState(initialText)` or `withMarkdown(...)`).

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
@@ -37,7 +37,7 @@ import com.darkrockstudios.texteditor.state.TextEditorState
  * triple-click line / long-press on touch), copy to the clipboard, select all, and open a
  * right-click "Copy / Select All" context menu. The copy and select-all shortcuts follow the
  * host platform: Ctrl+C / Ctrl+A on Windows and Linux, Cmd+C / Cmd+A on macOS and iOS. The
- * text cursor caret is still never drawn — only selection.
+ * text cursor caret is still never drawn, only selection.
  *
  * The caller owns the [TextEditorState] and is responsible for seeding it with content
  * (e.g. via `rememberTextEditorState(initialText)` or `withMarkdown(...)`).

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
@@ -23,6 +23,7 @@ import com.darkrockstudios.texteditor.contextmenu.ContextMenuActions
 import com.darkrockstudios.texteditor.contextmenu.ContextMenuStrings
 import com.darkrockstudios.texteditor.contextmenu.TextEditorContextMenuProvider
 import com.darkrockstudios.texteditor.contextmenu.TextEditorContextMenuState
+import com.darkrockstudios.texteditor.input.LocalKeyBindings
 import com.darkrockstudios.texteditor.input.TextEditorInputModifierElement
 import com.darkrockstudios.texteditor.state.TextEditorState
 
@@ -63,8 +64,9 @@ fun RichTextView(
 		val focusRequester = remember { FocusRequester() }
 		val interactionSource = remember { MutableInteractionSource() }
 		val contextMenuState = remember { TextEditorContextMenuState() }
-		val inputModifierElement = remember(state, clipboard) {
-			TextEditorInputModifierElement(state, clipboard, enabled = false)
+		val keyBindings = LocalKeyBindings.current
+		val inputModifierElement = remember(state, clipboard, keyBindings) {
+			TextEditorInputModifierElement(state, clipboard, enabled = false, keyBindings = keyBindings)
 		}
 		val contextMenuActions = remember(state, clipboard) {
 			ContextMenuActions(state, clipboard, state.scope)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorCommand.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorCommand.kt
@@ -1,0 +1,45 @@
+package com.darkrockstudios.texteditor.input
+
+/**
+ * An editor operation, named by intent rather than by the keys that trigger it.
+ * [KeyBindings] maps a platform's key chords onto these.
+ */
+internal sealed interface EditorCommand {
+	/** Commands that change the document; they are ignored while the editor is disabled. */
+	val isEdit: Boolean
+
+	/** Cursor movement. Every motion extends the selection instead when Shift is held. */
+	enum class Motion : EditorCommand {
+		Left,
+		Right,
+		Up,
+		Down,
+		WordLeft,
+		WordRight,
+		LineStart,
+		LineEnd,
+		DocumentStart,
+		DocumentEnd,
+		PageUp,
+		PageDown;
+
+		override val isEdit: Boolean get() = false
+	}
+
+	enum class Action(override val isEdit: Boolean) : EditorCommand {
+		SelectAll(isEdit = false),
+		Copy(isEdit = false),
+		Cut(isEdit = true),
+		Paste(isEdit = true),
+		Undo(isEdit = true),
+		Redo(isEdit = true),
+		DeleteBackward(isEdit = true),
+		DeleteForward(isEdit = true),
+		DeleteWordBackward(isEdit = true),
+		DeleteWordForward(isEdit = true),
+		DeleteToLineStart(isEdit = true),
+		Indent(isEdit = true),
+		Outdent(isEdit = true),
+		NewLine(isEdit = true),
+	}
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
@@ -1,0 +1,113 @@
+package com.darkrockstudios.texteditor.input
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import com.darkrockstudios.texteditor.input.EditorCommand.Action
+import com.darkrockstudios.texteditor.input.EditorCommand.Motion
+
+/** Maps a platform's key chords onto the editor's [EditorCommand] vocabulary. */
+internal fun interface KeyBindings {
+	/** The command [event] triggers, or null when the chord is unbound. */
+	fun commandFor(event: KeyEvent): EditorCommand?
+}
+
+/** The bindings of the host platform. */
+internal expect fun platformKeyBindings(): KeyBindings
+
+internal val LocalKeyBindings = staticCompositionLocalOf { platformKeyBindings() }
+
+/** Windows and Linux conventions: Ctrl for shortcuts, Ctrl+Arrow for word jumps, Home/End for line bounds. */
+internal object CtrlKeyBindings : KeyBindings {
+	override fun commandFor(event: KeyEvent): EditorCommand? {
+		val ctrl = event.isCtrlPressed
+		return when (event.key) {
+			Key.A -> if (ctrl) Action.SelectAll else null
+			Key.C -> if (ctrl) Action.Copy else null
+			Key.X -> if (ctrl) Action.Cut else null
+			Key.V -> if (ctrl) Action.Paste else null
+			Key.Y -> if (ctrl) Action.Redo else null
+			Key.Z -> when {
+				ctrl && event.isShiftPressed -> Action.Redo
+				ctrl -> Action.Undo
+				else -> null
+			}
+
+			Key.DirectionLeft -> if (ctrl) Motion.WordLeft else Motion.Left
+			Key.DirectionRight -> if (ctrl) Motion.WordRight else Motion.Right
+			Key.DirectionUp -> Motion.Up
+			Key.DirectionDown -> Motion.Down
+			Key.MoveHome -> if (ctrl) Motion.DocumentStart else Motion.LineStart
+			Key.MoveEnd -> if (ctrl) Motion.DocumentEnd else Motion.LineEnd
+			Key.Backspace -> if (ctrl) Action.DeleteWordBackward else Action.DeleteBackward
+			Key.Delete -> if (ctrl) Action.DeleteWordForward else Action.DeleteForward
+			else -> commonCommandFor(event)
+		}
+	}
+}
+
+/**
+ * macOS conventions: Cmd for shortcuts, Option+Arrow for word jumps, Cmd+Arrow for line and
+ * document bounds. Ctrl is deliberately unbound, since on macOS it belongs to the system and to
+ * the Emacs-style text bindings.
+ *
+ * Option is also the macOS compose modifier (Option+8 types '{'), so only the chords claimed here
+ * may consume an Option event; everything else must fall through to
+ * [TextEditorKeyCommandHandler.handleCharacterInput] to be typed as a literal character.
+ */
+internal object MacKeyBindings : KeyBindings {
+	override fun commandFor(event: KeyEvent): EditorCommand? {
+		val cmd = event.isMetaPressed
+		val option = event.isAltPressed
+		return when (event.key) {
+			Key.A -> if (cmd) Action.SelectAll else null
+			Key.C -> if (cmd) Action.Copy else null
+			Key.X -> if (cmd) Action.Cut else null
+			Key.V -> if (cmd) Action.Paste else null
+			Key.Z -> when {
+				cmd && event.isShiftPressed -> Action.Redo
+				cmd -> Action.Undo
+				else -> null
+			}
+
+			Key.DirectionLeft -> when {
+				cmd -> Motion.LineStart
+				option -> Motion.WordLeft
+				else -> Motion.Left
+			}
+
+			Key.DirectionRight -> when {
+				cmd -> Motion.LineEnd
+				option -> Motion.WordRight
+				else -> Motion.Right
+			}
+
+			Key.DirectionUp -> if (cmd) Motion.DocumentStart else Motion.Up
+			Key.DirectionDown -> if (cmd) Motion.DocumentEnd else Motion.Down
+			Key.MoveHome -> Motion.LineStart
+			Key.MoveEnd -> Motion.LineEnd
+			Key.Backspace -> when {
+				cmd -> Action.DeleteToLineStart
+				option -> Action.DeleteWordBackward
+				else -> Action.DeleteBackward
+			}
+
+			Key.Delete -> if (option) Action.DeleteWordForward else Action.DeleteForward
+			else -> commonCommandFor(event)
+		}
+	}
+}
+
+/** Chords that mean the same thing everywhere. */
+private fun commonCommandFor(event: KeyEvent): EditorCommand? = when (event.key) {
+	Key.PageUp -> Motion.PageUp
+	Key.PageDown -> Motion.PageDown
+	Key.Tab -> if (event.isShiftPressed) Action.Outdent else Action.Indent
+	Key.Enter, Key.NumPadEnter -> Action.NewLine
+	else -> null
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
@@ -53,8 +53,8 @@ internal object CtrlKeyBindings : KeyBindings {
 
 /**
  * macOS conventions: Cmd for shortcuts, Option+Arrow for word jumps, Cmd+Arrow for line and
- * document bounds. Ctrl is deliberately unbound, since on macOS it belongs to the system and to
- * the Emacs-style text bindings.
+ * document bounds. Ctrl never selects a different command than the unmodified key would, since
+ * on macOS it belongs to the system and to the Emacs-style text bindings.
  *
  * Option is also the macOS compose modifier (Option+8 types '{'), so only the chords claimed here
  * may consume an Option event; everything else must fall through to

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorInputModifierNode.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorInputModifierNode.kt
@@ -29,14 +29,15 @@ import kotlinx.coroutines.launch
 internal class TextEditorInputModifierNode(
 	var state: TextEditorState,
 	var clipboard: Clipboard,
-	var enabled: Boolean
+	var enabled: Boolean,
+	keyBindings: KeyBindings
 ) : androidx.compose.ui.Modifier.Node(),
 	KeyInputModifierNode,
 	SoftKeyboardInterceptionModifierNode,
 	FocusEventModifierNode,
 	PlatformTextInputModifierNode {
 
-	private val keyCommandHandler = TextEditorKeyCommandHandler()
+	private val keyCommandHandler = TextEditorKeyCommandHandler(keyBindings)
 	private var inputSessionJob: Job? = null
 	private var imeCursorSync: ImeCursorSync? = null
 
@@ -111,11 +112,13 @@ internal class TextEditorInputModifierNode(
 	fun update(
 		state: TextEditorState,
 		clipboard: Clipboard,
-		enabled: Boolean
+		enabled: Boolean,
+		keyBindings: KeyBindings
 	) {
 		this.state = state
 		this.clipboard = clipboard
 		this.enabled = enabled
+		keyCommandHandler.keyBindings = keyBindings
 	}
 }
 
@@ -125,15 +128,16 @@ internal class TextEditorInputModifierNode(
 internal data class TextEditorInputModifierElement(
 	val state: TextEditorState,
 	val clipboard: Clipboard,
-	val enabled: Boolean
+	val enabled: Boolean,
+	val keyBindings: KeyBindings
 ) : ModifierNodeElement<TextEditorInputModifierNode>() {
 
 	override fun create(): TextEditorInputModifierNode {
-		return TextEditorInputModifierNode(state, clipboard, enabled)
+		return TextEditorInputModifierNode(state, clipboard, enabled, keyBindings)
 	}
 
 	override fun update(node: TextEditorInputModifierNode) {
-		node.update(state, clipboard, enabled)
+		node.update(state, clipboard, enabled, keyBindings)
 	}
 
 	override fun InspectorInfo.inspectableProperties() {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
@@ -180,57 +180,37 @@ internal class TextEditorKeyCommandHandler(
 		}
 	}
 
-	private fun handleDeletePreviousWord(state: TextEditorState) {
-		if (state.selector.selection != null) {
-			state.selector.deleteSelection()
-			return
-		}
-		val wordEnd = state.cursorPosition
-		state.moveToPreviousWord()
-		val wordStart = state.cursorPosition
-		if (wordStart != wordEnd) {
-			deleteRange(state, TextEditorRange(wordStart, wordEnd), caretBefore = wordEnd)
-		}
-	}
+	private fun handleDeletePreviousWord(state: TextEditorState) =
+		deleteByMotion(state) { state.moveToPreviousWord() }
 
-	private fun handleDeleteNextWord(state: TextEditorState) {
-		if (state.selector.selection != null) {
-			state.selector.deleteSelection()
-			return
-		}
-		val wordStart = state.cursorPosition
-		state.moveToNextWord()
-		val wordEnd = state.cursorPosition
-		if (wordStart != wordEnd) {
-			deleteRange(state, TextEditorRange(wordStart, wordEnd), caretBefore = wordStart)
-		}
-	}
+	private fun handleDeleteNextWord(state: TextEditorState) =
+		deleteByMotion(state) { state.moveToNextWord() }
 
-	private fun handleDeleteToLineStart(state: TextEditorState) {
-		if (state.selector.selection != null) {
-			state.selector.deleteSelection()
-			return
-		}
-		val lineEnd = state.cursorPosition
-		state.cursor.moveToLineStart()
-		val lineStart = state.cursorPosition
-		if (lineStart != lineEnd) {
-			deleteRange(state, TextEditorRange(lineStart, lineEnd), caretBefore = lineEnd)
-		}
-	}
+	private fun handleDeleteToLineStart(state: TextEditorState) =
+		deleteByMotion(state) { state.cursor.moveToLineStart() }
 
 	/**
-	 * Deletes [range] as if the caret were at [caretBefore]. The word and line motions
-	 * that locate the range leave the caret at the far end of it, and [TextEditorState.delete]
-	 * records wherever the caret is as the position undo restores.
+	 * Deletes between the caret and wherever [locateRangeEdge] moves it, or the selection when
+	 * there is one. The caret the user had is handed to [TextEditorState.delete] explicitly:
+	 * [locateRangeEdge] has already moved it off that position, and delete otherwise records
+	 * wherever the caret currently sits as the position undo returns to.
 	 */
-	private fun deleteRange(
-		state: TextEditorState,
-		range: TextEditorRange,
-		caretBefore: CharLineOffset
-	) {
-		state.cursor.updatePosition(caretBefore)
-		state.delete(range)
+	private fun deleteByMotion(state: TextEditorState, locateRangeEdge: () -> Unit) {
+		if (state.selector.selection != null) {
+			state.selector.deleteSelection()
+			return
+		}
+		val origin = state.cursorPosition
+		locateRangeEdge()
+		val edge = state.cursorPosition
+		if (edge == origin) return
+
+		val range = if (edge < origin) {
+			TextEditorRange(edge, origin)
+		} else {
+			TextEditorRange(origin, edge)
+		}
+		state.delete(range, cursorBefore = origin)
 	}
 
 	private fun handleIndent(state: TextEditorState) {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
@@ -189,7 +189,7 @@ internal class TextEditorKeyCommandHandler(
 		state.moveToPreviousWord()
 		val wordStart = state.cursorPosition
 		if (wordStart != wordEnd) {
-			state.delete(TextEditorRange(wordStart, wordEnd))
+			deleteRange(state, TextEditorRange(wordStart, wordEnd), caretBefore = wordEnd)
 		}
 	}
 
@@ -202,7 +202,7 @@ internal class TextEditorKeyCommandHandler(
 		state.moveToNextWord()
 		val wordEnd = state.cursorPosition
 		if (wordStart != wordEnd) {
-			state.delete(TextEditorRange(wordStart, wordEnd))
+			deleteRange(state, TextEditorRange(wordStart, wordEnd), caretBefore = wordStart)
 		}
 	}
 
@@ -215,8 +215,22 @@ internal class TextEditorKeyCommandHandler(
 		state.cursor.moveToLineStart()
 		val lineStart = state.cursorPosition
 		if (lineStart != lineEnd) {
-			state.delete(TextEditorRange(lineStart, lineEnd))
+			deleteRange(state, TextEditorRange(lineStart, lineEnd), caretBefore = lineEnd)
 		}
+	}
+
+	/**
+	 * Deletes [range] as if the caret were at [caretBefore]. The word and line motions
+	 * that locate the range leave the caret at the far end of it, and [TextEditorState.delete]
+	 * records wherever the caret is as the position undo restores.
+	 */
+	private fun deleteRange(
+		state: TextEditorState,
+		range: TextEditorRange,
+		caretBefore: CharLineOffset
+	) {
+		state.cursor.updatePosition(caretBefore)
+		state.delete(range)
 	}
 
 	private fun handleIndent(state: TextEditorState) {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
@@ -1,12 +1,10 @@
 package com.darkrockstudios.texteditor.input
 
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
-import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.utf16CodePoint
 import androidx.compose.ui.platform.Clipboard
@@ -15,6 +13,8 @@ import androidx.compose.ui.text.buildAnnotatedString
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.clipboard.ClipboardHelper
+import com.darkrockstudios.texteditor.input.EditorCommand.Action
+import com.darkrockstudios.texteditor.input.EditorCommand.Motion
 import com.darkrockstudios.texteditor.input.TextEditorKeyCommandHandler.Companion.TAB_SIZE
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.moveCursorDown
@@ -32,8 +32,13 @@ import kotlinx.coroutines.launch
 /**
  * Handles keyboard commands (shortcuts and navigation) for the text editor.
  * Also handles character input for desktop platforms via KEY_TYPED events.
+ *
+ * Which chord triggers which command is [keyBindings]' business; this class only
+ * knows what the commands do.
  */
-internal class TextEditorKeyCommandHandler {
+internal class TextEditorKeyCommandHandler(
+	var keyBindings: KeyBindings,
+) {
 
 	private companion object {
 		const val TAB_SIZE = 4
@@ -53,118 +58,28 @@ internal class TextEditorKeyCommandHandler {
 	): Boolean {
 		if (keyEvent.type != KeyEventType.KeyDown) return false
 
-		return when {
-			// Selection, copy and navigation operations are always allowed
-			keyEvent.isCtrlPressed && keyEvent.key == Key.A -> {
-				state.selector.selectAll()
-				true
-			}
+		val command = keyBindings.commandFor(keyEvent) ?: return false
+		// Selection, copy and navigation stay available in a disabled editor.
+		if (command.isEdit && !enabled) return false
 
-			keyEvent.isCtrlPressed && keyEvent.key == Key.C -> {
-				handleCopy(state, clipboard, scope)
-				true
-			}
-
-			keyEvent.key == Key.DirectionLeft -> {
-				handleLeftArrow(keyEvent, state)
-				true
-			}
-
-			keyEvent.key == Key.DirectionRight -> {
-				handleRightArrow(keyEvent, state)
-				true
-			}
-
-			keyEvent.key == Key.DirectionUp -> {
-				handleUpArrow(keyEvent, state)
-				true
-			}
-
-			keyEvent.key == Key.DirectionDown -> {
-				handleDownArrow(keyEvent, state)
-				true
-			}
-
-			keyEvent.key == Key.MoveHome -> {
-				handleHome(keyEvent, state)
-				true
-			}
-
-			keyEvent.key == Key.MoveEnd -> {
-				handleEnd(keyEvent, state)
-				true
-			}
-
-			keyEvent.key == Key.PageUp -> {
-				handlePageUp(keyEvent, state)
-				true
-			}
-
-			keyEvent.key == Key.PageDown -> {
-				handlePageDown(keyEvent, state)
-				true
-			}
-
-			// Editing operations require enabled=true
-			!enabled -> false
-
-			keyEvent.isCtrlPressed && keyEvent.key == Key.X -> {
-				handleCut(state, clipboard, scope)
-				true
-			}
-
-			keyEvent.isCtrlPressed && keyEvent.key == Key.V -> {
-				handlePaste(state, clipboard, scope)
-				true
-			}
-
-			keyEvent.isCtrlPressed && keyEvent.isShiftPressed && keyEvent.key == Key.Z -> {
-				state.redo()
-				true
-			}
-
-			keyEvent.isCtrlPressed && keyEvent.key == Key.Z -> {
-				state.undo()
-				true
-			}
-
-			keyEvent.isCtrlPressed && keyEvent.key == Key.Y -> {
-				state.redo()
-				true
-			}
-
-			keyEvent.isCtrlPressed && keyEvent.key == Key.Delete -> {
-				handleDeleteNextWord(state)
-				true
-			}
-
-			keyEvent.key == Key.Delete -> {
-				handleDelete(state)
-				true
-			}
-
-			keyEvent.isCtrlPressed && keyEvent.key == Key.Backspace -> {
-				handleDeletePreviousWord(state)
-				true
-			}
-
-			keyEvent.key == Key.Backspace -> {
-				handleBackspace(state)
-				true
-			}
-
-			keyEvent.key == Key.Tab -> {
-				handleTab(keyEvent, state)
-				true
-			}
-
-			keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter -> {
-				handleEnter(state)
-				true
-			}
-
-			else -> false
+		when (command) {
+			is Motion -> moveCursor(command, state, extendSelection = keyEvent.isShiftPressed)
+			Action.SelectAll -> state.selector.selectAll()
+			Action.Copy -> handleCopy(state, clipboard, scope)
+			Action.Cut -> handleCut(state, clipboard, scope)
+			Action.Paste -> handlePaste(state, clipboard, scope)
+			Action.Undo -> state.undo()
+			Action.Redo -> state.redo()
+			Action.DeleteBackward -> handleBackspace(state)
+			Action.DeleteForward -> handleDelete(state)
+			Action.DeleteWordBackward -> handleDeletePreviousWord(state)
+			Action.DeleteWordForward -> handleDeleteNextWord(state)
+			Action.DeleteToLineStart -> handleDeleteToLineStart(state)
+			Action.Indent -> handleIndent(state)
+			Action.Outdent -> handleOutdent(state)
+			Action.NewLine -> handleEnter(state)
 		}
+		return true
 	}
 
 	/**
@@ -291,11 +206,16 @@ internal class TextEditorKeyCommandHandler {
 		}
 	}
 
-	private fun handleTab(keyEvent: KeyEvent, state: TextEditorState) {
-		if (keyEvent.isShiftPressed) {
-			handleOutdent(state)
-		} else {
-			handleIndent(state)
+	private fun handleDeleteToLineStart(state: TextEditorState) {
+		if (state.selector.selection != null) {
+			state.selector.deleteSelection()
+			return
+		}
+		val lineEnd = state.cursorPosition
+		state.cursor.moveToLineStart()
+		val lineStart = state.cursorPosition
+		if (lineStart != lineEnd) {
+			state.delete(TextEditorRange(lineStart, lineEnd))
 		}
 	}
 
@@ -390,123 +310,28 @@ internal class TextEditorKeyCommandHandler {
 		state.insertNewlineAtCursor()
 	}
 
-	private fun handleLeftArrow(keyEvent: KeyEvent, state: TextEditorState) {
-		if (keyEvent.isShiftPressed) {
-			val initialPosition = state.cursorPosition
-			if (keyEvent.isCtrlPressed)
-				state.moveToPreviousWord()
-			else
-				state.cursor.moveLeft()
-			updateSelectionForCursorMovement(state, initialPosition)
-		} else {
-			state.selector.clearSelection()
-			if (keyEvent.isCtrlPressed)
-				state.moveToPreviousWord()
-			else
-				state.cursor.moveLeft()
-		}
-	}
+	private fun moveCursor(motion: Motion, state: TextEditorState, extendSelection: Boolean) {
+		val initialPosition = state.cursorPosition
+		if (!extendSelection) state.selector.clearSelection()
 
-	private fun handleRightArrow(keyEvent: KeyEvent, state: TextEditorState) {
-		if (keyEvent.isShiftPressed) {
-			val initialPosition = state.cursorPosition
-			if (keyEvent.isCtrlPressed)
-				state.moveToNextWord()
-			else
-				state.cursor.moveRight()
-			updateSelectionForCursorMovement(state, initialPosition)
-		} else {
-			state.selector.clearSelection()
-			if (keyEvent.isCtrlPressed)
-				state.moveToNextWord()
-			else
-				state.cursor.moveRight()
+		when (motion) {
+			Motion.Left -> state.cursor.moveLeft()
+			Motion.Right -> state.cursor.moveRight()
+			Motion.Up -> state.moveCursorUp()
+			Motion.Down -> state.moveCursorDown()
+			Motion.WordLeft -> state.moveToPreviousWord()
+			Motion.WordRight -> state.moveToNextWord()
+			Motion.LineStart -> state.cursor.moveToLineStart()
+			Motion.LineEnd -> state.moveCursorToLineEnd()
+			Motion.DocumentStart -> state.moveToDocumentStart()
+			Motion.DocumentEnd -> state.moveToDocumentEnd()
+			Motion.PageUp -> state.moveCursorPageUp()
+			Motion.PageDown -> state.moveCursorPageDown()
 		}
-	}
 
-	private fun handleUpArrow(keyEvent: KeyEvent, state: TextEditorState) {
-		if (keyEvent.isShiftPressed) {
-			val initialPosition = state.cursorPosition
-			state.moveCursorUp()
-			updateSelectionForCursorMovement(state, initialPosition)
-		} else {
-			state.selector.clearSelection()
-			state.moveCursorUp()
+		if (extendSelection) {
+			state.selector.extendSelection(initialPosition, state.cursorPosition)
 		}
-	}
-
-	private fun handleDownArrow(keyEvent: KeyEvent, state: TextEditorState) {
-		if (keyEvent.isShiftPressed) {
-			val initialPosition = state.cursorPosition
-			state.moveCursorDown()
-			updateSelectionForCursorMovement(state, initialPosition)
-		} else {
-			state.selector.clearSelection()
-			state.moveCursorDown()
-		}
-	}
-
-	private fun handleHome(keyEvent: KeyEvent, state: TextEditorState) {
-		if (keyEvent.isShiftPressed) {
-			val initialPosition = state.cursorPosition
-			if (keyEvent.isCtrlPressed)
-				state.moveToDocumentStart()
-			else
-				state.cursor.moveToLineStart()
-			updateSelectionForCursorMovement(state, initialPosition)
-		} else {
-			state.selector.clearSelection()
-			if (keyEvent.isCtrlPressed)
-				state.moveToDocumentStart()
-			else
-				state.cursor.moveToLineStart()
-		}
-	}
-
-	private fun handleEnd(keyEvent: KeyEvent, state: TextEditorState) {
-		if (keyEvent.isShiftPressed) {
-			val initialPosition = state.cursorPosition
-			if (keyEvent.isCtrlPressed)
-				state.moveToDocumentEnd()
-			else
-				state.moveCursorToLineEnd()
-			updateSelectionForCursorMovement(state, initialPosition)
-		} else {
-			state.selector.clearSelection()
-			if (keyEvent.isCtrlPressed)
-				state.moveToDocumentEnd()
-			else
-				state.moveCursorToLineEnd()
-		}
-	}
-
-	private fun handlePageUp(keyEvent: KeyEvent, state: TextEditorState) {
-		if (keyEvent.isShiftPressed) {
-			val initialPosition = state.cursorPosition
-			state.moveCursorPageUp()
-			updateSelectionForCursorMovement(state, initialPosition)
-		} else {
-			state.selector.clearSelection()
-			state.moveCursorPageUp()
-		}
-	}
-
-	private fun handlePageDown(keyEvent: KeyEvent, state: TextEditorState) {
-		if (keyEvent.isShiftPressed) {
-			val initialPosition = state.cursorPosition
-			state.moveCursorPageDown()
-			updateSelectionForCursorMovement(state, initialPosition)
-		} else {
-			state.selector.clearSelection()
-			state.moveCursorPageDown()
-		}
-	}
-
-	private fun updateSelectionForCursorMovement(
-		state: TextEditorState,
-		initialPosition: CharLineOffset
-	) {
-		state.selector.extendSelection(initialPosition, state.cursorPosition)
 	}
 
 	/**

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -480,10 +480,17 @@ class TextEditorState(
 	}
 
 	/** Deletes the text covered by [range], leaving the cursor at the range start. */
-	fun delete(range: TextEditorRange) {
+	fun delete(range: TextEditorRange) = delete(range, cursorBefore = cursorPosition)
+
+	/**
+	 * Deletes the text covered by [range], recording [cursorBefore] as the position undo
+	 * returns to. Callers that located [range] by running a cursor motion have already moved
+	 * the caret off the position the user actually had, and pass it explicitly.
+	 */
+	internal fun delete(range: TextEditorRange, cursorBefore: CharLineOffset) {
 		val operation = TextEditOperation.Delete(
 			range = range,
-			cursorBefore = cursorPosition,
+			cursorBefore = cursorBefore,
 			cursorAfter = range.start
 		)
 		editManager.applyOperation(operation)

--- a/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.desktop.kt
+++ b/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.desktop.kt
@@ -1,7 +1,12 @@
 package com.darkrockstudios.texteditor.input
 
-private val isMacOs: Boolean =
-	System.getProperty("os.name").orEmpty().startsWith("Mac", ignoreCase = true)
+/** Split out from [platformKeyBindings] so the host detection itself is testable. */
+internal fun keyBindingsForOs(osName: String): KeyBindings =
+	if (osName.startsWith("Mac", ignoreCase = true) || osName.startsWith("Darwin", ignoreCase = true)) {
+		MacKeyBindings
+	} else {
+		CtrlKeyBindings
+	}
 
 internal actual fun platformKeyBindings(): KeyBindings =
-	if (isMacOs) MacKeyBindings else CtrlKeyBindings
+	keyBindingsForOs(System.getProperty("os.name").orEmpty())

--- a/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.desktop.kt
+++ b/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.desktop.kt
@@ -1,0 +1,7 @@
+package com.darkrockstudios.texteditor.input
+
+private val isMacOs: Boolean =
+	System.getProperty("os.name").orEmpty().startsWith("Mac", ignoreCase = true)
+
+internal actual fun platformKeyBindings(): KeyBindings =
+	if (isMacOs) MacKeyBindings else CtrlKeyBindings

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/MacShortcutsE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/MacShortcutsE2eTest.kt
@@ -143,6 +143,34 @@ class MacShortcutsE2eTest {
 	}
 
 	@Test
+	fun `undo after cmd+backspace returns the caret to where the user had it`() = editorUiTest(
+		initialText = AnnotatedString("first\nsecond line"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(13)
+		press(Key.Backspace, meta = true)
+		assertEquals(listOf("first", "line"), lines)
+
+		press(Key.Z, meta = true)
+		assertEquals(listOf("first", "second line"), lines)
+		assertEquals(13, cursorIndex)
+	}
+
+	@Test
+	fun `undo after option+backspace returns the caret to where the user had it`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(10)
+		press(Key.Backspace, alt = true)
+		assertEquals("The brown fox", text)
+
+		press(Key.Z, meta = true)
+		assertEquals("The quick brown fox", text)
+		assertEquals(10, cursorIndex)
+	}
+
+	@Test
 	fun `option+delete deletes the next word`() = editorUiTest(
 		initialText = AnnotatedString("The quick brown fox"),
 		keyBindings = MacKeyBindings,

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/MacShortcutsE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/MacShortcutsE2eTest.kt
@@ -1,0 +1,178 @@
+package e2e
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.input.MacKeyBindings
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The macOS binding set driven through a real editor: Cmd for shortcuts, Option
+ * for word-wise motion, Cmd+Arrow for line and document bounds.
+ */
+class MacShortcutsE2eTest {
+
+	@Test
+	fun `cmd+c then cmd+v copies and pastes`() = editorUiTest(
+		initialText = AnnotatedString("Hello World"),
+		keyBindings = MacKeyBindings,
+	) {
+		dragSelect(fromChar = 0, toChar = 5)
+		press(Key.C, meta = true)
+
+		press(Key.DirectionRight, meta = true)
+		press(Key.V, meta = true)
+
+		assertEquals("Hello WorldHello", text)
+	}
+
+	@Test
+	fun `cmd+x cuts the selection`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+		keyBindings = MacKeyBindings,
+	) {
+		dragSelect(fromChar = 4, toChar = 10)
+		press(Key.X, meta = true)
+
+		assertEquals("The brown fox", text)
+	}
+
+	@Test
+	fun `cmd+a selects the whole document`() = editorUiTest(
+		initialText = AnnotatedString("first\nsecond"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(2)
+		press(Key.A, meta = true)
+
+		assertEquals("first\nsecond", selectedText)
+	}
+
+	@Test
+	fun `cmd+z undoes and cmd+shift+z redoes`() = editorUiTest(
+		initialText = AnnotatedString("HelloWorld"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(5)
+		press(Key.Enter)
+		assertEquals(listOf("Hello", "World"), lines)
+
+		press(Key.Z, meta = true)
+		assertEquals("HelloWorld", text)
+
+		press(Key.Z, meta = true, shift = true)
+		assertEquals(listOf("Hello", "World"), lines)
+	}
+
+	@Test
+	fun `option+arrow moves by word`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(0)
+		press(Key.DirectionRight, alt = true)
+		assertEquals(4, cursorIndex, "first jump lands on 'quick'")
+
+		press(Key.DirectionRight, alt = true)
+		assertEquals(10, cursorIndex, "second jump lands on 'brown'")
+
+		press(Key.DirectionLeft, alt = true)
+		assertEquals(4, cursorIndex)
+	}
+
+	@Test
+	fun `shift+option+arrow extends the selection by word`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(0)
+		press(Key.DirectionRight, alt = true, shift = true)
+
+		assertEquals("The ", selectedText)
+	}
+
+	@Test
+	fun `cmd+arrow moves to the line bounds`() = editorUiTest(
+		initialText = AnnotatedString("first\nsecond\nthird"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(9)
+		press(Key.DirectionLeft, meta = true)
+		assertEquals(CharLineOffset(1, 0), state.cursorPosition)
+
+		press(Key.DirectionRight, meta = true)
+		assertEquals(CharLineOffset(1, 6), state.cursorPosition)
+	}
+
+	@Test
+	fun `cmd+up and cmd+down move to the document bounds`() = editorUiTest(
+		initialText = AnnotatedString("first\nsecond\nthird"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(9)
+		press(Key.DirectionUp, meta = true)
+		assertEquals(CharLineOffset(0, 0), state.cursorPosition)
+
+		press(Key.DirectionDown, meta = true)
+		assertEquals(CharLineOffset(2, 5), state.cursorPosition)
+	}
+
+	@Test
+	fun `option+backspace deletes the previous word`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(10)
+		press(Key.Backspace, alt = true)
+
+		assertEquals("The brown fox", text)
+	}
+
+	@Test
+	fun `cmd+backspace deletes to the line start`() = editorUiTest(
+		initialText = AnnotatedString("first\nsecond line"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(13)
+		press(Key.Backspace, meta = true)
+
+		assertEquals(listOf("first", "line"), lines)
+	}
+
+	@Test
+	fun `option+delete deletes the next word`() = editorUiTest(
+		initialText = AnnotatedString("The quick brown fox"),
+		keyBindings = MacKeyBindings,
+	) {
+		clickAtCharacter(4)
+		press(Key.Delete, alt = true)
+
+		assertEquals("The brown fox", text)
+	}
+
+	@Test
+	fun `ctrl shortcuts are not claimed on macos`() = editorUiTest(
+		initialText = AnnotatedString("Hello World"),
+		keyBindings = MacKeyBindings,
+	) {
+		dragSelect(fromChar = 0, toChar = 5)
+		press(Key.C, ctrl = true)
+
+		assertTrue(clipboard.isEmpty, "Ctrl+C must not copy on macOS")
+		assertEquals("Hello", selectedText, "Ctrl+C must leave the document and selection alone")
+	}
+
+	@Test
+	fun `option composes a literal character instead of navigating`() = editorUiTest(
+		initialText = AnnotatedString("ab"),
+		keyBindings = MacKeyBindings,
+	) {
+		press(Key.DirectionRight, meta = true)
+		typeWithOption(Key.Eight, '{')
+
+		assertEquals("ab{", text)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/KeyBindingsTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/KeyBindingsTest.kt
@@ -1,0 +1,216 @@
+package input
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import com.darkrockstudios.texteditor.input.CtrlKeyBindings
+import com.darkrockstudios.texteditor.input.EditorCommand
+import com.darkrockstudios.texteditor.input.EditorCommand.Action
+import com.darkrockstudios.texteditor.input.EditorCommand.Motion
+import com.darkrockstudios.texteditor.input.MacKeyBindings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(InternalComposeUiApi::class)
+private fun chord(
+	key: Key,
+	ctrl: Boolean = false,
+	meta: Boolean = false,
+	alt: Boolean = false,
+	shift: Boolean = false,
+) = KeyEvent(
+	key = key,
+	type = KeyEventType.KeyDown,
+	isCtrlPressed = ctrl,
+	isMetaPressed = meta,
+	isAltPressed = alt,
+	isShiftPressed = shift,
+)
+
+/** The chord tables themselves: which key combination means what on each platform. */
+class KeyBindingsTest {
+
+	@Test
+	fun `windows and linux clipboard shortcuts use ctrl`() {
+		assertEquals(Action.SelectAll, CtrlKeyBindings.commandFor(chord(Key.A, ctrl = true)))
+		assertEquals(Action.Copy, CtrlKeyBindings.commandFor(chord(Key.C, ctrl = true)))
+		assertEquals(Action.Cut, CtrlKeyBindings.commandFor(chord(Key.X, ctrl = true)))
+		assertEquals(Action.Paste, CtrlKeyBindings.commandFor(chord(Key.V, ctrl = true)))
+	}
+
+	@Test
+	fun `windows and linux undo and redo`() {
+		assertEquals(Action.Undo, CtrlKeyBindings.commandFor(chord(Key.Z, ctrl = true)))
+		assertEquals(
+			Action.Redo,
+			CtrlKeyBindings.commandFor(chord(Key.Z, ctrl = true, shift = true)),
+		)
+		assertEquals(Action.Redo, CtrlKeyBindings.commandFor(chord(Key.Y, ctrl = true)))
+	}
+
+	@Test
+	fun `windows and linux navigation`() {
+		assertEquals(Motion.Left, CtrlKeyBindings.commandFor(chord(Key.DirectionLeft)))
+		assertEquals(
+			Motion.WordLeft,
+			CtrlKeyBindings.commandFor(chord(Key.DirectionLeft, ctrl = true)),
+		)
+		assertEquals(
+			Motion.WordRight,
+			CtrlKeyBindings.commandFor(chord(Key.DirectionRight, ctrl = true)),
+		)
+		assertEquals(Motion.LineStart, CtrlKeyBindings.commandFor(chord(Key.MoveHome)))
+		assertEquals(Motion.LineEnd, CtrlKeyBindings.commandFor(chord(Key.MoveEnd)))
+		assertEquals(
+			Motion.DocumentStart,
+			CtrlKeyBindings.commandFor(chord(Key.MoveHome, ctrl = true)),
+		)
+		assertEquals(
+			Motion.DocumentEnd,
+			CtrlKeyBindings.commandFor(chord(Key.MoveEnd, ctrl = true)),
+		)
+	}
+
+	@Test
+	fun `windows and linux word deletion uses ctrl`() {
+		assertEquals(Action.DeleteBackward, CtrlKeyBindings.commandFor(chord(Key.Backspace)))
+		assertEquals(
+			Action.DeleteWordBackward,
+			CtrlKeyBindings.commandFor(chord(Key.Backspace, ctrl = true)),
+		)
+		assertEquals(Action.DeleteForward, CtrlKeyBindings.commandFor(chord(Key.Delete)))
+		assertEquals(
+			Action.DeleteWordForward,
+			CtrlKeyBindings.commandFor(chord(Key.Delete, ctrl = true)),
+		)
+	}
+
+	@Test
+	fun `windows and linux leave cmd unbound`() {
+		assertNull(CtrlKeyBindings.commandFor(chord(Key.C, meta = true)))
+		assertNull(CtrlKeyBindings.commandFor(chord(Key.V, meta = true)))
+		assertNull(CtrlKeyBindings.commandFor(chord(Key.Z, meta = true)))
+	}
+
+	@Test
+	fun `windows and linux leave option arrows as plain movement`() {
+		assertEquals(Motion.Left, CtrlKeyBindings.commandFor(chord(Key.DirectionLeft, alt = true)))
+		assertEquals(
+			Action.DeleteBackward,
+			CtrlKeyBindings.commandFor(chord(Key.Backspace, alt = true)),
+		)
+	}
+
+	@Test
+	fun `macos clipboard shortcuts use cmd`() {
+		assertEquals(Action.SelectAll, MacKeyBindings.commandFor(chord(Key.A, meta = true)))
+		assertEquals(Action.Copy, MacKeyBindings.commandFor(chord(Key.C, meta = true)))
+		assertEquals(Action.Cut, MacKeyBindings.commandFor(chord(Key.X, meta = true)))
+		assertEquals(Action.Paste, MacKeyBindings.commandFor(chord(Key.V, meta = true)))
+	}
+
+	@Test
+	fun `macos undo and redo`() {
+		assertEquals(Action.Undo, MacKeyBindings.commandFor(chord(Key.Z, meta = true)))
+		assertEquals(
+			Action.Redo,
+			MacKeyBindings.commandFor(chord(Key.Z, meta = true, shift = true)),
+		)
+	}
+
+	@Test
+	fun `macos moves by word with option and to bounds with cmd`() {
+		assertEquals(
+			Motion.WordLeft,
+			MacKeyBindings.commandFor(chord(Key.DirectionLeft, alt = true)),
+		)
+		assertEquals(
+			Motion.WordRight,
+			MacKeyBindings.commandFor(chord(Key.DirectionRight, alt = true)),
+		)
+		assertEquals(
+			Motion.LineStart,
+			MacKeyBindings.commandFor(chord(Key.DirectionLeft, meta = true)),
+		)
+		assertEquals(
+			Motion.LineEnd,
+			MacKeyBindings.commandFor(chord(Key.DirectionRight, meta = true)),
+		)
+		assertEquals(
+			Motion.DocumentStart,
+			MacKeyBindings.commandFor(chord(Key.DirectionUp, meta = true)),
+		)
+		assertEquals(
+			Motion.DocumentEnd,
+			MacKeyBindings.commandFor(chord(Key.DirectionDown, meta = true)),
+		)
+	}
+
+	@Test
+	fun `macos deletion uses option for words and cmd for the line start`() {
+		assertEquals(Action.DeleteBackward, MacKeyBindings.commandFor(chord(Key.Backspace)))
+		assertEquals(
+			Action.DeleteWordBackward,
+			MacKeyBindings.commandFor(chord(Key.Backspace, alt = true)),
+		)
+		assertEquals(
+			Action.DeleteToLineStart,
+			MacKeyBindings.commandFor(chord(Key.Backspace, meta = true)),
+		)
+		assertEquals(
+			Action.DeleteWordForward,
+			MacKeyBindings.commandFor(chord(Key.Delete, alt = true)),
+		)
+	}
+
+	@Test
+	fun `macos leaves ctrl to the system`() {
+		assertNull(MacKeyBindings.commandFor(chord(Key.A, ctrl = true)))
+		assertNull(MacKeyBindings.commandFor(chord(Key.C, ctrl = true)))
+		assertNull(MacKeyBindings.commandFor(chord(Key.X, ctrl = true)))
+		assertNull(MacKeyBindings.commandFor(chord(Key.V, ctrl = true)))
+		assertNull(MacKeyBindings.commandFor(chord(Key.Z, ctrl = true)))
+		assertNull(MacKeyBindings.commandFor(chord(Key.Y, ctrl = true)))
+	}
+
+	@Test
+	fun `macos leaves ctrl arrows and deletion as their unmodified form`() {
+		assertEquals(Motion.Left, MacKeyBindings.commandFor(chord(Key.DirectionLeft, ctrl = true)))
+		assertEquals(
+			Action.DeleteBackward,
+			MacKeyBindings.commandFor(chord(Key.Backspace, ctrl = true)),
+		)
+	}
+
+	@Test
+	fun `option chords that are not navigation stay unbound so they can compose characters`() {
+		assertNull(MacKeyBindings.commandFor(chord(Key.Eight, alt = true)))
+		assertNull(MacKeyBindings.commandFor(chord(Key.N, alt = true)))
+		assertNull(MacKeyBindings.commandFor(chord(Key.E, alt = true)))
+	}
+
+	@Test
+	fun `unmodified editing keys mean the same thing on both platforms`() {
+		for (bindings in listOf(CtrlKeyBindings, MacKeyBindings)) {
+			assertEquals(Action.NewLine, bindings.commandFor(chord(Key.Enter)))
+			assertEquals(Action.Indent, bindings.commandFor(chord(Key.Tab)))
+			assertEquals(Action.Outdent, bindings.commandFor(chord(Key.Tab, shift = true)))
+			assertEquals(Motion.PageUp, bindings.commandFor(chord(Key.PageUp)))
+			assertEquals(Motion.PageDown, bindings.commandFor(chord(Key.PageDown)))
+			assertNull(bindings.commandFor(chord(Key.F)))
+		}
+	}
+
+	@Test
+	fun `only document changing commands are edits`() {
+		val readOnly = listOf<EditorCommand>(Action.SelectAll, Action.Copy) + Motion.entries
+		for (command in readOnly) {
+			assertEquals(false, command.isEdit, "$command must be allowed in a disabled editor")
+		}
+		for (command in Action.entries - Action.SelectAll - Action.Copy) {
+			assertEquals(true, command.isEdit, "$command changes the document")
+		}
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/PlatformKeyBindingsTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/PlatformKeyBindingsTest.kt
@@ -1,0 +1,35 @@
+package input
+
+import com.darkrockstudios.texteditor.input.CtrlKeyBindings
+import com.darkrockstudios.texteditor.input.MacKeyBindings
+import com.darkrockstudios.texteditor.input.keyBindingsForOs
+import com.darkrockstudios.texteditor.input.platformKeyBindings
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+/**
+ * The host detection that decides which chord table ships. The UI harness pins its own
+ * bindings, so without this nothing exercises the choice real users get.
+ */
+class PlatformKeyBindingsTest {
+
+	@Test
+	fun `macos host names select the mac bindings`() {
+		for (osName in listOf("Mac OS X", "macOS", "Darwin")) {
+			assertSame(MacKeyBindings, keyBindingsForOs(osName), "os.name '$osName'")
+		}
+	}
+
+	@Test
+	fun `other host names select the ctrl bindings`() {
+		for (osName in listOf("Windows 11", "Windows 10", "Linux", "FreeBSD", "")) {
+			assertSame(CtrlKeyBindings, keyBindingsForOs(osName), "os.name '$osName'")
+		}
+	}
+
+	@Test
+	fun `the host actual resolves to one of the two tables`() {
+		val bindings = platformKeyBindings()
+		assertSame(keyBindingsForOs(System.getProperty("os.name").orEmpty()), bindings)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/PlatformKeyBindingsTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/PlatformKeyBindingsTest.kt
@@ -6,6 +6,7 @@ import com.darkrockstudios.texteditor.input.keyBindingsForOs
 import com.darkrockstudios.texteditor.input.platformKeyBindings
 import kotlin.test.Test
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 /**
  * The host detection that decides which chord table ships. The UI harness pins its own
@@ -28,8 +29,11 @@ class PlatformKeyBindingsTest {
 	}
 
 	@Test
-	fun `the host actual resolves to one of the two tables`() {
+	fun `the host actual returns one of the known tables`() {
 		val bindings = platformKeyBindings()
-		assertSame(keyBindingsForOs(System.getProperty("os.name").orEmpty()), bindings)
+		assertTrue(
+			bindings === CtrlKeyBindings || bindings === MacKeyBindings,
+			"platformKeyBindings() returned an unknown table: $bindings",
+		)
 	}
 }

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
@@ -21,6 +21,10 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.texteditor.BasicTextEditor
 import com.darkrockstudios.texteditor.RichSpanClickListener
+import com.darkrockstudios.texteditor.input.CtrlKeyBindings
+import com.darkrockstudios.texteditor.input.KeyBindings
+import com.darkrockstudios.texteditor.input.LocalKeyBindings
+import com.darkrockstudios.texteditor.input.MacKeyBindings
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.rememberTextEditorState
 
@@ -31,13 +35,18 @@ import com.darkrockstudios.texteditor.state.rememberTextEditorState
  * [dragSelect]) resolve pixel positions through the editor's own layout, so
  * tests never hard-code coordinates. Clipboard operations go through an
  * isolated [InMemoryClipboard], never the OS clipboard.
+ *
+ * [keyBindings] is pinned rather than taken from the host, so the same shortcuts
+ * are exercised no matter which OS runs the suite; pass [MacKeyBindings] to test
+ * the macOS chords.
  */
 @OptIn(ExperimentalTestApi::class)
-fun editorUiTest(
+internal fun editorUiTest(
 	initialText: AnnotatedString = AnnotatedString(""),
 	width: Dp = 400.dp,
 	height: Dp = 300.dp,
 	enabled: Boolean = true,
+	keyBindings: KeyBindings = CtrlKeyBindings,
 	onRichSpanClick: RichSpanClickListener? = null,
 	block: EditorUiTestScope.() -> Unit,
 ) = runSkikoComposeUiTest {
@@ -45,7 +54,10 @@ fun editorUiTest(
 	lateinit var state: TextEditorState
 	setContent {
 		state = rememberTextEditorState(initialText = initialText)
-		CompositionLocalProvider(LocalClipboard provides clipboard) {
+		CompositionLocalProvider(
+			LocalClipboard provides clipboard,
+			LocalKeyBindings provides keyBindings,
+		) {
 			BasicTextEditor(
 				state = state,
 				modifier = Modifier.size(width, height),
@@ -80,13 +92,24 @@ class EditorUiTestScope(
 	/** Types printable characters through real desktop key events; `\n` and `\t` become Enter/Tab. */
 	fun typeText(text: String) = test.typeText(text)
 
+	/** Types [char] as a macOS Option chord over [key], the way Option+8 composes '{'. */
+	fun typeWithOption(key: Key, char: Char) = test.typeWithOption(key, char)
+
 	/** Presses [key] with optional modifiers held, e.g. `press(Key.Z, ctrl = true)`. */
-	fun press(key: Key, ctrl: Boolean = false, shift: Boolean = false, alt: Boolean = false) {
+	fun press(
+		key: Key,
+		ctrl: Boolean = false,
+		shift: Boolean = false,
+		alt: Boolean = false,
+		meta: Boolean = false,
+	) {
 		test.onRoot().performKeyInput {
 			if (ctrl) keyDown(Key.CtrlLeft)
 			if (shift) keyDown(Key.ShiftLeft)
 			if (alt) keyDown(Key.AltLeft)
+			if (meta) keyDown(Key.MetaLeft)
 			pressKey(key)
+			if (meta) keyUp(Key.MetaLeft)
 			if (alt) keyUp(Key.AltLeft)
 			if (shift) keyUp(Key.ShiftLeft)
 			if (ctrl) keyUp(Key.CtrlLeft)

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/UiTestTyping.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/UiTestTyping.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performKeyInput
 
 /**
  * Types [text] into the focused editor by replaying the event sequence a real
@@ -39,5 +41,25 @@ fun SkikoComposeUiTest.typeText(text: String) {
 			)
 		}
 	}
+	waitForIdle()
+}
+
+/**
+ * Types [char] the way a macOS Option chord composes one: Option is held down over
+ * a [key] whose KEY_TYPED event carries the composed character (Option+8 types '{').
+ * The scene fills in the held modifiers on events that don't specify any, so the
+ * KeyDown the editor sees is a real Option chord.
+ */
+@OptIn(ExperimentalTestApi::class, InternalComposeUiApi::class)
+fun SkikoComposeUiTest.typeWithOption(key: Key, char: Char) {
+	onRoot().performKeyInput { keyDown(Key.AltLeft) }
+	runOnUiThread {
+		scene.sendKeyEvent(KeyEvent(key = key, type = KeyEventType.KeyDown, codePoint = char.code))
+		scene.sendKeyEvent(
+			KeyEvent(key = Key.Unknown, type = KeyEventType.Unknown, codePoint = char.code)
+		)
+		scene.sendKeyEvent(KeyEvent(key = key, type = KeyEventType.KeyUp, codePoint = char.code))
+	}
+	onRoot().performKeyInput { keyUp(Key.AltLeft) }
 	waitForIdle()
 }

--- a/ComposeTextEditor/src/iosMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.ios.kt
+++ b/ComposeTextEditor/src/iosMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.ios.kt
@@ -1,0 +1,4 @@
+package com.darkrockstudios.texteditor.input
+
+/** Hardware keyboards on iPadOS follow the macOS conventions. */
+internal actual fun platformKeyBindings(): KeyBindings = MacKeyBindings

--- a/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.wasmJs.kt
+++ b/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.wasmJs.kt
@@ -1,8 +1,12 @@
 package com.darkrockstudios.texteditor.input
 
-/** Browsers on macOS deliver Cmd as the meta modifier, so the page follows the macOS conventions. */
+/**
+ * Browsers on macOS deliver Cmd as the meta modifier, so the page follows the macOS conventions.
+ * `navigator.platform` is deprecated and frozen or reduced by some browsers, so the userAgent is
+ * searched as well rather than only as a fallback for an empty platform.
+ */
 private fun isMacHost(): Boolean =
-	js("/Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent || '')")
+	js("/Mac|iPhone|iPad|iPod/.test((navigator.platform || '') + ' ' + (navigator.userAgent || ''))")
 
 internal actual fun platformKeyBindings(): KeyBindings =
 	if (isMacHost()) MacKeyBindings else CtrlKeyBindings

--- a/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.wasmJs.kt
+++ b/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.wasmJs.kt
@@ -1,0 +1,8 @@
+package com.darkrockstudios.texteditor.input
+
+/** Browsers on macOS deliver Cmd as the meta modifier, so the page follows the macOS conventions. */
+private fun isMacHost(): Boolean =
+	js("/Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent || '')")
+
+internal actual fun platformKeyBindings(): KeyBindings =
+	if (isMacHost()) MacKeyBindings else CtrlKeyBindings


### PR DESCRIPTION
Fixes #40

Editor shortcuts were gated on `isCtrlPressed` everywhere, so on macOS Cmd+C / Cmd+V / Cmd+A / Cmd+Z did nothing, while Ctrl chords (which no other Mac app uses) worked.

Rather than sprinkling `|| isMetaPressed` through the `when`, chords now resolve through a binding layer.

### `EditorCommand`

The vocabulary the handler dispatches on: `Motion` (Left / WordLeft / LineStart / DocumentEnd / ...) and `Action` (Copy / Paste / Undo / DeleteWordBackward / ...). Each carries `isEdit`, so the disabled-editor gate is a single check rather than a positional `!enabled -> false` in the middle of the chain.

### `KeyBindings`

`CtrlKeyBindings` keeps the existing Windows/Linux chords. `MacKeyBindings`:

| Action | macOS |
| --- | --- |
| Select all / copy / cut / paste / undo | Cmd+A/C/X/V/Z |
| Redo | Cmd+Shift+Z (Cmd+Y unbound) |
| Word left/right | Option+Arrow |
| Line start/end | Cmd+Left / Cmd+Right |
| Document start/end | Cmd+Up / Cmd+Down |
| Delete word back/forward | Option+Backspace / Option+Delete |
| Delete to line start | Cmd+Backspace |

Ctrl is left entirely to the system on macOS. Only the chords above claim Option, so `Option+8` stays unbound and falls through to the character-input path to compose `{`.

Selected per platform via `expect`/`actual` (desktop reads `os.name`; iOS gets the Mac set for iPad hardware keyboards; wasm sniffs `navigator`), delivered through an internal `LocalKeyBindings` CompositionLocal.

### Handler cleanup

`TextEditorKeyCommandHandler` loses ~250 lines: the seven near-identical `handleLeftArrow` / `handleHome` / `handlePageUp` / ... functions collapse into one `moveCursor(motion, extendSelection)`, since shift-extends-selection is uniform across every motion.

### Tests

- `KeyBindingsTest` (15) covers both chord tables directly, including the negative cases: Cmd unbound on Win/Linux, Ctrl unbound on macOS, non-navigation Option chords unbound.
- `MacShortcutsE2eTest` (13) drives a real editor with the macOS bindings, including Ctrl+C leaving the clipboard untouched and Option+8 typing a literal `{`.
- The UI test harness now pins its binding set instead of inheriting the host's, so the suite is OS-independent (the existing Ctrl-based tests would otherwise fail on a Mac dev machine).

`gradle check` passes locally: 641 desktop tests, 0 failures.

### Not verified here

The iOS and wasm actuals compile but are not exercised from a Windows host, and the macOS behavior is verified through the synthetic binding set rather than on real hardware.