### PR TITLE
Fix undo of an insert wiping every rich span

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
@@ -302,79 +302,51 @@ class RichSpanManager(
 		updatedSpans: MutableSet<RichSpan>,
 		span: RichSpan
 	) {
-		if (metadata != null) {
-			if (metadata.deletedText?.text == "\n") {
-				// Special handling for newline deletion
-				val deletionPoint = operation.range.start
-				val nextLineStart = operation.range.end
+		// updateSpans rebuilds the whole set from what these handlers contribute, so a
+		// handler that adds nothing erases the span. With no metadata to transform
+		// against, a stale position beats deleting the span outright.
+		if (metadata == null) {
+			updatedSpans.add(span)
+			return
+		}
 
-				when {
-					// Span is entirely before the deletion point on the first line
-					end.line < deletionPoint.line ||
-							(end.line == deletionPoint.line && end.char <= deletionPoint.char) -> {
-						updatedSpans.add(span)
-					}
-					// Span is entirely below the joined line — the deleted newline pulls
-					// every following line up by one, so decrement its line index.
-					start.line > nextLineStart.line -> {
-						updatedSpans.add(
-							span.copy(
-								range = TextEditorRange(
-									start = CharLineOffset(start.line - 1, start.char),
-									end = CharLineOffset(end.line - 1, end.char)
-								)
-							)
-						)
-					}
-					// Span is entirely on the second line
-					start.line == nextLineStart.line -> {
-						val newStart = CharLineOffset(
-							deletionPoint.line,
-							deletionPoint.char + start.char
-						)
-						val newEnd = CharLineOffset(
-							deletionPoint.line,
-							deletionPoint.char + end.char
-						)
-						updatedSpans.add(
-							span.copy(
-								range = TextEditorRange(
-									start = newStart,
-									end = newEnd
-								)
-							)
-						)
-					}
-					// Span crosses the newline
-					start.line == deletionPoint.line &&
-							end.line == nextLineStart.line -> {
-						val newEnd = CharLineOffset(
-							deletionPoint.line,
-							deletionPoint.char + end.char
-						)
+		if (metadata.deletedText?.text == "\n") {
+			// A pure newline delete joins two lines: nothing on the first line moves,
+			// the second line's content slides onto the join point, and everything
+			// below is pulled up one line.
+			val deletionPoint = operation.range.start
+			val nextLineStart = operation.range.end
 
-						updatedSpans.add(
-							span.copy(
-								range = span.range.copy(
-									end = newEnd
-								)
-							)
-						)
-					}
-				}
-			} else {
-				// Regular delete operation
-				val newStart = operation.transformOffset(start, state)
-				val newEnd = operation.transformOffset(end, state)
-				if (newStart != newEnd) {
-					updatedSpans.add(
-						span.copy(
-							range = TextEditorRange(
-								start = newStart, end = newEnd
-							)
+			fun joinOffset(offset: CharLineOffset): CharLineOffset = when {
+				offset.line < nextLineStart.line -> offset
+				offset.line == nextLineStart.line -> CharLineOffset(
+					deletionPoint.line,
+					deletionPoint.char + offset.char
+				)
+
+				else -> CharLineOffset(offset.line - 1, offset.char)
+			}
+
+			updatedSpans.add(
+				span.copy(
+					range = TextEditorRange(
+						start = joinOffset(start),
+						end = joinOffset(end)
+					)
+				)
+			)
+		} else {
+			// Regular delete operation
+			val newStart = operation.transformOffset(start, state)
+			val newEnd = operation.transformOffset(end, state)
+			if (newStart != newEnd) {
+				updatedSpans.add(
+					span.copy(
+						range = TextEditorRange(
+							start = newStart, end = newEnd
 						)
 					)
-				}
+				)
 			}
 		}
 	}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
@@ -59,7 +59,7 @@ class TextEditManager(private val state: TextEditorState) {
 		state.withAtomicEdit {
 			val metadata = when (operation) {
 				is TextEditOperation.Insert -> applyInsert(operation)
-				is TextEditOperation.Delete -> applyDelete(addToHistory, operation)
+				is TextEditOperation.Delete -> applyDelete(operation)
 				is TextEditOperation.Replace -> applyReplace(addToHistory, operation)
 				is TextEditOperation.StyleSpan -> applyStyleOperation(operation)
 				is TextEditOperation.RichSpan -> applyRichSpanOperation(operation)
@@ -248,15 +248,12 @@ class TextEditManager(private val state: TextEditorState) {
 		return metadata
 	}
 
-	private fun applyDelete(
-		addToHistory: Boolean,
-		operation: TextEditOperation.Delete
-	): OperationMetadata? {
-		val metadata = if (addToHistory) {
-			state.captureMetadata(operation.range)
-		} else {
-			null
-		}
+	private fun applyDelete(operation: TextEditOperation.Delete): OperationMetadata {
+		// Captured whether or not this delete is recorded: the rich span transformer
+		// needs the deleted text to re-anchor spans, and the two non-recording paths
+		// (undo of an insert, redo of a delete) are exactly where spans would
+		// otherwise be dropped.
+		val metadata = state.captureMetadata(operation.range)
 
 		when {
 			operation.range.isSingleLine() -> {

--- a/ComposeTextEditor/src/desktopTest/kotlin/texteditmanager/undo/RichSpanSurvivalTests.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/texteditmanager/undo/RichSpanSurvivalTests.kt
@@ -1,0 +1,113 @@
+package texteditmanager.undo
+
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Undo and redo re-apply their inverse operations without recording history.
+ * The rich span set is rebuilt from scratch on every edit, so a transform that
+ * skips a span erases it from the document rather than merely misplacing it;
+ * these pin down that spans survive both paths.
+ */
+class RichSpanSurvivalTests {
+
+	private fun TestScope.editorState() = TextEditorState(
+		scope = backgroundScope,
+		measurer = mockk(relaxed = true),
+	)
+
+	private fun TextEditorState.bulletEachLine() {
+		textLines.forEachIndexed { index, line ->
+			addRichSpan(
+				TextEditorRange(
+					start = CharLineOffset(index, 0),
+					end = CharLineOffset(index, line.length),
+				),
+				BulletListSpanStyle,
+			)
+		}
+	}
+
+	@Test
+	fun `undo of a typed character keeps every bullet span`() = runTest {
+		val state = editorState()
+		state.setText("alpha\nbravo\ncharlie")
+		state.bulletEachLine()
+		assertEquals(3, state.richSpanManager.getAllRichSpans().size)
+
+		state.cursor.updatePosition(CharLineOffset(0, 5))
+		state.insertStringAtCursor("X")
+		assertEquals(3, state.richSpanManager.getAllRichSpans().size)
+
+		state.undo()
+
+		assertEquals(3, state.richSpanManager.getAllRichSpans().size)
+		val first = state.richSpanManager.getAllRichSpans()
+			.single { it.range.start.line == 0 }
+		assertEquals(CharLineOffset(0, 0), first.range.start)
+		assertEquals(CharLineOffset(0, 5), first.range.end)
+	}
+
+	@Test
+	fun `undo of a newline insert restores the split span`() = runTest {
+		val state = editorState()
+		state.setText("alpha")
+		state.bulletEachLine()
+
+		state.cursor.updatePosition(CharLineOffset(0, 2))
+		state.insertStringAtCursor("\n")
+		assertEquals(2, state.textLines.size)
+
+		state.undo()
+
+		assertEquals("alpha", state.textLines[0].text)
+		val span = state.richSpanManager.getAllRichSpans().single()
+		assertEquals(CharLineOffset(0, 0), span.range.start)
+		assertEquals(CharLineOffset(0, 5), span.range.end)
+	}
+
+	@Test
+	fun `redo of a delete keeps spans on untouched lines`() = runTest {
+		val state = editorState()
+		state.setText("alpha\nbravo\ncharlie")
+		state.bulletEachLine()
+
+		state.delete(
+			TextEditorRange(
+				start = CharLineOffset(1, 0),
+				end = CharLineOffset(1, 5),
+			)
+		)
+		state.undo()
+		assertEquals(3, state.richSpanManager.getAllRichSpans().size)
+
+		state.redo()
+
+		assertEquals("", state.textLines[1].text)
+		val lines = state.richSpanManager.getAllRichSpans().map { it.range.start.line }
+		assertEquals(listOf(0, 2), lines.sorted())
+	}
+
+	@Test
+	fun `undo of typing in a markdown list preserves the list markers`() = runTest {
+		val state = editorState()
+		val extension = MarkdownExtension(state)
+		extension.importMarkdown("- alpha\n- bravo\n- charlie")
+		assertEquals(3, state.richSpanManager.getAllRichSpans().size)
+
+		state.cursor.updatePosition(CharLineOffset(0, 5))
+		state.insertStringAtCursor("X")
+		state.undo()
+
+		assertEquals(3, state.richSpanManager.getAllRichSpans().size)
+		assertEquals("- alpha\n- bravo\n- charlie", extension.exportAsMarkdown())
+	}
+}


### PR DESCRIPTION
Fixes #54

## The bug

`applyDelete` captured `OperationMetadata` only when the delete was being recorded to history. Two everyday paths apply a delete with `addToHistory = false`:

- `undoInsert` inverts an insert into a delete
- `redo()` re-applies a stored operation

Both reached `updateSpans` with `metadata == null`. `handleDelete` was wrapped in `if (metadata != null)` with no `else`, so it contributed nothing, and since `updateSpans` replaces the entire span set with whatever the handlers collected, every rich span in the document was erased. Bullets, ordered lists, blockquotes, code fences, rules and images all vanished at once, on screen and in both exporters, and redo did not bring them back because they were gone from the model.

One keystroke in a list plus Ctrl+Z was enough.

## The fix

`applyDelete` now captures metadata unconditionally. `history.recordEdit` was already gated on `addToHistory` in `applyOperation`, so nothing extra lands in the undo stack; the delete transform just gets the deleted text it needs to re-anchor spans. The `addToHistory` parameter is no longer used by `applyDelete` and is dropped.

`handleDelete` also gets the null-metadata fallback the issue asked for: keep the span rather than drop it. A stale position beats erasing a marker. With the capture change this is a safety net rather than a live path.

While in there, the newline branch's four-case `when` collapses into a single offset mapper. It had no `else`, and two span shapes matched none of its cases and were dropped the same silent way:

- a span starting above the join line and ending at or below it
- a span starting on the join line and ending more than one line below

The mapper reproduces all four original cases exactly and covers those two.

## Tests

`RichSpanSurvivalTests` covers four paths, all failing before this change with `expected:<3> but was:<0>`:

- undo of a typed character keeps every bullet span, at its original range
- undo of a newline insert restores a span the insert had split
- redo of a delete keeps spans on untouched lines
- the issue's markdown repro, asserting `exportAsMarkdown()` still round-trips the list

Full `desktopTest` and `testAndroidHostTest` suites pass.

## Not done

The issue floats a bigger alternative: snapshot spans into the insert's `OperationMetadata` so undo restores them wholesale. With metadata available the existing transform already inverts the insert exactly, including the span-splitting newline case, so the snapshot would be redundant on these paths.
