### PR TITLE
Bump maven-publish plugin to 0.37.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ composeBom = "2026.06.01"
 symspellkt = "3.4.0"
 spellcheckerkt = "1.3.1"
 
-maven-publish = "0.36.0"
+maven-publish = "0.37.0"
 dokka = "2.2.0"
 
 [libraries]


### PR DESCRIPTION
Bumps `com.vanniktech.maven.publish` from 0.36.0 to 0.37.0.

## What's in 0.37.0

- **Redundant checksums excluded by default** when publishing to Maven Central: checksums of `.asc` signature files, plus the `sha256`/`sha512` checksums, which are never read by Gradle or Maven Central. Published checksums default to `md5,sha1` and are configurable via `checksums(...)` in the DSL or the `mavenCentralChecksums` property; signature-checksum exclusion via `excludeSignatureChecksums()` / `mavenCentralExcludeSignatureChecksums`.
- **Maven Central deployment id is logged after upload**, which makes tracing a release on central.sonatype.com easier.

No breaking changes and no API migration. Minimum supported versions are unchanged from 0.36.0 (JDK 17, Gradle 9.0.0, AGP 8.13.0, KGP 2.2.0), all of which this repo already exceeds: Gradle 9.5.1, AGP 9.1.1, Kotlin 2.4.10, Dokka 2.2.0.

## Verification

- `:ComposeTextEditor:publishToMavenLocal --dry-run` succeeds; the full publication task graph resolves across all KMP targets, Dokka javadoc jars, and signing tasks.
- `publishToMavenLocal --dry-run --warning-mode all` succeeds across all three published modules (`ComposeTextEditor`, `ComposeTextEditorFind`, `ComposeTextEditorSpellCheck`) with zero deprecation warnings from the plugin.
- A real publish was **not** run locally, since `signAllPublications()` needs the GPG key that only exists in CI. Signing and the actual upload path are unexercised until the next release.
- `.github/workflows/deploy.yml` needs no changes: the `ORG_GRADLE_PROJECT_mavenCentral*` / `signingInMemory*` env vars and `publishAllPublicationsToMavenCentralRepository` are all still current.

## Note for the next release

The checksum change alters the uploaded bundle's file set: no more `.asc.md5`/`.asc.sha1`, no `.sha256`/`.sha512`. This is the plugin's new default and matches what Central actually consumes, but it will look different on the first release after this merge. Setting `mavenCentralChecksums=md5,sha1,sha256,sha512` and `mavenCentralExcludeSignatureChecksums=false` in `gradle.properties` restores the old shape if that's preferred for a release.
