### PR TITLE
Let AltGr chords type their character instead of firing shortcuts

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
@@ -11,6 +11,15 @@ import androidx.compose.ui.input.key.key
 import com.darkrockstudios.texteditor.input.EditorCommand.Action
 import com.darkrockstudios.texteditor.input.EditorCommand.Motion
 
+/**
+ * A Ctrl chord that is a real shortcut rather than an AltGr composition. Windows
+ * synthesizes AltGr as left-Ctrl + right-Alt, so a Ctrl-only test steals the layout
+ * chords that type a character (Hungarian AltGr+X is `#`, Polish AltGr+Z is `ż`).
+ * Compose folds AltGraph into `isAltPressed`, and no Ctrl+Alt chord is bound.
+ */
+internal val KeyEvent.isCtrlShortcut: Boolean
+	get() = isCtrlPressed && !isAltPressed
+
 /** Maps a platform's key chords onto the editor's [EditorCommand] vocabulary. */
 internal fun interface KeyBindings {
 	/** The command [event] triggers, or null when the chord is unbound. */
@@ -25,7 +34,7 @@ internal val LocalKeyBindings = staticCompositionLocalOf { platformKeyBindings()
 /** Windows and Linux conventions: Ctrl for shortcuts, Ctrl+Arrow for word jumps, Home/End for line bounds. */
 internal object CtrlKeyBindings : KeyBindings {
 	override fun commandFor(event: KeyEvent): EditorCommand? {
-		val ctrl = event.isCtrlPressed
+		val ctrl = event.isCtrlShortcut
 		return when (event.key) {
 			Key.A -> if (ctrl) Action.SelectAll else null
 			Key.C -> if (ctrl) Action.Copy else null

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
@@ -2,7 +2,6 @@ package com.darkrockstudios.texteditor.input
 
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.type
@@ -100,8 +99,8 @@ internal class TextEditorKeyCommandHandler(
 		if (!keyEvent.isCharacterInputCandidate()) return false
 
 		// Skip unrecognized shortcuts so they don't insert a literal char.
-		// Alt is excluded: macOS Option is text composition (Option+8 = '{').
-		if (keyEvent.isCtrlPressed || keyEvent.isMetaPressed) {
+		// Alt is excluded: it composes text (macOS Option+8 = '{', Windows AltGr+V = '@').
+		if (keyEvent.isCtrlShortcut || keyEvent.isMetaPressed) {
 			return false
 		}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/AltGrChordTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/AltGrChordTest.kt
@@ -1,0 +1,178 @@
+package input
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.input.CtrlKeyBindings
+import com.darkrockstudios.texteditor.input.TextEditorKeyCommandHandler
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Windows synthesizes AltGr as left-Ctrl + right-Alt, so layouts that reach common
+ * characters through AltGr (Hungarian AltGr+V is `@`, Polish AltGr+Z is `ż`) must not
+ * trip the Ctrl shortcuts. Whether AWT reports the chord as Alt or as AltGraph varies
+ * by JDK; Compose folds both into `isAltPressed`, which is what these chords set.
+ */
+@OptIn(InternalComposeUiApi::class)
+class AltGrChordTest {
+
+	private lateinit var state: TextEditorState
+	private lateinit var handler: TextEditorKeyCommandHandler
+	private lateinit var clipboard: Clipboard
+	private lateinit var scope: TestScope
+
+	@BeforeTest
+	fun setup() {
+		scope = TestScope()
+		state = TextEditorState(
+			scope = scope,
+			measurer = mockk(relaxed = true),
+			initialText = AnnotatedString(""),
+		)
+		handler = TextEditorKeyCommandHandler(CtrlKeyBindings)
+		clipboard = mockk(relaxed = true)
+	}
+
+	private fun chord(key: Key, ctrl: Boolean = false, alt: Boolean = false) = KeyEvent(
+		key = key,
+		type = KeyEventType.KeyDown,
+		isCtrlPressed = ctrl,
+		isAltPressed = alt,
+	)
+
+	/** The composed character, delivered as its own event after the chord. */
+	private fun typed(char: Char, ctrl: Boolean = false, alt: Boolean = false) = KeyEvent(
+		key = Key.Unknown,
+		type = KeyEventType.Unknown,
+		codePoint = char.code,
+		isCtrlPressed = ctrl,
+		isAltPressed = alt,
+	)
+
+	private fun handleKey(event: KeyEvent) = handler.handleKeyEvent(event, state, clipboard, scope)
+
+	private fun selectAll() {
+		state.selector.updateSelection(
+			start = CharLineOffset(0, 0),
+			end = CharLineOffset(0, state.textLines[0].length),
+		)
+	}
+
+	@Test
+	fun `AltGr+X does not cut`() {
+		state.setText("hello")
+		selectAll()
+
+		assertFalse(handleKey(chord(Key.X, ctrl = true, alt = true)))
+
+		assertEquals("hello", state.getAllText().text, "The selection must survive an AltGr chord")
+		assertNotNull(state.selector.selection)
+	}
+
+	@Test
+	fun `AltGr+V does not paste`() {
+		state.setText("hello")
+
+		assertFalse(handleKey(chord(Key.V, ctrl = true, alt = true)))
+	}
+
+	@Test
+	fun `AltGr+C does not copy`() {
+		state.setText("hello")
+		selectAll()
+
+		assertFalse(handleKey(chord(Key.C, ctrl = true, alt = true)))
+	}
+
+	@Test
+	fun `AltGr+Z does not undo`() {
+		state.setText("hello")
+		state.cursor.updatePosition(CharLineOffset(0, 5))
+		state.insertStringAtCursor(" world")
+
+		assertFalse(handleKey(chord(Key.Z, ctrl = true, alt = true)))
+
+		assertEquals("hello world", state.getAllText().text, "The last edit must not be reverted")
+	}
+
+	@Test
+	fun `AltGr+A does not select all`() {
+		state.setText("hello")
+
+		assertFalse(handleKey(chord(Key.A, ctrl = true, alt = true)))
+
+		assertNull(state.selector.selection)
+	}
+
+	@Test
+	fun `AltGr+Y does not redo`() {
+		state.setText("hello")
+		state.insertStringAtCursor(" world")
+		state.undo()
+
+		assertFalse(handleKey(chord(Key.Y, ctrl = true, alt = true)))
+
+		assertEquals("hello", state.getAllText().text)
+	}
+
+	@Test
+	fun `AltGr composed character is typed`() {
+		state.setText("mail")
+		state.cursor.updatePosition(CharLineOffset(0, 4))
+
+		assertTrue(handler.handleCharacterInput(typed('@', ctrl = true, alt = true), state))
+
+		assertEquals("mail@", state.getAllText().text)
+	}
+
+	@Test
+	fun `Ctrl+A still selects all`() {
+		state.setText("hello")
+
+		assertTrue(handleKey(chord(Key.A, ctrl = true)))
+
+		assertNotNull(state.selector.selection)
+	}
+
+	@Test
+	fun `Ctrl+Z still undoes`() {
+		state.setText("hello")
+		state.insertStringAtCursor(" world")
+
+		assertTrue(handleKey(chord(Key.Z, ctrl = true)))
+
+		assertEquals("hello", state.getAllText().text)
+	}
+
+	@Test
+	fun `Ctrl+X is still cut`() {
+		state.setText("hello")
+		selectAll()
+
+		assertTrue(handleKey(chord(Key.X, ctrl = true)))
+
+		assertEquals("", state.getAllText().text)
+	}
+
+	@Test
+	fun `Ctrl chord does not insert a literal character`() {
+		state.setText("hello")
+
+		assertFalse(handler.handleCharacterInput(typed(0x18.toChar(), ctrl = true), state))
+
+		assertEquals("hello", state.getAllText().text)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/KeyBindingsTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/KeyBindingsTest.kt
@@ -95,6 +95,48 @@ class KeyBindingsTest {
 	}
 
 	@Test
+	fun `windows and linux leave altgr chords unbound so they can compose characters`() {
+		// Windows delivers AltGr as Ctrl+Alt: these chords type a character on the
+		// Hungarian, Croatian and Polish layouts.
+		assertNull(CtrlKeyBindings.commandFor(chord(Key.A, ctrl = true, alt = true)))
+		assertNull(CtrlKeyBindings.commandFor(chord(Key.C, ctrl = true, alt = true)))
+		assertNull(CtrlKeyBindings.commandFor(chord(Key.X, ctrl = true, alt = true)))
+		assertNull(CtrlKeyBindings.commandFor(chord(Key.V, ctrl = true, alt = true)))
+		assertNull(CtrlKeyBindings.commandFor(chord(Key.Y, ctrl = true, alt = true)))
+		assertNull(CtrlKeyBindings.commandFor(chord(Key.Z, ctrl = true, alt = true)))
+		assertNull(CtrlKeyBindings.commandFor(chord(Key.Z, ctrl = true, alt = true, shift = true)))
+	}
+
+	@Test
+	fun `windows and linux treat altgr navigation as its unmodified form`() {
+		// AltGr reaches no navigation chord, so the Ctrl meaning must not apply.
+		assertEquals(
+			Motion.Left,
+			CtrlKeyBindings.commandFor(chord(Key.DirectionLeft, ctrl = true, alt = true)),
+		)
+		assertEquals(
+			Motion.Right,
+			CtrlKeyBindings.commandFor(chord(Key.DirectionRight, ctrl = true, alt = true)),
+		)
+		assertEquals(
+			Motion.LineStart,
+			CtrlKeyBindings.commandFor(chord(Key.MoveHome, ctrl = true, alt = true)),
+		)
+		assertEquals(
+			Motion.LineEnd,
+			CtrlKeyBindings.commandFor(chord(Key.MoveEnd, ctrl = true, alt = true)),
+		)
+		assertEquals(
+			Action.DeleteBackward,
+			CtrlKeyBindings.commandFor(chord(Key.Backspace, ctrl = true, alt = true)),
+		)
+		assertEquals(
+			Action.DeleteForward,
+			CtrlKeyBindings.commandFor(chord(Key.Delete, ctrl = true, alt = true)),
+		)
+	}
+
+	@Test
 	fun `windows and linux leave option arrows as plain movement`() {
 		assertEquals(Motion.Left, CtrlKeyBindings.commandFor(chord(Key.DirectionLeft, alt = true)))
 		assertEquals(


### PR DESCRIPTION
Fixes #52. Rebased onto main after #45 landed, so the fix now lives in the binding tables.

On Windows AltGr is synthesized as left-Ctrl + right-Alt, so gating the shortcuts on `isCtrlPressed` alone stole every AltGr chord: Hungarian AltGr+X ran **Cut** (selection deleted, clipboard overwritten), AltGr+V pasted, Polish AltGr+Z ran **Undo**. The intended character was never inserted, because `handleCharacterInput` rejected the same event.

Both gates now go through one predicate in `KeyBindings.kt`:

```kotlin
internal val KeyEvent.isCtrlShortcut: Boolean
	get() = isCtrlPressed && !isAltPressed
```

`CtrlKeyBindings` uses it for its whole table, and `handleCharacterInput` uses it to decide what to swallow. Compose folds AltGraph into `isAltPressed`, so this holds whichever way the JDK reports the chord. No Ctrl+Alt chord is bound, so nothing is lost. Linux gets the same coverage (`ISO_Level3_Shift` reports as AltGraph); `MacKeyBindings` keys off Cmd and is unaffected.

The source change against main is one line: `val ctrl = event.isCtrlPressed` becomes `val ctrl = event.isCtrlShortcut`, plus the same swap in the character-input guard.

Applying it to the whole table rather than just the letter shortcuts also means AltGr+Arrow, AltGr+Home/End and AltGr+Backspace/Delete now do what the unmodified key does instead of the Ctrl variant (plain left instead of word-left, and so on). Someone holding AltGr is reaching for the compose modifier, not for a word jump, so that is the more defensible reading and it keeps one rule for the whole table.

## Verification

Two layers:

- `KeyBindingsTest` gains two cases: the six affected letter chords (plus Ctrl+Alt+Shift+Z) map to `null`, and the six navigation and deletion chords map to their unmodified form.
- `AltGrChordTest` drives the whole handler: the affected chords are asserted unconsumed and non-destructive, AltGr+`@` is asserted to insert, and plain Ctrl+A/X/Z are asserted to still fire.

With the `&& !isAltPressed` removed, 8 of those fail; with it, the whole desktop suite passes.

The OS-level Ctrl+Alt synthesis can't be reproduced in a test, so end-to-end confirmation still needs a physical AltGr press on an affected layout.
