### PR TITLE
Lay an import out once instead of once per block line

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
@@ -246,9 +246,9 @@ class MarkdownExtension(
 		}
 		val processedMarkdown = processedLines.joinToString("\n")
 		val annotatedString = processedMarkdown.toAnnotatedStringFromMarkdown(markdownConfiguration)
-		// setText publishes the text with no spans and applyDocumentBlocks re-attaches
-		// them one at a time. As one revision, so a concurrent export can't catch the
-		// document fully loaded but entirely unstyled.
+		// setText publishes the text with no spans and applyDocumentBlocks attaches them
+		// afterwards. As one revision, so a concurrent export can't catch the document
+		// fully loaded but entirely unstyled.
 		editorState.withAtomicEdit {
 			editorState.setText(annotatedString)
 			editorState.applyDocumentBlocks(

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/DocumentBlocks.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/DocumentBlocks.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.texteditor.richstyle
 
 import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.state.TextEditorState
 
 /**
@@ -63,34 +64,72 @@ internal fun documentBlocksOf(allSpans: Set<RichSpan>): DocumentBlocks {
 /**
  * Attaches the decorations an importer parsed out of a source document.
  *
- * Rules and images go through the manager directly while block styles go through
- * [applyLineBlock], which also installs the indent paragraph style. Neither path
- * records an edit: loading a document is not something the user should be able to
- * undo one list item at a time.
+ * Every span is published and every block line rebuilt against the current content
+ * before a single relayout runs at the end. A relayout re-measures from the line it
+ * is given to the end of the document, so one per block line would measure an
+ * n-line import O(n²) times. No edit is recorded: loading a document is not
+ * something the user should be able to undo one list item at a time.
  */
 internal fun TextEditorState.applyDocumentBlocks(
 	horizontalRuleLines: Collection<Int> = emptyList(),
 	imageLines: Map<Int, ImageBlockSpanStyle> = emptyMap(),
 	blockLines: Map<LineBlockStyle, Collection<Int>> = emptyMap(),
 ) = withAtomicEdit {
+	val added = mutableListOf<RichSpan>()
+	val removed = mutableListOf<RichSpan>()
+
 	horizontalRuleLines.forEach { line ->
-		richSpanManager.addRichSpan(
-			start = CharLineOffset(line, 0),
-			end = CharLineOffset(line, HR_PLACEHOLDER.length),
+		added += RichSpan(
+			range = lineRange(line, HR_PLACEHOLDER.length),
 			style = HorizontalRuleSpanStyle,
 		)
 	}
 	imageLines.forEach { (line, style) ->
-		richSpanManager.addRichSpan(
-			start = CharLineOffset(line, 0),
-			end = CharLineOffset(line, IMAGE_PLACEHOLDER.length),
-			style = style,
-		)
+		added += RichSpan(range = lineRange(line, IMAGE_PLACEHOLDER.length), style = style)
 	}
-	// Blockquote before the list styles: `applyLineBlock` demotes anything
-	// mutually exclusive with what it is applying, and the two stack, so the
-	// order only has to keep a list from arriving while a fence is pending.
+
+	// Invert to line -> requested blocks so each line is visited once. Within a line
+	// the [ALL_BLOCK_STYLES] order decides how a stack resolves: each block demotes
+	// whatever it excludes, so a fence beats a list and blockquote stacks with both.
+	val requested = mutableMapOf<Int, MutableList<LineBlockStyle>>()
 	ALL_BLOCK_STYLES.forEach { block ->
-		blockLines[block]?.forEach { applyLineBlock(it, block) }
+		blockLines[block]?.forEach { line ->
+			requested.getOrPut(line) { mutableListOf() } += block
+		}
 	}
+
+	val lines = textLines.toMutableList()
+	var rebuiltAnyLine = false
+	for ((line, blocks) in requested) {
+		var text = lines.getOrNull(line) ?: continue
+		val present = ALL_BLOCK_STYLES.filter { hasLineBlock(line, it) }.toMutableList()
+		// Spans staged for this line, so a block demoted after being applied in this
+		// same pass is withdrawn rather than published alongside the block that
+		// replaced it.
+		val staged = linkedMapOf<LineBlockStyle, RichSpan>()
+		for (block in blocks) {
+			if (block in present) continue
+			for (excluded in mutuallyExcluded(block)) {
+				if (!present.remove(excluded)) continue
+				if (staged.remove(excluded) == null) removed += lineBlockSpans(line, excluded)
+				text = rebuildWithoutBlock(text, excluded)
+			}
+			staged[block] = RichSpan(lineRange(line, text.length), block.spanStyle)
+			text = rebuildWithBlock(text, block)
+			present += block
+		}
+		if (staged.isEmpty()) continue
+		added += staged.values
+		lines[line] = text
+		rebuiltAnyLine = true
+	}
+
+	richSpanManager.removeRichSpans(removed)
+	richSpanManager.addRichSpans(added)
+	if (rebuiltAnyLine) setLines(lines)
+	updateBookKeeping()
 }
+
+/** The range covering [length] characters from the start of [line]. */
+private fun lineRange(line: Int, length: Int) =
+	TextEditorRange(CharLineOffset(line, 0), CharLineOffset(line, length))

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
@@ -113,7 +113,7 @@ internal val ALL_BLOCK_STYLES: List<LineBlockStyle> =
  * - [CodeFence] stacks with nothing — quoted/listed code blocks aren't
  *   meaningful in our editor's model and the visual treatments would conflict.
  */
-private fun mutuallyExcluded(applied: LineBlockStyle): Set<LineBlockStyle> = when (applied) {
+internal fun mutuallyExcluded(applied: LineBlockStyle): Set<LineBlockStyle> = when (applied) {
 	CodeFence -> setOf(Blockquote, BulletList, OrderedList)
 	BulletList -> setOf(OrderedList, CodeFence)
 	OrderedList -> setOf(BulletList, CodeFence)
@@ -122,9 +122,7 @@ private fun mutuallyExcluded(applied: LineBlockStyle): Set<LineBlockStyle> = whe
 }
 
 internal fun TextEditorState.hasLineBlock(line: Int, block: LineBlockStyle): Boolean =
-	richSpanManager.getAllRichSpans().any { span ->
-		span.style === block.spanStyle && span.range.start.line == line
-	}
+	richSpanManager.getRichSpansStartingOn(line).any { it.style === block.spanStyle }
 
 /** Wraps [existing] in [block]'s indent paragraph style (and optional text style). */
 internal fun rebuildWithBlock(existing: AnnotatedString, block: LineBlockStyle): AnnotatedString =
@@ -198,10 +196,12 @@ internal fun TextEditorState.addLineBlockSpan(line: Int, length: Int, block: Lin
 
 /** Drops every span anchored to [line] for [block] via the direct manager path. */
 internal fun TextEditorState.removeLineBlockSpans(line: Int, block: LineBlockStyle) {
-	richSpanManager.getAllRichSpans()
-		.filter { it.style === block.spanStyle && it.range.start.line == line }
-		.forEach { richSpanManager.removeRichSpan(it) }
+	richSpanManager.removeRichSpans(lineBlockSpans(line, block))
 }
+
+/** The spans anchored to [line] that carry [block]'s decoration. */
+internal fun TextEditorState.lineBlockSpans(line: Int, block: LineBlockStyle): List<RichSpan> =
+	richSpanManager.getRichSpansStartingOn(line).filter { it.style === block.spanStyle }
 
 /**
  * Drops every span anchored to [line] for [block] and rebuilds the line without

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/DocumentSnapshot.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/DocumentSnapshot.kt
@@ -13,19 +13,33 @@ import com.darkrockstudios.texteditor.richstyle.RichSpan
  * [TextEditorState.snapshot]; it is safe to hold and to read from any thread, and it
  * does not reflect later edits.
  */
-class DocumentSnapshot internal constructor(
+class DocumentSnapshot private constructor(
 	/** The document as one [AnnotatedString] per line, in order. */
 	val lines: List<AnnotatedString>,
 	/** Every rich span in the document, its ranges addressing [lines]. */
 	val richSpans: Set<RichSpan>,
+	/**
+	 * Backs [richSpansByStartLine]. Held as the [Lazy] rather than the map so
+	 * [withLines] can hand the same one to the revision it produces, which keeps the
+	 * memoized index alive across a text-only edit. Sharing it also carries the
+	 * `PUBLICATION` safety over, where a plain field would publish the map unsafely.
+	 */
+	private val spansByStartLine: Lazy<Map<Int, List<RichSpan>>>,
 ) {
+	internal constructor(lines: List<AnnotatedString>, richSpans: Set<RichSpan>) : this(
+		lines = lines,
+		richSpans = richSpans,
+		spansByStartLine = lazy(LazyThreadSafetyMode.PUBLICATION) {
+			richSpans.groupBy { it.range.start.line }
+		},
+	)
+
 	/**
 	 * [richSpans] grouped by the line each one starts on. Built on first read and
-	 * reused for the rest of the revision, so the line-anchored block queries cost a
-	 * map lookup instead of a scan of every span in the document.
+	 * reused until a revision changes the spans, so the line-anchored block queries
+	 * cost a map lookup instead of a scan of every span in the document.
 	 */
-	internal val richSpansByStartLine: Map<Int, List<RichSpan>> by
-		lazy(LazyThreadSafetyMode.PUBLICATION) { richSpans.groupBy { it.range.start.line } }
+	internal val richSpansByStartLine: Map<Int, List<RichSpan>> get() = spansByStartLine.value
 
 	/** The whole document as a single [AnnotatedString], lines joined with newlines. */
 	fun getAllText(): AnnotatedString = buildAnnotatedString {
@@ -35,7 +49,12 @@ class DocumentSnapshot internal constructor(
 		}
 	}
 
-	internal fun withLines(lines: List<AnnotatedString>) = DocumentSnapshot(lines, richSpans)
+	/**
+	 * Keeps the span index: the ranges are untouched by a text edit, so the lines they
+	 * start on are the same ones they started on before.
+	 */
+	internal fun withLines(lines: List<AnnotatedString>) =
+		DocumentSnapshot(lines, richSpans, spansByStartLine)
 
 	internal fun withRichSpans(richSpans: Set<RichSpan>) = DocumentSnapshot(lines, richSpans)
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/DocumentSnapshot.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/DocumentSnapshot.kt
@@ -19,6 +19,14 @@ class DocumentSnapshot internal constructor(
 	/** Every rich span in the document, its ranges addressing [lines]. */
 	val richSpans: Set<RichSpan>,
 ) {
+	/**
+	 * [richSpans] grouped by the line each one starts on. Built on first read and
+	 * reused for the rest of the revision, so the line-anchored block queries cost a
+	 * map lookup instead of a scan of every span in the document.
+	 */
+	internal val richSpansByStartLine: Map<Int, List<RichSpan>> by
+		lazy(LazyThreadSafetyMode.PUBLICATION) { richSpans.groupBy { it.range.start.line } }
+
 	/** The whole document as a single [AnnotatedString], lines joined with newlines. */
 	fun getAllText(): AnnotatedString = buildAnnotatedString {
 		lines.forEachIndexed { index, line ->

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
@@ -24,6 +24,14 @@ class RichSpanManager(
 	 */
 	fun getAllRichSpans(): Set<RichSpan> = spans
 
+	/**
+	 * Every span anchored to (starting on) [line]. Reads a per-revision index rather
+	 * than scanning the whole set, so the line-block queries stay cheap on documents
+	 * carrying thousands of spans.
+	 */
+	internal fun getRichSpansStartingOn(line: Int): List<RichSpan> =
+		state.workingContent.richSpansByStartLine[line] ?: emptyList()
+
 	internal fun addRichSpan(range: TextEditorRange, style: RichSpanStyle) {
 		spans = spans + RichSpan(range, style)
 	}
@@ -32,12 +40,24 @@ class RichSpanManager(
 		addRichSpan(TextEditorRange(start, end), style)
 	}
 
+	/** Adds every span in [newSpans] in one publish, for bulk callers like an import. */
+	internal fun addRichSpans(newSpans: Collection<RichSpan>) {
+		if (newSpans.isEmpty()) return
+		spans = spans + newSpans
+	}
+
 	internal fun removeRichSpan(start: CharLineOffset, end: CharLineOffset, style: RichSpanStyle) {
 		removeRichSpan(RichSpan(TextEditorRange(start, end), style))
 	}
 
 	internal fun removeRichSpan(span: RichSpan) {
 		spans = spans - span
+	}
+
+	/** Drops every span in [doomed] in one publish. */
+	internal fun removeRichSpans(doomed: Collection<RichSpan>) {
+		if (doomed.isEmpty()) return
+		spans = spans - doomed.toSet()
 	}
 
 	fun getSpansForLineWrap(lineWrap: LineWrap): List<RichSpan> {

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/ImportRelayoutCostTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/ImportRelayoutCostTest.kt
@@ -1,0 +1,111 @@
+package markdown
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextMeasurer
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * An import lays the document out a fixed number of times, however many decorated
+ * lines it carries.
+ *
+ * A relayout re-measures from the line it is handed to the end of the document, so
+ * applying block styles a line at a time walks a triangle and makes an import cost
+ * quadratic in line count. Counting measure calls pins the cost to a constant number
+ * of whole-document passes, so a regression fails the build instead of waiting to be
+ * found by profiling.
+ */
+class ImportRelayoutCostTest {
+
+	/** Whole-document layout passes an import runs: one for the text, one for the blocks. */
+	private val passesPerImport = 2
+
+	private class MeasureCounter {
+		var calls = 0
+	}
+
+	/**
+	 * A [TextMeasurer] that tallies calls and hands back a one-visual-line layout, so
+	 * `updateBookKeeping` builds a full set of line offsets from what it returns.
+	 */
+	private fun countingMeasurer(counter: MeasureCounter): TextMeasurer {
+		val layout = mockk<TextLayoutResult>(relaxed = true)
+		every { layout.multiParagraph.lineCount } returns 1
+		return mockk(relaxed = true) {
+			every {
+				measure(
+					any<AnnotatedString>(), any(), any(), any(), any(), any(),
+					any(), any(), any(), any(), any(),
+				)
+			} answers {
+				counter.calls++
+				layout
+			}
+		}
+	}
+
+	private fun TestScope.editorWithCounter(counter: MeasureCounter): TextEditorState {
+		val state = TextEditorState(scope = this, measurer = countingMeasurer(counter))
+		// Book-keeping is suppressed until the viewport has a real size, so lay the
+		// empty document out first and count only what the import itself costs.
+		state.onViewportSizeChange(Size(800f, 600f))
+		counter.calls = 0
+		return state
+	}
+
+	/** Returns how many times importing [markdown] measured a line. */
+	private fun TestScope.measuresToImport(markdown: String): Int {
+		val counter = MeasureCounter()
+		MarkdownExtension(editorWithCounter(counter)).importMarkdown(markdown)
+		return counter.calls
+	}
+
+	private fun bulletDocument(lines: Int): String =
+		(0 until lines).joinToString("\n") { "- bullet $it" }
+
+	@Test
+	fun `import measures the document a fixed number of times`() = runTest {
+		assertEquals(passesPerImport * 50, measuresToImport(bulletDocument(50)))
+	}
+
+	@Test
+	fun `import cost grows linearly with document size`() = runTest {
+		val small = measuresToImport(bulletDocument(50))
+		val large = measuresToImport(bulletDocument(100))
+		assertEquals(
+			2 * small,
+			large,
+			"doubling the document must double the measure calls, not quadruple them",
+		)
+	}
+
+	@Test
+	fun `mixed block document costs the same fixed number of passes`() = runTest {
+		val markdown = buildString {
+			repeat(20) { index ->
+				appendLine("# Heading $index")
+				appendLine("> quoted $index")
+				appendLine("- bullet $index")
+				appendLine("1. numbered $index")
+				appendLine("---")
+				appendLine("```")
+				appendLine("code $index")
+				appendLine("```")
+			}
+		}.trimEnd('\n')
+
+		val counter = MeasureCounter()
+		val state = editorWithCounter(counter)
+		MarkdownExtension(state).importMarkdown(markdown)
+
+		assertEquals(passesPerImport * state.textLines.size, counter.calls)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/DocumentSnapshotIndexTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/DocumentSnapshotIndexTest.kt
@@ -1,0 +1,79 @@
+package state
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpan
+import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.state.DocumentSnapshot
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * `DocumentSnapshot` indexes its rich spans by the line each one starts on. The index
+ * is what keeps the line-anchored block queries from scanning every span in the
+ * document, so it has to survive an edit that cannot invalidate it and be discarded by
+ * one that can.
+ */
+class DocumentSnapshotIndexTest {
+
+	private fun lineSpan(line: Int, style: RichSpanStyle) = RichSpan(
+		range = TextEditorRange(CharLineOffset(line, 0), CharLineOffset(line, 4)),
+		style = style,
+	)
+
+	private fun snapshot(vararg spans: RichSpan) = DocumentSnapshot(
+		lines = List(4) { AnnotatedString("line") },
+		richSpans = spans.toSet(),
+	)
+
+	@Test
+	fun `index groups spans by the line they start on`() {
+		val bullet = lineSpan(1, BulletListSpanStyle)
+		val quote = lineSpan(1, BlockquoteSpanStyle)
+		val other = lineSpan(3, BulletListSpanStyle)
+
+		val index = snapshot(bullet, quote, other).richSpansByStartLine
+
+		assertEquals(setOf(bullet, quote), index.getValue(1).toSet())
+		assertEquals(listOf(other), index.getValue(3))
+		assertTrue(0 !in index, "a line with no spans has no entry")
+	}
+
+	@Test
+	fun `a text-only revision keeps the built index`() {
+		val original = snapshot(lineSpan(1, BulletListSpanStyle))
+		val index = original.richSpansByStartLine
+
+		val rewritten = original.withLines(List(4) { AnnotatedString("edited") })
+
+		// Same instance, not merely equal: a text edit leaves every span range alone,
+		// so rebuilding the index would be pure work for an identical result.
+		assertSame(index, rewritten.richSpansByStartLine)
+	}
+
+	@Test
+	fun `a span revision rebuilds the index`() {
+		val original = snapshot(lineSpan(1, BulletListSpanStyle))
+		val index = original.richSpansByStartLine
+
+		val added = lineSpan(2, BulletListSpanStyle)
+		val respanned = original.withRichSpans(original.richSpans + added)
+
+		assertNotSame(index, respanned.richSpansByStartLine)
+		assertEquals(listOf(added), respanned.richSpansByStartLine.getValue(2))
+	}
+
+	@Test
+	fun `an index carried across a text edit still answers span queries`() {
+		val bullet = lineSpan(2, BulletListSpanStyle)
+		val rewritten = snapshot(bullet).withLines(List(4) { AnnotatedString("edited") })
+
+		assertEquals(listOf(bullet), rewritten.richSpansByStartLine.getValue(2))
+	}
+}


### PR DESCRIPTION
Closes #47.

## The defect

`importMarkdown` / `importHtml` applied block styles a line at a time through `applyLineBlock`, which ends in `updateBookKeeping(index..index)`. That pass re-measures from the touched line to the end of the document, so applying blocks top to bottom walked a triangle. An n-line bulleted import cost `n(n+1)/2 + n` text-measure calls: double the document, quadruple the work.

## The fix

1. **`applyDocumentBlocks` is now a bulk path.** It resolves each line's final block stack (same mutual-exclusion rules, same `ALL_BLOCK_STYLES` ordering, so stacking resolves identically), stages that line's spans, rebuilds its text once, and then publishes the spans, the lines, and a **single** relayout.
2. **Batch span mutation.** `RichSpanManager.addRichSpans` / `removeRichSpans` publish once, undoing the per-call `O(|spans|)` copy that #42's copy-on-write fix introduced on the bare HR/image loops.
3. **Line-indexed span lookup.** Each `DocumentSnapshot` lazily groups its spans by start line, so `hasLineBlock` is a map lookup instead of a scan of the whole flat set (issue point 2, shared with #36 point 4).

An import now costs two whole-document layout passes: one from `setText` for the text, one from `applyDocumentBlocks` for the blocks. Collapsing those two into one needs a relayout-suppression window, which is split out into its own draft PR rather than carried here.

`applyDocumentBlocks` also now relayouts when a document has images or rules but no block lines. Previously nothing triggered a pass after those spans were attached, so `blockHeight` stayed unresolved until something else forced one.

## Measured

`ImportRelayoutCostTest` is the fixture the issue asked for: a counting `TextMeasurer` that fails the build if import cost goes superlinear again. Reverting `commonMain` and rerunning it reproduces the issue's table exactly.

| document | measures before | measures after |
|---|---|---|
| 50 bullets | 1,325 | 100 |
| 100 bullets | 5,150 | 200 |
| 160 mixed block lines | 4,940 | 320 |

## Verification

`./gradlew check` (what CI runs) passes, including the existing markdown/HTML serialization, paste, and e2e suites.