### PR TITLE
Fix line-block corruption on sweeps, stacked markers, and placeholder lines (#43)

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,5 @@
+---
+# Design documents are prose references, not shipped artifacts; markdownlint's
+# 80-column and table rules fight their long table rows.
+exclude_paths:
+  - "docs/design/**"

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
@@ -10,9 +10,11 @@ import com.darkrockstudios.texteditor.richstyle.ImageProvider
 import com.darkrockstudios.texteditor.richstyle.LINE_BLOCK_STYLES
 import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
 import com.darkrockstudios.texteditor.richstyle.OrderedList
+import com.darkrockstudios.texteditor.richstyle.allowedOnPlaceholderLine
 import com.darkrockstudios.texteditor.richstyle.applyDocumentBlocks
 import com.darkrockstudios.texteditor.richstyle.documentBlocksOf
 import com.darkrockstudios.texteditor.richstyle.hasLineBlock
+import com.darkrockstudios.texteditor.richstyle.mutuallyExcluded
 import com.darkrockstudios.texteditor.state.TextEditorState
 
 private val HR_LINE_TOKENS = setOf("---", "***", "___")
@@ -82,6 +84,56 @@ private fun stripCodeFences(markdown: String): CodeFenceStripResult {
 	)
 }
 
+/** A line's body once its stacked block markers are peeled, and the styles peeled. */
+private data class PeeledLine(
+	val body: String,
+	val blocks: List<LineBlockStyle>,
+)
+
+/**
+ * Peels stacked block markers off [line] as the exact mirror of how export
+ * emits them: styles are tried in [LINE_BLOCK_STYLES] registry order, each at
+ * most once, and only when it can stack with everything already peeled.
+ * `> - item` peels quote then bullet; `- 1990. plans` peels only the bullet,
+ * because the two list styles are mutually exclusive, so `1990. ` stays in the
+ * body text. A nested `> > quoted` keeps its second level as body text.
+ */
+private fun peelLineBlocks(line: String): PeeledLine {
+	var body = line
+	val peeled = mutableListOf<LineBlockStyle>()
+	for (block in LINE_BLOCK_STYLES) {
+		if (peeled.any { block in mutuallyExcluded(it) || it in mutuallyExcluded(block) }) continue
+		val match = block.markdownPattern.matchEntire(body) ?: continue
+		peeled += block
+		body = match.groupValues[1]
+	}
+	return PeeledLine(body, peeled)
+}
+
+private val RESIDUAL_ORDERED_MARKER = Regex("""^(\d+)\.""")
+private val RESIDUAL_BULLET_MARKER = Regex("""^([-*+])(\s)""")
+private val RESIDUAL_QUOTE_MARKER = Regex("""^>""")
+
+/**
+ * Escapes a marker-shaped lead left in a peeled body. The peel already consumed
+ * every marker the line's spans account for, so whatever still looks like one is
+ * literal text and must not reach the GFM parser bare, or it parses as markup
+ * and the author's characters are consumed. The parser strips the escapes back
+ * out via `removeMarkdownEscapes`.
+ */
+private fun String.escapeResidualMarker(): String = when {
+	RESIDUAL_ORDERED_MARKER.containsMatchIn(this) ->
+		replaceFirst(RESIDUAL_ORDERED_MARKER, "$1\\\\.")
+
+	RESIDUAL_BULLET_MARKER.containsMatchIn(this) ->
+		replaceFirst(RESIDUAL_BULLET_MARKER, "\\\\$1$2")
+
+	RESIDUAL_QUOTE_MARKER.containsMatchIn(this) ->
+		replaceFirst(RESIDUAL_QUOTE_MARKER, "\\\\>")
+
+	else -> this
+}
+
 /**
  * An extension to TextEditorState that provides markdown functionality.
  * This separates markdown concerns from the core text editor functionality.
@@ -124,7 +176,9 @@ class MarkdownExtension(
 
 		val annotated = content.getAllText()
 		val text = annotated.text
-		if (text.isEmpty() && hrLines.isEmpty() && imageLines.isEmpty() && codeFenceLines.isEmpty()) return ""
+		// An empty document with any block decoration still serializes: a lone
+		// empty quote line is `> `, not nothing.
+		if (text.isEmpty() && blocks.isEmpty()) return ""
 
 		val sb = StringBuilder()
 		var lineIndex = 0
@@ -214,13 +268,21 @@ class MarkdownExtension(
 			if (index in codeFenceLineIndices) {
 				return@mapIndexed line.escapeMarkdownSpecials()
 			}
-			val imageMatch = STANDALONE_IMAGE_REGEX.matchEntire(line)
-			val blockMatch = LINE_BLOCK_STYLES.firstNotNullOfOrNull { block ->
-				block.markdownPattern.matchEntire(line)?.let { block to it }
+			// Markers peel before the body is classified, so a rule or image keeps
+			// a stacked blockquote (`> ---`), and a `- ---` line comes back as the
+			// rule it once was rather than a bullet holding literal dashes.
+			val peeled = peelLineBlocks(line)
+			val imageMatch = STANDALONE_IMAGE_REGEX.matchEntire(peeled.body)
+			// On a placeholder line only the styles that may stack there attach;
+			// a peeled list marker is dropped, not recorded.
+			val placeholderBlocks = peeled.blocks.filter { allowedOnPlaceholderLine(it) }
+			fun record(blocks: List<LineBlockStyle>) = blocks.forEach { block ->
+				blockHits.getOrPut(block) { mutableListOf() } += index
 			}
 			when {
-				line.trim() in HR_LINE_TOKENS -> {
+				peeled.body.trim() in HR_LINE_TOKENS -> {
 					hrLineIndices += index
+					record(placeholderBlocks)
 					HR_PLACEHOLDER
 				}
 
@@ -232,13 +294,13 @@ class MarkdownExtension(
 						alt = alt,
 						provider = provider,
 					)
+					record(placeholderBlocks)
 					IMAGE_PLACEHOLDER
 				}
 
-				blockMatch != null -> {
-					val (block, match) = blockMatch
-					blockHits.getOrPut(block) { mutableListOf() } += index
-					match.groupValues[1]
+				peeled.blocks.isNotEmpty() -> {
+					record(peeled.blocks)
+					peeled.body.escapeResidualMarker()
 				}
 
 				else -> line

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
@@ -10,7 +10,8 @@ import com.darkrockstudios.texteditor.richstyle.ImageProvider
 import com.darkrockstudios.texteditor.richstyle.LINE_BLOCK_STYLES
 import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
 import com.darkrockstudios.texteditor.richstyle.OrderedList
-import com.darkrockstudios.texteditor.richstyle.allowedOnPlaceholderLine
+import com.darkrockstudios.texteditor.richstyle.PlaceholderKind
+import com.darkrockstudios.texteditor.richstyle.allowedOn
 import com.darkrockstudios.texteditor.richstyle.applyDocumentBlocks
 import com.darkrockstudios.texteditor.richstyle.documentBlocksOf
 import com.darkrockstudios.texteditor.richstyle.hasLineBlock
@@ -102,7 +103,7 @@ private fun peelLineBlocks(line: String): PeeledLine {
 	var body = line
 	val peeled = mutableListOf<LineBlockStyle>()
 	for (block in LINE_BLOCK_STYLES) {
-		if (peeled.any { block in mutuallyExcluded(it) || it in mutuallyExcluded(block) }) continue
+		if (peeled.any { block in mutuallyExcluded(it) }) continue
 		val match = block.markdownPattern.matchEntire(body) ?: continue
 		peeled += block
 		body = match.groupValues[1]
@@ -110,7 +111,6 @@ private fun peelLineBlocks(line: String): PeeledLine {
 	return PeeledLine(body, peeled)
 }
 
-private val RESIDUAL_ORDERED_MARKER = Regex("""^(\d+)\.""")
 private val RESIDUAL_BULLET_MARKER = Regex("""^([-*+])(\s)""")
 private val RESIDUAL_QUOTE_MARKER = Regex("""^>""")
 
@@ -119,19 +119,20 @@ private val RESIDUAL_QUOTE_MARKER = Regex("""^>""")
  * every marker the line's spans account for, so whatever still looks like one is
  * literal text and must not reach the GFM parser bare, or it parses as markup
  * and the author's characters are consumed. The parser strips the escapes back
- * out via `removeMarkdownEscapes`.
+ * out via `removeMarkdownEscapes`. Ordered markers go through export's own
+ * escape helper so the two sides cannot drift apart.
  */
-private fun String.escapeResidualMarker(): String = when {
-	RESIDUAL_ORDERED_MARKER.containsMatchIn(this) ->
-		replaceFirst(RESIDUAL_ORDERED_MARKER, "$1\\\\.")
+private fun String.escapeResidualMarker(): String {
+	escapeOrderedListMarkers(this).let { if (it != this) return it }
+	return when {
+		RESIDUAL_BULLET_MARKER.containsMatchIn(this) ->
+			replaceFirst(RESIDUAL_BULLET_MARKER, "\\\\$1$2")
 
-	RESIDUAL_BULLET_MARKER.containsMatchIn(this) ->
-		replaceFirst(RESIDUAL_BULLET_MARKER, "\\\\$1$2")
+		RESIDUAL_QUOTE_MARKER.containsMatchIn(this) ->
+			replaceFirst(RESIDUAL_QUOTE_MARKER, "\\\\>")
 
-	RESIDUAL_QUOTE_MARKER.containsMatchIn(this) ->
-		replaceFirst(RESIDUAL_QUOTE_MARKER, "\\\\>")
-
-	else -> this
+		else -> this
+	}
 }
 
 /**
@@ -273,16 +274,15 @@ class MarkdownExtension(
 			// rule it once was rather than a bullet holding literal dashes.
 			val peeled = peelLineBlocks(line)
 			val imageMatch = STANDALONE_IMAGE_REGEX.matchEntire(peeled.body)
-			// On a placeholder line only the styles that may stack there attach;
-			// a peeled list marker is dropped, not recorded.
-			val placeholderBlocks = peeled.blocks.filter { allowedOnPlaceholderLine(it) }
 			fun record(blocks: List<LineBlockStyle>) = blocks.forEach { block ->
 				blockHits.getOrPut(block) { mutableListOf() } += index
 			}
 			when {
 				peeled.body.trim() in HR_LINE_TOKENS -> {
 					hrLineIndices += index
-					record(placeholderBlocks)
+					// A rule takes only a stacked quote; a peeled list marker has
+					// no meaning on one and is dropped.
+					record(peeled.blocks.filter { it.allowedOn(PlaceholderKind.OTHER) })
 					HR_PLACEHOLDER
 				}
 
@@ -294,7 +294,9 @@ class MarkdownExtension(
 						alt = alt,
 						provider = provider,
 					)
-					record(placeholderBlocks)
+					// An image can be a quoted line or a list item, so its
+					// peeled markers all attach (`1. ![shot](url)`).
+					record(peeled.blocks.filter { it.allowedOn(PlaceholderKind.IMAGE) })
 					IMAGE_PLACEHOLDER
 				}
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/DocumentBlocks.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/DocumentBlocks.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.texteditor.richstyle
 
+import androidx.compose.ui.text.AnnotatedString
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.state.TextEditorState
@@ -77,14 +78,28 @@ internal fun TextEditorState.applyDocumentBlocks(
 ) = withAtomicEdit {
 	val added = mutableListOf<RichSpan>()
 	val removed = mutableListOf<RichSpan>()
+	val lines = textLines.toMutableList()
+	var rebuiltAnyLine = false
+
+	// The GFM parser drops a lone leading space at document start, so a
+	// placeholder line at index 0 can arrive empty; restore the character the
+	// span's range addresses.
+	fun ensurePlaceholder(line: Int, placeholder: String) {
+		if (lines.getOrNull(line)?.isEmpty() == true) {
+			lines[line] = AnnotatedString(placeholder)
+			rebuiltAnyLine = true
+		}
+	}
 
 	horizontalRuleLines.forEach { line ->
+		ensurePlaceholder(line, HR_PLACEHOLDER)
 		added += RichSpan(
 			range = lineRange(line, HR_PLACEHOLDER.length),
 			style = HorizontalRuleSpanStyle,
 		)
 	}
 	imageLines.forEach { (line, style) ->
+		ensurePlaceholder(line, IMAGE_PLACEHOLDER)
 		added += RichSpan(range = lineRange(line, IMAGE_PLACEHOLDER.length), style = style)
 	}
 
@@ -98,8 +113,6 @@ internal fun TextEditorState.applyDocumentBlocks(
 		}
 	}
 
-	val lines = textLines.toMutableList()
-	var rebuiltAnyLine = false
 	for ((line, blocks) in requested) {
 		var text = lines.getOrNull(line) ?: continue
 		val present = ALL_BLOCK_STYLES.filter { hasLineBlock(line, it) }.toMutableList()

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockNormalization.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockNormalization.kt
@@ -3,27 +3,31 @@ package com.darkrockstudios.texteditor.richstyle
 import com.darkrockstudios.texteditor.state.DocumentSnapshot
 
 /**
- * Repairs line-block invariant violations in a revision about to be published:
- * a placeholder line (rule, image) may carry a [Blockquote] span but never a
- * list or fence span, because those have nothing to decorate there and their
- * markers do not survive a serialization round trip. Violating spans are
- * removed and their lines rebuilt without the orphaned indent.
+ * Repairs line-block invariant violations in a revision about to be published.
+ * A placeholder line (blank text owned by a full-line span) may carry a
+ * [Blockquote]; an image may also carry one list style; anything else is a
+ * marker with nothing to decorate that cannot survive a serialization round
+ * trip. Violating spans are removed and their lines rebuilt without the
+ * orphaned indent.
  *
  * Runs on every publish, from [com.darkrockstudios.texteditor.state.TextEditorState],
  * so the invariant holds no matter which path attached the span: a toggle, an
  * importer, smart Enter, a host app on the public span API, or span
- * re-anchoring after an edit. Returns the snapshot unchanged (no allocation)
- * when the document is already valid, which is the overwhelmingly common case.
+ * re-anchoring after an edit. The repair is deterministic and outside the undo
+ * history; since only blank lines classify as placeholders, the most it can
+ * ever discard is a marker on empty content. Returns the snapshot unchanged
+ * (no line allocation) when the document is already valid, the overwhelmingly
+ * common case.
  */
 internal fun normalizeLineBlocks(snapshot: DocumentSnapshot): DocumentSnapshot {
-	val placeholders = placeholderLines(snapshot.richSpans)
-	if (placeholders.isEmpty()) return snapshot
+	val kinds = placeholderKinds(snapshot.richSpans, snapshot.lines)
+	if (kinds.isEmpty()) return snapshot
 
 	val violations = snapshot.richSpans.mapNotNull { span ->
 		val block = ALL_BLOCK_STYLES.firstOrNull { it.spanStyle === span.style }
-		if (block != null && !allowedOnPlaceholderLine(block) &&
-			span.range.start.line in placeholders
-		) span to block else null
+			?: return@mapNotNull null
+		val kind = kinds[span.range.start.line] ?: return@mapNotNull null
+		if (block.allowedOn(kind)) null else span to block
 	}
 	if (violations.isEmpty()) return snapshot
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockNormalization.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockNormalization.kt
@@ -1,0 +1,36 @@
+package com.darkrockstudios.texteditor.richstyle
+
+import com.darkrockstudios.texteditor.state.DocumentSnapshot
+
+/**
+ * Repairs line-block invariant violations in a revision about to be published:
+ * a placeholder line (rule, image) may carry a [Blockquote] span but never a
+ * list or fence span, because those have nothing to decorate there and their
+ * markers do not survive a serialization round trip. Violating spans are
+ * removed and their lines rebuilt without the orphaned indent.
+ *
+ * Runs on every publish, from [com.darkrockstudios.texteditor.state.TextEditorState],
+ * so the invariant holds no matter which path attached the span: a toggle, an
+ * importer, smart Enter, a host app on the public span API, or span
+ * re-anchoring after an edit. Returns the snapshot unchanged (no allocation)
+ * when the document is already valid, which is the overwhelmingly common case.
+ */
+internal fun normalizeLineBlocks(snapshot: DocumentSnapshot): DocumentSnapshot {
+	val placeholders = placeholderLines(snapshot.richSpans)
+	if (placeholders.isEmpty()) return snapshot
+
+	val violations = snapshot.richSpans.mapNotNull { span ->
+		val block = ALL_BLOCK_STYLES.firstOrNull { it.spanStyle === span.style }
+		if (block != null && !allowedOnPlaceholderLine(block) &&
+			span.range.start.line in placeholders
+		) span to block else null
+	}
+	if (violations.isEmpty()) return snapshot
+
+	val lines = snapshot.lines.toMutableList()
+	violations.forEach { (span, block) ->
+		val line = span.range.start.line
+		lines.getOrNull(line)?.let { lines[line] = rebuildWithoutBlock(it, block) }
+	}
+	return DocumentSnapshot(lines, snapshot.richSpans - violations.map { it.first }.toSet())
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
@@ -121,6 +121,24 @@ internal fun mutuallyExcluded(applied: LineBlockStyle): Set<LineBlockStyle> = wh
 	else -> emptySet()
 }
 
+/**
+ * Whether [block] may sit on a placeholder line (a horizontal rule or an image,
+ * whose text is a placeholder owned by the full-line span). Blockquote may:
+ * `> ---` is legitimate markdown, and HTML nests `<hr>`/`<img>` inside
+ * `<blockquote>`. Lists and fences have nothing to number or fence there, and
+ * their markers cannot survive a serialization round trip.
+ */
+internal fun allowedOnPlaceholderLine(block: LineBlockStyle): Boolean = block === Blockquote
+
+/**
+ * The lines in [spans] whose text is a placeholder owned by a full-line block
+ * span (rule, image): every style where [BlockSpanStyle.replacesText] is true.
+ */
+internal fun placeholderLines(spans: Set<RichSpan>): Set<Int> =
+	spans.mapNotNullTo(mutableSetOf()) { span ->
+		span.range.start.line.takeIf { (span.style as? BlockSpanStyle)?.replacesText() == true }
+	}
+
 internal fun TextEditorState.hasLineBlock(line: Int, block: LineBlockStyle): Boolean =
 	richSpanManager.getRichSpansStartingOn(line).any { it.style === block.spanStyle }
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
@@ -122,22 +122,50 @@ internal fun mutuallyExcluded(applied: LineBlockStyle): Set<LineBlockStyle> = wh
 }
 
 /**
- * Whether [block] may sit on a placeholder line (a horizontal rule or an image,
- * whose text is a placeholder owned by the full-line span). Blockquote may:
- * `> ---` is legitimate markdown, and HTML nests `<hr>`/`<img>` inside
- * `<blockquote>`. Lists and fences have nothing to number or fence there, and
- * their markers cannot survive a serialization round trip.
+ * What owns a placeholder line, for stacking policy: an image can be a list
+ * item, any other full-line block (a rule) cannot.
  */
-internal fun allowedOnPlaceholderLine(block: LineBlockStyle): Boolean = block === Blockquote
+internal enum class PlaceholderKind { IMAGE, OTHER }
 
 /**
- * The lines in [spans] whose text is a placeholder owned by a full-line block
- * span (rule, image): every style where [BlockSpanStyle.replacesText] is true.
+ * The lines whose content is a placeholder owned by a full-line block span
+ * ([BlockSpanStyle.replacesText]) and whose text is still just that
+ * placeholder. A line holding real text is not a placeholder no matter which
+ * spans it carries: a line merge can re-anchor a rule's span onto a text line,
+ * and the text keeps its own formatting there.
  */
-internal fun placeholderLines(spans: Set<RichSpan>): Set<Int> =
-	spans.mapNotNullTo(mutableSetOf()) { span ->
-		span.range.start.line.takeIf { (span.style as? BlockSpanStyle)?.replacesText() == true }
+internal fun placeholderKinds(
+	spans: Set<RichSpan>,
+	lines: List<AnnotatedString>,
+): Map<Int, PlaceholderKind> {
+	val kinds = mutableMapOf<Int, PlaceholderKind>()
+	spans.forEach { span ->
+		if ((span.style as? BlockSpanStyle)?.replacesText() != true) return@forEach
+		val line = span.range.start.line
+		if (lines.getOrNull(line)?.isBlank() != true) return@forEach
+		val kind = if (span.style is ImageBlockSpanStyle) {
+			PlaceholderKind.IMAGE
+		} else {
+			PlaceholderKind.OTHER
+		}
+		// When two full-line spans share a line, the stricter policy applies.
+		if (kinds[line] != PlaceholderKind.OTHER) kinds[line] = kind
 	}
+	return kinds
+}
+
+/**
+ * Whether this block style may sit on a line of [kind]: null means an ordinary
+ * line (anything may), an image takes a stacked quote or one list style
+ * (`1. ![shot](url)` is a numbered figure), any other placeholder takes only a
+ * quote (`> ---`).
+ */
+internal fun LineBlockStyle.allowedOn(kind: PlaceholderKind?): Boolean = when {
+	kind == null -> true
+	this === Blockquote -> true
+	kind == PlaceholderKind.IMAGE -> this === BulletList || this === OrderedList
+	else -> false
+}
 
 internal fun TextEditorState.hasLineBlock(line: Int, block: LineBlockStyle): Boolean =
 	richSpanManager.getRichSpansStartingOn(line).any { it.style === block.spanStyle }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
@@ -9,10 +9,12 @@ import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.annotatedstring.splitAnnotatedString
 import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
 import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.richstyle.allowedOnPlaceholderLine
 import com.darkrockstudios.texteditor.richstyle.applyLineBlock
 import com.darkrockstudios.texteditor.richstyle.demoteLineBlock
 import com.darkrockstudios.texteditor.richstyle.hasLineBlock
 import com.darkrockstudios.texteditor.richstyle.lineBlockSpanStyles
+import com.darkrockstudios.texteditor.richstyle.placeholderLines
 import com.darkrockstudios.texteditor.richstyle.setLineBlockSpans
 import com.darkrockstudios.texteditor.utils.appendAnnotatedStrings
 import com.darkrockstudios.texteditor.utils.buildAnnotatedStringWithSpans
@@ -623,14 +625,25 @@ class TextEditManager(private val state: TextEditorState) {
 	/**
 	 * Captures each line's before/after content + block spans, applies the toggle
 	 * via the direct (non-recording) path, then records ONE atomic LineBlock entry.
+	 *
+	 * Acts on the in-range lines that can carry [block]: placeholder lines (rules,
+	 * images) count only for a blockquote toggle, the one style that stacks on
+	 * them. The toggle direction is decided from the same set, so a rule inside
+	 * the selection cannot wedge a list toggle into always-apply.
 	 */
 	internal fun toggleLineBlock(lines: IntRange, block: LineBlockStyle) = state.withAtomicEdit {
-		val anyOff = lines.any { !state.hasLineBlock(it, block) }
+		val placeholders = placeholderLines(state.richSpanManager.getAllRichSpans())
+		val targets = lines.filter { line ->
+			line in state.textLines.indices &&
+				(allowedOnPlaceholderLine(block) || line !in placeholders)
+		}
+		if (targets.isEmpty()) return@withAtomicEdit
+		val anyOff = targets.any { !state.hasLineBlock(it, block) }
 		val cursorBefore = state.cursorPosition
 
 		// The toggle mutates lines and spans here, before applyOperation records it;
 		// this outer transaction keeps that prelude out of public view too.
-		val changes = lines.map { lineIdx ->
+		val changes = targets.map { lineIdx ->
 			val contentBefore = state.getLine(lineIdx)
 			val spansBefore = state.lineBlockSpanStyles(lineIdx)
 			if (anyOff) {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
@@ -9,12 +9,12 @@ import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.annotatedstring.splitAnnotatedString
 import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
 import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
-import com.darkrockstudios.texteditor.richstyle.allowedOnPlaceholderLine
+import com.darkrockstudios.texteditor.richstyle.allowedOn
 import com.darkrockstudios.texteditor.richstyle.applyLineBlock
 import com.darkrockstudios.texteditor.richstyle.demoteLineBlock
 import com.darkrockstudios.texteditor.richstyle.hasLineBlock
 import com.darkrockstudios.texteditor.richstyle.lineBlockSpanStyles
-import com.darkrockstudios.texteditor.richstyle.placeholderLines
+import com.darkrockstudios.texteditor.richstyle.placeholderKinds
 import com.darkrockstudios.texteditor.richstyle.setLineBlockSpans
 import com.darkrockstudios.texteditor.utils.appendAnnotatedStrings
 import com.darkrockstudios.texteditor.utils.buildAnnotatedStringWithSpans
@@ -626,16 +626,15 @@ class TextEditManager(private val state: TextEditorState) {
 	 * Captures each line's before/after content + block spans, applies the toggle
 	 * via the direct (non-recording) path, then records ONE atomic LineBlock entry.
 	 *
-	 * Acts on the in-range lines that can carry [block]: placeholder lines (rules,
-	 * images) count only for a blockquote toggle, the one style that stacks on
-	 * them. The toggle direction is decided from the same set, so a rule inside
-	 * the selection cannot wedge a list toggle into always-apply.
+	 * Acts on the in-range lines that can carry [block]: placeholder lines count
+	 * for the styles that stack on them (blockquote on any, a list style on an
+	 * image, nothing else). The toggle direction is decided from the same set, so
+	 * a rule inside the selection cannot wedge a list toggle into always-apply.
 	 */
 	internal fun toggleLineBlock(lines: IntRange, block: LineBlockStyle) = state.withAtomicEdit {
-		val placeholders = placeholderLines(state.richSpanManager.getAllRichSpans())
+		val kinds = placeholderKinds(state.richSpanManager.getAllRichSpans(), state.textLines)
 		val targets = lines.filter { line ->
-			line in state.textLines.indices &&
-				(allowedOnPlaceholderLine(block) || line !in placeholders)
+			line in state.textLines.indices && block.allowedOn(kinds[line])
 		}
 		if (targets.isEmpty()) return@withAtomicEdit
 		val anyOff = targets.any { !state.hasLineBlock(it, block) }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -37,6 +37,7 @@ import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
 import com.darkrockstudios.texteditor.richstyle.applyLineBlock
 import com.darkrockstudios.texteditor.richstyle.demoteLineBlock
 import com.darkrockstudios.texteditor.richstyle.detectLineBlock
+import com.darkrockstudios.texteditor.richstyle.normalizeLineBlocks
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -175,7 +176,9 @@ class TextEditorState(
 		draft = content
 		try {
 			val result = block()
-			draft?.let { content = it }
+			// Every publish passes through line-block normalization, so no caller
+			// can commit a revision violating the placeholder-line invariant.
+			draft?.let { content = normalizeLineBlocks(it) }
 			return result
 		} finally {
 			draft = null
@@ -197,7 +200,13 @@ class TextEditorState(
 	}
 
 	private fun mutateContent(transform: (DocumentSnapshot) -> DocumentSnapshot) {
-		if (draft != null) draft = transform(workingContent) else content = transform(content)
+		// The no-draft branch publishes directly, so it normalizes like a commit;
+		// drafted mutations wait for the transaction's own commit to normalize once.
+		if (draft != null) {
+			draft = transform(workingContent)
+		} else {
+			content = normalizeLineBlocks(transform(content))
+		}
 	}
 
 	/**

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -177,8 +177,9 @@ class TextEditorState(
 		try {
 			val result = block()
 			// Every publish passes through line-block normalization, so no caller
-			// can commit a revision violating the placeholder-line invariant.
-			draft?.let { content = normalizeLineBlocks(it) }
+			// can commit a revision violating the placeholder-line invariant. A
+			// transaction that mutated nothing skips the scan and the republish.
+			draft?.let { if (it !== content) content = normalizeLineBlocks(it) }
 			return result
 		} finally {
 			draft = null

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/LineBlockToggleE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/LineBlockToggleE2eTest.kt
@@ -1,0 +1,123 @@
+package e2e
+
+import androidx.compose.ui.input.key.Key
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.markdown.withMarkdown
+import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import utils.EditorUiTestScope
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * A block toggle applied to a real select-all, driven through the composed
+ * editor: keyboard selection, the selection-to-line-range mapping a host app
+ * performs, the toggle, and the markdown that gets saved. This is the full
+ * pipeline of issue #43's report, where the toggle is applied to a whole
+ * document containing blank separators and a horizontal rule.
+ */
+class LineBlockToggleE2eTest {
+
+	private fun TextEditorState.linesWith(style: RichSpanStyle): List<Int> =
+		richSpanManager.getAllRichSpans()
+			.filter { it.style === style }
+			.map { it.range.start.line }
+			.sorted()
+
+	/** The selection-to-lines mapping host apps use for their toolbar toggles. */
+	private fun EditorUiTestScope.selectedLines(): IntRange {
+		val selection = state.selector.selection
+		assertNotNull(selection, "expected an active selection")
+		return selection.start.line..selection.end.line
+	}
+
+	private fun EditorUiTestScope.importDocument(markdown: MarkdownExtension, text: String) {
+		markdown.importMarkdown(text)
+		waitForIdle()
+	}
+
+	private val document = "Chapter One\n\nShe walked in.\n\n---\n\nThe end."
+
+	@Test
+	fun `select-all bullet toggle bullets the prose and spares the rule`() = editorUiTest {
+		val markdown = state.withMarkdown()
+		importDocument(markdown, document)
+
+		press(Key.A, ctrl = true)
+		markdown.toggleBulletList(selectedLines())
+		waitForIdle()
+
+		assertEquals(listOf(0, 1, 2, 3, 5, 6), state.linesWith(BulletListSpanStyle))
+		assertEquals(listOf(4), state.linesWith(HorizontalRuleSpanStyle))
+		assertEquals(
+			"- Chapter One\n- \n- She walked in.\n- \n---\n- \n- The end.",
+			markdown.exportAsMarkdown(),
+		)
+	}
+
+	@Test
+	fun `select-all bullet toggle twice restores the saved document`() = editorUiTest {
+		val markdown = state.withMarkdown()
+		importDocument(markdown, document)
+
+		press(Key.A, ctrl = true)
+		markdown.toggleBulletList(selectedLines())
+		press(Key.A, ctrl = true)
+		markdown.toggleBulletList(selectedLines())
+		waitForIdle()
+
+		assertTrue(state.linesWith(BulletListSpanStyle).isEmpty())
+		assertEquals(document, markdown.exportAsMarkdown())
+	}
+
+	@Test
+	fun `select-all bullet toggle survives a save and reload`() = editorUiTest {
+		val markdown = state.withMarkdown()
+		importDocument(markdown, document)
+
+		press(Key.A, ctrl = true)
+		markdown.toggleBulletList(selectedLines())
+		val saved = markdown.exportAsMarkdown()
+
+		importDocument(markdown, saved)
+
+		assertEquals(listOf(4), state.linesWith(HorizontalRuleSpanStyle))
+		assertEquals(saved, markdown.exportAsMarkdown())
+	}
+
+	@Test
+	fun `select-all quote toggle wraps the whole document including the rule`() = editorUiTest {
+		val markdown = state.withMarkdown()
+		importDocument(markdown, document)
+
+		press(Key.A, ctrl = true)
+		markdown.toggleBlockquote(selectedLines())
+		waitForIdle()
+
+		assertEquals(listOf(0, 1, 2, 3, 4, 5, 6), state.linesWith(BlockquoteSpanStyle))
+		assertEquals(
+			"> Chapter One\n> \n> She walked in.\n> \n> ---\n> \n> The end.",
+			markdown.exportAsMarkdown(),
+		)
+	}
+
+	@Test
+	fun `undo after a select-all bullet toggle restores the document`() = editorUiTest {
+		val markdown = state.withMarkdown()
+		importDocument(markdown, document)
+
+		press(Key.A, ctrl = true)
+		markdown.toggleBulletList(selectedLines())
+		press(Key.Z, ctrl = true)
+		waitForIdle()
+
+		assertTrue(state.linesWith(BulletListSpanStyle).isEmpty())
+		assertEquals(document, markdown.exportAsMarkdown())
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/BulletListSerializationTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/BulletListSerializationTest.kt
@@ -144,6 +144,63 @@ class BulletListSerializationTest {
 	}
 
 	@Test
+	fun `import peels a bullet marker stacked inside a blockquote`() = runTest {
+		// Quote stacks with a list, so `> - item` carries two markers; both peel,
+		// leaving the body as the document text.
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("> - quoted item")
+
+		assertEquals("quoted item", extension.editorState.getAllText().text)
+		assertEquals(listOf(0), extension.bulletLines())
+	}
+
+	@Test
+	fun `roundtrip preserves a bullet stacked inside a blockquote`() = runTest {
+		val extension = createMarkdownExtension()
+		val original = "> - quoted item"
+		extension.importMarkdown(original)
+		assertEquals(original, extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `import keeps a nested blockquote marker as body text`() = runTest {
+		// Each style peels at most once; a second quote level is not representable,
+		// so its marker stays in the body.
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("> > quoted")
+
+		assertEquals("> quoted", extension.editorState.getAllText().text)
+		assertTrue(extension.bulletLines().isEmpty())
+	}
+
+	@Test
+	fun `import keeps an ordered lookalike inside a bullet body`() = runTest {
+		// The two list styles are mutually exclusive, so after the bullet peels,
+		// a numeral-period lead is the author's text, not a second marker.
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("- 1990. The year everything changed")
+
+		assertEquals("1990. The year everything changed", extension.editorState.getAllText().text)
+		assertEquals(listOf(0), extension.bulletLines())
+	}
+
+	@Test
+	fun `roundtrip preserves an ordered lookalike inside a bullet body`() = runTest {
+		// Export escapes the numeral-period lead (`- 1990\. ...`) so no parser can
+		// read it as a second marker; the text and the bullet survive unchanged and
+		// the serialized form is stable from the first save.
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("- 1990. The year everything changed")
+		val exported = extension.exportAsMarkdown()
+
+		extension.importMarkdown(exported)
+
+		assertEquals("1990. The year everything changed", extension.editorState.getAllText().text)
+		assertEquals(listOf(0), extension.bulletLines())
+		assertEquals(exported, extension.exportAsMarkdown())
+	}
+
+	@Test
 	fun `roundtrip preserves bold inside bullet`() = runTest {
 		val extension = createMarkdownExtension()
 		val original = "- **bold** in item"

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/LineBlockRoundTripPropertyTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/LineBlockRoundTripPropertyTest.kt
@@ -6,6 +6,9 @@ import com.darkrockstudios.texteditor.markdown.MarkdownExtension
 import com.darkrockstudios.texteditor.richstyle.Blockquote
 import com.darkrockstudios.texteditor.richstyle.BulletList
 import com.darkrockstudios.texteditor.richstyle.HR_PLACEHOLDER
+import com.darkrockstudios.texteditor.richstyle.IMAGE_PLACEHOLDER
+import com.darkrockstudios.texteditor.richstyle.ImageBlockSpanStyle
+import com.darkrockstudios.texteditor.richstyle.InMemoryImageProvider
 import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
 import com.darkrockstudios.texteditor.richstyle.OrderedList
 import com.darkrockstudios.texteditor.richstyle.applyDocumentBlocks
@@ -29,7 +32,8 @@ class LineBlockRoundTripPropertyTest {
 
 	private data class GeneratedLine(
 		val text: String,
-		val isRule: Boolean,
+		val isRule: Boolean = false,
+		val isImage: Boolean = false,
 		val quote: Boolean,
 		val list: LineBlockStyle?,
 	)
@@ -50,25 +54,32 @@ class LineBlockRoundTripPropertyTest {
 	)
 
 	private fun generateLine(random: Random): GeneratedLine {
-		if (random.nextInt(8) == 0) {
-			return GeneratedLine(
-				text = HR_PLACEHOLDER,
-				isRule = true,
-				quote = random.nextBoolean(),
-				list = null,
-			)
-		}
 		val list = when (random.nextInt(4)) {
 			0 -> BulletList
 			1 -> OrderedList
 			else -> null
 		}
-		return GeneratedLine(
-			text = bodyPool.random(random),
-			isRule = false,
-			quote = random.nextInt(3) == 0,
-			list = list,
-		)
+		return when (random.nextInt(10)) {
+			0 -> GeneratedLine(
+				text = HR_PLACEHOLDER,
+				isRule = true,
+				quote = random.nextBoolean(),
+				list = null,
+			)
+
+			1 -> GeneratedLine(
+				text = IMAGE_PLACEHOLDER,
+				isImage = true,
+				quote = random.nextBoolean(),
+				list = list,
+			)
+
+			else -> GeneratedLine(
+				text = bodyPool.random(random),
+				quote = random.nextInt(3) == 0,
+				list = list,
+			)
+		}
 	}
 
 	private fun TestScope.buildDocument(lines: List<GeneratedLine>): MarkdownExtension {
@@ -77,10 +88,16 @@ class LineBlockRoundTripPropertyTest {
 			measurer = mockk(relaxed = true),
 			initialText = null as AnnotatedString?,
 		)
-		val extension = MarkdownExtension(state, MarkdownConfiguration.DEFAULT)
+		val provider = InMemoryImageProvider()
+		val extension = MarkdownExtension(state, MarkdownConfiguration.DEFAULT, imageProvider = provider)
 		state.setText(AnnotatedString(lines.joinToString("\n") { it.text }))
 		state.applyDocumentBlocks(
 			horizontalRuleLines = lines.withIndex().filter { it.value.isRule }.map { it.index },
+			imageLines = lines.withIndex()
+				.filter { it.value.isImage }
+				.associate { (index, _) ->
+					index to ImageBlockSpanStyle(source = "img.png", alt = "alt", provider = provider)
+				},
 			blockLines = mapOf(
 				Blockquote to lines.withIndex().filter { it.value.quote }.map { it.index },
 				BulletList to lines.withIndex()

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/LineBlockRoundTripPropertyTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/LineBlockRoundTripPropertyTest.kt
@@ -1,0 +1,132 @@
+package markdown
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.Blockquote
+import com.darkrockstudios.texteditor.richstyle.BulletList
+import com.darkrockstudios.texteditor.richstyle.HR_PLACEHOLDER
+import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
+import com.darkrockstudios.texteditor.richstyle.OrderedList
+import com.darkrockstudios.texteditor.richstyle.applyDocumentBlocks
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The serialization contract, checked over generated documents instead of
+ * hand-picked examples: exporting a valid document and importing the result
+ * preserves the text and the block placement, and a second export equals the
+ * first. Line bodies are drawn from a pool that includes marker lookalikes
+ * (`1990. plans`, `- dash lead`, `---`) precisely because those are the shapes
+ * that corrupt when escaping or marker peeling has a hole.
+ */
+class LineBlockRoundTripPropertyTest {
+
+	private data class GeneratedLine(
+		val text: String,
+		val isRule: Boolean,
+		val quote: Boolean,
+		val list: LineBlockStyle?,
+	)
+
+	private val bodyPool = listOf(
+		"plain prose line",
+		"she walked into the room",
+		"",
+		"1990. The year everything changed",
+		"1. Introduction",
+		"- dash lead",
+		"* star lead",
+		"+ plus lead",
+		"> angle lead",
+		"---",
+		"a - b in the middle",
+		"trailing marker -",
+	)
+
+	private fun generateLine(random: Random): GeneratedLine {
+		if (random.nextInt(8) == 0) {
+			return GeneratedLine(
+				text = HR_PLACEHOLDER,
+				isRule = true,
+				quote = random.nextBoolean(),
+				list = null,
+			)
+		}
+		val list = when (random.nextInt(4)) {
+			0 -> BulletList
+			1 -> OrderedList
+			else -> null
+		}
+		return GeneratedLine(
+			text = bodyPool.random(random),
+			isRule = false,
+			quote = random.nextInt(3) == 0,
+			list = list,
+		)
+	}
+
+	private fun TestScope.buildDocument(lines: List<GeneratedLine>): MarkdownExtension {
+		val state = TextEditorState(
+			scope = this,
+			measurer = mockk(relaxed = true),
+			initialText = null as AnnotatedString?,
+		)
+		val extension = MarkdownExtension(state, MarkdownConfiguration.DEFAULT)
+		state.setText(AnnotatedString(lines.joinToString("\n") { it.text }))
+		state.applyDocumentBlocks(
+			horizontalRuleLines = lines.withIndex().filter { it.value.isRule }.map { it.index },
+			blockLines = mapOf(
+				Blockquote to lines.withIndex().filter { it.value.quote }.map { it.index },
+				BulletList to lines.withIndex()
+					.filter { it.value.list === BulletList }.map { it.index },
+				OrderedList to lines.withIndex()
+					.filter { it.value.list === OrderedList }.map { it.index },
+			),
+		)
+		return extension
+	}
+
+	private fun MarkdownExtension.blockPlacement(): Map<String, List<Int>> {
+		val spans = editorState.richSpanManager.getAllRichSpans()
+		return spans.groupBy { it.style::class.simpleName ?: "?" }
+			.mapValues { (_, group) -> group.map { it.range.start.line }.sorted() }
+	}
+
+	@Test
+	fun `export then import preserves text and blocks over generated documents`() = runTest {
+		val random = Random(20260801)
+		repeat(200) { iteration ->
+			val lines = List(random.nextInt(1, 10)) { generateLine(random) }
+			val extension = buildDocument(lines)
+
+			val expectedText = extension.editorState.getAllText().text
+			val expectedBlocks = extension.blockPlacement()
+			val exported = extension.exportAsMarkdown()
+
+			extension.importMarkdown(exported)
+
+			val context = "iteration $iteration\n--- exported ---\n$exported"
+			assertEquals(
+				expectedText,
+				extension.editorState.getAllText().text,
+				"text drifted: $context",
+			)
+			assertEquals(
+				expectedBlocks,
+				extension.blockPlacement(),
+				"blocks drifted: $context",
+			)
+			assertEquals(
+				exported,
+				extension.exportAsMarkdown(),
+				"second export drifted: $context",
+			)
+		}
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/LineBlockSweepTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/LineBlockSweepTest.kt
@@ -1,0 +1,200 @@
+package markdown
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.richstyle.CodeFenceSpanStyle
+import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Multi-line block toggles act on every selected line that can carry the style:
+ * blank lines are included (an empty list item, as in Word and Google Docs) and
+ * placeholder lines (rules, images) are excluded for every style except
+ * blockquote, the one style that stacks on them. The toggle direction is decided
+ * from the same set of lines, so both directions always reach every line they
+ * could change.
+ */
+class LineBlockSweepTest {
+
+	private fun TestScope.createMarkdownExtension(): MarkdownExtension {
+		val state = TextEditorState(
+			scope = this,
+			measurer = mockk(relaxed = true),
+			initialText = null as AnnotatedString?,
+		)
+		return MarkdownExtension(state, MarkdownConfiguration.DEFAULT)
+	}
+
+	private fun MarkdownExtension.selectAll(): IntRange = 0..editorState.textLines.lastIndex
+
+	private fun MarkdownExtension.linesWith(style: RichSpanStyle): List<Int> =
+		editorState.richSpanManager.getAllRichSpans()
+			.filter { it.style === style }
+			.map { it.range.start.line }
+			.sorted()
+
+	@Test
+	fun `select-all bullet includes blank separator lines as empty items`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("Chapter One\n\nShe walked in.")
+
+		extension.toggleBulletList(extension.selectAll())
+
+		assertEquals(listOf(0, 1, 2), extension.linesWith(BulletListSpanStyle))
+		assertEquals("- Chapter One\n- \n- She walked in.", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `select-all bullet twice returns to the original document`() = runTest {
+		val extension = createMarkdownExtension()
+		val original = "Chapter One\n\nShe walked in."
+		extension.importMarkdown(original)
+
+		extension.toggleBulletList(extension.selectAll())
+		extension.toggleBulletList(extension.selectAll())
+
+		assertTrue(extension.linesWith(BulletListSpanStyle).isEmpty())
+		assertEquals(original, extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `select-all clear removes a bullet from a blank line`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("- one\n- \n- two")
+		assertEquals(listOf(0, 1, 2), extension.linesWith(BulletListSpanStyle))
+
+		extension.toggleBulletList(extension.selectAll())
+
+		assertTrue(extension.linesWith(BulletListSpanStyle).isEmpty())
+		assertEquals("one\n\ntwo", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `select-all ordered list numbers contiguously across blank lines`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("First\n\nSecond\n\nThird")
+
+		extension.toggleOrderedList(extension.selectAll())
+
+		assertEquals(
+			"1. First\n2. \n3. Second\n4. \n5. Third",
+			extension.exportAsMarkdown(),
+		)
+	}
+
+	@Test
+	fun `select-all fence keeps a snippet with blank lines as one fence`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("fun a() {}\n\nfun b() {}")
+
+		extension.toggleCodeFence(extension.selectAll())
+
+		assertEquals(listOf(0, 1, 2), extension.linesWith(CodeFenceSpanStyle))
+		assertEquals("```\nfun a() {}\n\nfun b() {}\n```", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `select-all bullet leaves a horizontal rule untouched`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("before\n---\nafter")
+
+		extension.toggleBulletList(extension.selectAll())
+
+		assertEquals(listOf(0, 2), extension.linesWith(BulletListSpanStyle))
+		assertEquals(listOf(1), extension.linesWith(HorizontalRuleSpanStyle))
+		assertEquals("- before\n---\n- after", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `select-all bullet across a rule survives a save and reload`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("before\n---\nafter")
+		extension.toggleBulletList(extension.selectAll())
+		val saved = extension.exportAsMarkdown()
+
+		extension.importMarkdown(saved)
+
+		assertEquals(listOf(1), extension.linesWith(HorizontalRuleSpanStyle))
+		assertEquals(saved, extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `select-all bullet twice across a rule clears every bullet`() = runTest {
+		val extension = createMarkdownExtension()
+		val original = "before\n---\nafter"
+		extension.importMarkdown(original)
+
+		extension.toggleBulletList(extension.selectAll())
+		extension.toggleBulletList(extension.selectAll())
+
+		assertTrue(extension.linesWith(BulletListSpanStyle).isEmpty())
+		assertEquals(original, extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `select-all quote includes the rule line`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("before\n---\nafter")
+
+		extension.toggleBlockquote(extension.selectAll())
+
+		assertEquals(listOf(0, 1, 2), extension.linesWith(BlockquoteSpanStyle))
+		assertEquals(listOf(1), extension.linesWith(HorizontalRuleSpanStyle))
+		assertEquals("> before\n> ---\n> after", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `bullet sweep over only rule lines is a no-op`() = runTest {
+		val extension = createMarkdownExtension()
+		val original = "before\n---\n---\nafter"
+		extension.importMarkdown(original)
+
+		extension.toggleBulletList(1..2)
+
+		assertTrue(extension.linesWith(BulletListSpanStyle).isEmpty())
+		assertEquals(original, extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `sweep past the end of the document acts on the lines that exist`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("one\ntwo")
+
+		extension.toggleBulletList(0..9)
+
+		assertEquals(listOf(0, 1), extension.linesWith(BulletListSpanStyle))
+	}
+
+	@Test
+	fun `single-line toggle on a blank line makes an empty item`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("one\n\ntwo")
+
+		extension.toggleBulletList(1..1)
+
+		assertEquals(listOf(1), extension.linesWith(BulletListSpanStyle))
+	}
+
+	@Test
+	fun `undo restores the document after a select-all sweep`() = runTest {
+		val extension = createMarkdownExtension()
+		val original = "Chapter One\n\nShe walked in."
+		extension.importMarkdown(original)
+
+		extension.toggleBulletList(extension.selectAll())
+		extension.editorState.undo()
+
+		assertTrue(extension.linesWith(BulletListSpanStyle).isEmpty())
+		assertEquals(original, extension.exportAsMarkdown())
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/LineBlockSweepTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/LineBlockSweepTest.kt
@@ -7,7 +7,7 @@ import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
 import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
 import com.darkrockstudios.texteditor.richstyle.CodeFenceSpanStyle
 import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
-import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.richstyle.InMemoryImageProvider
 import com.darkrockstudios.texteditor.state.TextEditorState
 import io.mockk.mockk
 import kotlinx.coroutines.test.TestScope
@@ -18,30 +18,25 @@ import kotlin.test.assertTrue
 
 /**
  * Multi-line block toggles act on every selected line that can carry the style:
- * blank lines are included (an empty list item, as in Word and Google Docs) and
- * placeholder lines (rules, images) are excluded for every style except
- * blockquote, the one style that stacks on them. The toggle direction is decided
- * from the same set of lines, so both directions always reach every line they
- * could change.
+ * blank lines are included (an empty list item, as in Word and Google Docs),
+ * rule lines count only for blockquote, and image lines count for blockquote
+ * and the list styles. The toggle direction is decided from the same set of
+ * lines, so both directions always reach every line they could change.
  */
 class LineBlockSweepTest {
 
-	private fun TestScope.createMarkdownExtension(): MarkdownExtension {
+	private fun TestScope.createMarkdownExtension(
+		provider: InMemoryImageProvider? = null,
+	): MarkdownExtension {
 		val state = TextEditorState(
 			scope = this,
 			measurer = mockk(relaxed = true),
 			initialText = null as AnnotatedString?,
 		)
-		return MarkdownExtension(state, MarkdownConfiguration.DEFAULT)
+		return MarkdownExtension(state, MarkdownConfiguration.DEFAULT, imageProvider = provider)
 	}
 
 	private fun MarkdownExtension.selectAll(): IntRange = 0..editorState.textLines.lastIndex
-
-	private fun MarkdownExtension.linesWith(style: RichSpanStyle): List<Int> =
-		editorState.richSpanManager.getAllRichSpans()
-			.filter { it.style === style }
-			.map { it.range.start.line }
-			.sorted()
 
 	@Test
 	fun `select-all bullet includes blank separator lines as empty items`() = runTest {
@@ -151,6 +146,20 @@ class LineBlockSweepTest {
 		assertEquals(listOf(0, 1, 2), extension.linesWith(BlockquoteSpanStyle))
 		assertEquals(listOf(1), extension.linesWith(HorizontalRuleSpanStyle))
 		assertEquals("> before\n> ---\n> after", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `select-all bullet includes image lines`() = runTest {
+		val extension = createMarkdownExtension(provider = InMemoryImageProvider())
+		extension.importMarkdown("before\n![alt](img.png)\nafter")
+
+		extension.toggleBulletList(extension.selectAll())
+
+		assertEquals(listOf(0, 1, 2), extension.linesWith(BulletListSpanStyle))
+		assertEquals(
+			"- before\n- ![alt](img.png)\n- after",
+			extension.exportAsMarkdown(),
+		)
 	}
 
 	@Test

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/LineBlockTestHelpers.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/LineBlockTestHelpers.kt
@@ -1,0 +1,19 @@
+package markdown
+
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.ImageBlockSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+
+/** The lines currently carrying a rich span of exactly [style], sorted. */
+internal fun MarkdownExtension.linesWith(style: RichSpanStyle): List<Int> =
+	editorState.richSpanManager.getAllRichSpans()
+		.filter { it.style === style }
+		.map { it.range.start.line }
+		.sorted()
+
+/** The lines currently carrying an image block span, sorted. */
+internal fun MarkdownExtension.imageLines(): List<Int> =
+	editorState.richSpanManager.getAllRichSpans()
+		.filter { it.style is ImageBlockSpanStyle }
+		.map { it.range.start.line }
+		.sorted()

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/PlaceholderLineBlockTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/PlaceholderLineBlockTest.kt
@@ -10,9 +10,8 @@ import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
 import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
 import com.darkrockstudios.texteditor.richstyle.HR_PLACEHOLDER
 import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
-import com.darkrockstudios.texteditor.richstyle.ImageBlockSpanStyle
 import com.darkrockstudios.texteditor.richstyle.InMemoryImageProvider
-import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.richstyle.OrderedListSpanStyle
 import com.darkrockstudios.texteditor.state.TextEditorState
 import io.mockk.mockk
 import kotlinx.coroutines.test.TestScope
@@ -22,10 +21,13 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * Placeholder lines (horizontal rules, images) own their line through a
- * placeholder character. A blockquote may stack on one, serialized as `> ---`
- * or `> ![alt](src)`; list and fence spans may not, and every publish strips
- * them via normalization no matter which path attached them.
+ * Placeholder lines own their content through a placeholder character and a
+ * full-line span. A blockquote may stack on any of them (`> ---`,
+ * `> ![alt](src)`); an image may also be a list item (`1. ![shot](url)`); any
+ * other combination is stripped at publish by normalization, no matter which
+ * path attached it. A line only classifies as a placeholder while its text is
+ * blank, so a span re-anchored onto real text never costs that text its own
+ * formatting.
  */
 class PlaceholderLineBlockTest {
 
@@ -39,18 +41,6 @@ class PlaceholderLineBlockTest {
 		)
 		return MarkdownExtension(state, MarkdownConfiguration.DEFAULT, imageProvider = provider)
 	}
-
-	private fun MarkdownExtension.linesWith(style: RichSpanStyle): List<Int> =
-		editorState.richSpanManager.getAllRichSpans()
-			.filter { it.style === style }
-			.map { it.range.start.line }
-			.sorted()
-
-	private fun MarkdownExtension.imageLines(): List<Int> =
-		editorState.richSpanManager.getAllRichSpans()
-			.filter { it.style is ImageBlockSpanStyle }
-			.map { it.range.start.line }
-			.sorted()
 
 	@Test
 	fun `import reads a rule inside a blockquote`() = runTest {
@@ -112,9 +102,25 @@ class PlaceholderLineBlockTest {
 	}
 
 	@Test
-	fun `normalization strips a bullet when a rule span lands on its line`() = runTest {
+	fun `a rule span landing on a text line leaves the line's bullet alone`() = runTest {
+		// The line still holds real text, so it is not a placeholder and the
+		// text keeps its own formatting.
 		val extension = createMarkdownExtension()
 		extension.importMarkdown("- item")
+		val state = extension.editorState
+
+		state.addRichSpan(
+			TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 1)),
+			HorizontalRuleSpanStyle,
+		)
+
+		assertEquals(listOf(0), extension.linesWith(BulletListSpanStyle))
+	}
+
+	@Test
+	fun `normalization strips a bullet when a rule span lands on a blank line`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("- ")
 		assertEquals(listOf(0), extension.linesWith(BulletListSpanStyle))
 		val state = extension.editorState
 
@@ -124,6 +130,47 @@ class PlaceholderLineBlockTest {
 		)
 
 		assertTrue(extension.linesWith(BulletListSpanStyle).isEmpty())
+	}
+
+	@Test
+	fun `merging a rule line into a bullet line keeps the bullet`() = runTest {
+		// The delete pulls the rule's span onto the text line; the merged line is
+		// not a placeholder, so the bullet and its indent survive.
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("- item\n---")
+		val state = extension.editorState
+
+		state.delete(
+			TextEditorRange(CharLineOffset(0, 4), CharLineOffset(1, 0)),
+		)
+
+		assertEquals(1, state.textLines.size)
+		assertEquals(listOf(0), extension.linesWith(BulletListSpanStyle))
+	}
+
+	@Test
+	fun `import reads a numbered image list`() = runTest {
+		val extension = createMarkdownExtension(provider = InMemoryImageProvider())
+		extension.importMarkdown("1. ![shot1](u1.png)\n2. ![shot2](u2.png)")
+
+		assertEquals(listOf(0, 1), extension.imageLines())
+		assertEquals(listOf(0, 1), extension.linesWith(OrderedListSpanStyle))
+	}
+
+	@Test
+	fun `roundtrip preserves a numbered image list`() = runTest {
+		val extension = createMarkdownExtension(provider = InMemoryImageProvider())
+		val original = "1. ![shot1](u1.png)\n2. ![shot2](u2.png)"
+		extension.importMarkdown(original)
+		assertEquals(original, extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `roundtrip preserves a bulleted image`() = runTest {
+		val extension = createMarkdownExtension(provider = InMemoryImageProvider())
+		val original = "- ![alt](img.png)"
+		extension.importMarkdown(original)
+		assertEquals(original, extension.exportAsMarkdown())
 	}
 
 	@Test

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/PlaceholderLineBlockTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/PlaceholderLineBlockTest.kt
@@ -1,0 +1,157 @@
+package markdown
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.html.withHtml
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.richstyle.HR_PLACEHOLDER
+import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
+import com.darkrockstudios.texteditor.richstyle.ImageBlockSpanStyle
+import com.darkrockstudios.texteditor.richstyle.InMemoryImageProvider
+import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Placeholder lines (horizontal rules, images) own their line through a
+ * placeholder character. A blockquote may stack on one, serialized as `> ---`
+ * or `> ![alt](src)`; list and fence spans may not, and every publish strips
+ * them via normalization no matter which path attached them.
+ */
+class PlaceholderLineBlockTest {
+
+	private fun TestScope.createMarkdownExtension(
+		provider: InMemoryImageProvider? = null,
+	): MarkdownExtension {
+		val state = TextEditorState(
+			scope = this,
+			measurer = mockk(relaxed = true),
+			initialText = null as AnnotatedString?,
+		)
+		return MarkdownExtension(state, MarkdownConfiguration.DEFAULT, imageProvider = provider)
+	}
+
+	private fun MarkdownExtension.linesWith(style: RichSpanStyle): List<Int> =
+		editorState.richSpanManager.getAllRichSpans()
+			.filter { it.style === style }
+			.map { it.range.start.line }
+			.sorted()
+
+	private fun MarkdownExtension.imageLines(): List<Int> =
+		editorState.richSpanManager.getAllRichSpans()
+			.filter { it.style is ImageBlockSpanStyle }
+			.map { it.range.start.line }
+			.sorted()
+
+	@Test
+	fun `import reads a rule inside a blockquote`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("> above\n> ---\n> below")
+
+		assertEquals(listOf(0, 1, 2), extension.linesWith(BlockquoteSpanStyle))
+		assertEquals(listOf(1), extension.linesWith(HorizontalRuleSpanStyle))
+		assertEquals("above\n$HR_PLACEHOLDER\nbelow", extension.editorState.getAllText().text)
+	}
+
+	@Test
+	fun `roundtrip preserves a rule inside a blockquote`() = runTest {
+		val extension = createMarkdownExtension()
+		val original = "> above\n> ---\n> below"
+		extension.importMarkdown(original)
+		assertEquals(original, extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `import reads an image inside a blockquote`() = runTest {
+		val extension = createMarkdownExtension(provider = InMemoryImageProvider())
+		extension.importMarkdown("> intro\n> ![alt](img.png)")
+
+		assertEquals(listOf(0, 1), extension.linesWith(BlockquoteSpanStyle))
+		assertEquals(listOf(1), extension.imageLines())
+	}
+
+	@Test
+	fun `roundtrip preserves an image inside a blockquote`() = runTest {
+		val extension = createMarkdownExtension(provider = InMemoryImageProvider())
+		val original = "> intro\n> ![alt](img.png)"
+		extension.importMarkdown(original)
+		assertEquals(original, extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `import restores a rule from a bulleted rule line`() = runTest {
+		// A bullet marker in front of a rule has no meaning of its own: the marker
+		// peels, the body classifies as a rule, and the bullet is dropped, so a
+		// document saved as `- ---` comes back with its rule.
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("- before\n- ---\n- after")
+
+		assertEquals(listOf(1), extension.linesWith(HorizontalRuleSpanStyle))
+		assertEquals(listOf(0, 2), extension.linesWith(BulletListSpanStyle))
+		assertEquals("- before\n---\n- after", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `import keeps the quote when restoring a rule from a quoted bulleted line`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("> - ---")
+
+		assertEquals(listOf(0), extension.linesWith(HorizontalRuleSpanStyle))
+		assertEquals(listOf(0), extension.linesWith(BlockquoteSpanStyle))
+		assertTrue(extension.linesWith(BulletListSpanStyle).isEmpty())
+		assertEquals("> ---", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `normalization strips a bullet when a rule span lands on its line`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("- item")
+		assertEquals(listOf(0), extension.linesWith(BulletListSpanStyle))
+		val state = extension.editorState
+
+		state.addRichSpan(
+			TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 1)),
+			HorizontalRuleSpanStyle,
+		)
+
+		assertTrue(extension.linesWith(BulletListSpanStyle).isEmpty())
+	}
+
+	@Test
+	fun `normalization keeps a quote when a rule span lands on its line`() = runTest {
+		val extension = createMarkdownExtension()
+		extension.importMarkdown("> quoted")
+		val state = extension.editorState
+
+		state.addRichSpan(
+			TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 1)),
+			HorizontalRuleSpanStyle,
+		)
+
+		assertEquals(listOf(0), extension.linesWith(BlockquoteSpanStyle))
+	}
+
+	@Test
+	fun `html blockquote containing a rule keeps the quote on the rule line`() = runTest {
+		val extension = createMarkdownExtension()
+		val html = extension.editorState.withHtml()
+		html.importHtml("<blockquote><p>a</p><hr><p>b</p></blockquote>")
+
+		assertEquals(listOf(0, 1, 2), extension.linesWith(BlockquoteSpanStyle))
+		assertEquals(listOf(1), extension.linesWith(HorizontalRuleSpanStyle))
+		assertEquals(
+			"<blockquote>\n<p>a</p>\n<hr>\n<p>b</p>\n</blockquote>",
+			html.exportAsHtml(),
+		)
+		assertEquals("> a\n> ---\n> b", extension.exportAsMarkdown())
+	}
+}

--- a/docs/design/line-blocks.md
+++ b/docs/design/line-blocks.md
@@ -290,8 +290,10 @@ otherwise text). Consequences:
   placeholder line. Export already emits this form today; only import must learn it.
 - The HTML `<blockquote>a<hr>b</blockquote>` case stops being a conflict: the quote
   span stays on the rule line, both exporters render it correctly.
-- List and fence spans on a placeholder line remain invalid (a bullet on a rule has
-  no meaning in the model) and are stripped by normalization.
+- On a rule line, list and fence spans remain invalid (a bullet on a rule has no
+  meaning) and are stripped by normalization. On an image line, one list style is
+  valid alongside the quote: an image can be a list item, and markdown expresses
+  it directly.
 - A first-generation D2 save (`- ---`) heals on load: peel `- `, classify `---` as
   a rule, normalization strips the bullet span. The rule comes back.
 
@@ -301,10 +303,14 @@ and a style may only peel if it is not `mutuallyExcluded` with anything already
 peeled. This is what fixes Mechanism C's `- 1990. The year` text loss: after a list
 marker, the other list style is excluded, so `1990. ` stays in the body.
 
-3. **Placeholder stacking: quote may stack on placeholder lines; lists and fences
-   may not.** Import peels markers first, then classifies the residual body. `> ---`
-   and `> ![alt](src)` become representable and round-trip; normalization strips
-   only list/fence spans from placeholder lines.
+3. **Placeholder stacking is kind-aware: quote may stack on any placeholder
+   line; an image may also carry one list style; nothing else stacks.** Import
+   peels markers first, then classifies the residual body. `> ---`,
+   `> ![alt](src)`, and `1. ![shot](url)` (a numbered figure list) are all
+   representable and round-trip. A line only classifies as a placeholder while
+   its text is blank: a rule span re-anchored onto a text line by a line merge
+   does not make that line a placeholder, so the text keeps its own formatting
+   and the merge round-trips through undo.
 4. **Branch mechanics: reset to `main` and rebuild clean**, force-pushed to PR #57.
 5. **Property tests: yes.** Round-trip property testing over generated documents is
    the regression gate for this subsystem, alongside the example tests.
@@ -320,15 +326,21 @@ marker, the other list style is excluded, so `1990. ` stays in the body.
    else keeps all peels and the body goes to the GFM parser.
 2. **Commit-time normalization** (`TextEditorState`): every published revision
    passes through a pure `DocumentSnapshot -> DocumentSnapshot` step that removes
-   list/fence spans from placeholder lines and rebuilds those lines without the
-   orphaned indent. No-op fast path when the document has no placeholder lines.
-   The `applyLineBlock` primitive stays permissive, as on `main`.
-3. **Toggle** (`TextEditManager.toggleLineBlock`): eligibility is per style, from
-   one span-set snapshot: every in-range line for `Blockquote`; every in-range
-   non-placeholder line for the others. Blank lines are always eligible. Both
-   directions act on the eligible set, and the direction is decided from it. This
-   preserves "clear is never blocked" because the only excluded lines are ones that
-   cannot carry the style at all.
+   disallowed block spans from placeholder lines and rebuilds those lines without
+   the orphaned indent. A placeholder line is one whose full-line span's
+   `replacesText()` is true AND whose text is blank, so a span re-anchored onto
+   real text never strips that text's formatting. The repair is deterministic and
+   outside the undo history; given the blank-text rule, the most it can ever
+   discard is a marker on empty content. No-op fast path when nothing changed or
+   no placeholder lines exist. The `applyLineBlock` primitive stays permissive,
+   as on `main`.
+3. **Toggle** (`TextEditManager.toggleLineBlock`): eligibility is per style and
+   per placeholder kind, from one span-set snapshot: `Blockquote` takes every
+   in-range line; the list styles take every line except rule lines; `CodeFence`
+   takes only non-placeholder lines. Blank lines are always eligible. Both
+   directions act on the eligible set, and the direction is decided from it.
+   This preserves "clear is never blocked" because the only excluded lines are
+   ones that cannot carry the style at all.
 4. **Tests**: example tests for each defect and each decision, plus a seeded
    generator-based round-trip property test (`export` then `import` then `export`
    must be stable, text and block placement preserved).

--- a/docs/design/line-blocks.md
+++ b/docs/design/line-blocks.md
@@ -1,0 +1,334 @@
+# Line block styles: design reference
+
+Working document for issue #43 and the `fix/43-block-toggle-select-all` branch (PR #57).
+It records the original problem, how the code handled line blocks before the branch,
+what we actually want from the system, and what we have tried so far and how it failed.
+Line references are to `main` unless marked otherwise.
+
+## 1. The original problem
+
+Issue #43, reported from Hammer: a user pasted ~2500 words, selected all, applied a
+formatting change across the whole selection, and after the (separate, since-fixed #42)
+crash and a reload, **every line of the document carried a literal `- ` prefix**.
+Removing the strays by hand triggered more #42 crashes. The corruption survived
+save/reload, so it was persisted content, not a render glitch.
+
+Investigation on this branch established:
+
+- The reported step ("applied a header change") cannot produce the symptom. Header
+  cycling only touches character-level `SpanStyle`s and round-trips cleanly.
+- A **line-block toggle over a select-all** (the issue's own title) reproduces the
+  symptom exactly: every line, blank separators and horizontal rules included, gets a
+  marker, and parts of the result do not survive a save/reload.
+- The concurrency race hypothesized in the issue was already closed by #48 (snapshot
+  reads); it is not the mechanism here.
+
+Three distinct defects were identified, of which only some produce true corruption:
+
+| # | Behavior on `main` | Persisted corruption? |
+|---|---|---|
+| D1 | Sweep stamps a marker on every **blank line** (`- ` on each separator) | No: `- ` re-imports as an empty bullet, stable round trip. Severe noise the user must remove by hand, but not data loss. |
+| D2 | Sweep stamps a marker on **rule/image lines**; export writes `- ---` | Yes: re-import matches the bullet pattern first, the rule span is destroyed, the text becomes the literal `---`, and the next export escapes it to `- \-\-\-`. Unrecoverable. |
+| D3 | Import peels only the **outermost** stacked marker. Quote legitimately stacks with a list, so export writes `> - item`; import returns a quote whose *text* is `- item`, and the next save escapes the dash into the prose | Yes: pre-existing, independent of the sweep. This is the sharpest form of "a `- ` written into my text". |
+| D4 | A quote span on a rule line exports as `> ---` (the prefix loop runs on rule lines), but import checks the HR token against the **raw** line, so `> ---` comes back as a quote whose text is the literal `---` | Yes: pre-existing on `main`, no sweep involved. Found while analyzing Mechanism B; same family as D2 but reachable through ordinary HTML paste (`<blockquote>a<hr>b</blockquote>`) followed by a markdown save. |
+
+## 2. The model as it stood on `main`
+
+### 2.1 Two-layer document representation
+
+A document is:
+
+- **Lines**: `List<AnnotatedString>`, each carrying character-level `SpanStyle`s
+  (bold, header sizes, etc.) and `ParagraphStyle`s baked into the line itself.
+- **Rich spans**: a copy-on-write `Set<RichSpan>` in `RichSpanManager`, each a
+  `(TextEditorRange, RichSpanStyle)` pair. These are decorations drawn over or
+  instead of the text (gutter bullets, quote bars, rule lines, images, spell-check
+  underlines).
+
+Both layers publish atomically through `TextEditorState.withAtomicEdit` (a draft
+`DocumentSnapshot` committed as one revision), which is what #48 built.
+
+### 2.2 What a "line block" is
+
+A bullet / ordered-list / blockquote / code-fence line is a **bundle of three things
+that must stay in sync** (`richstyle/LineBlockStyle.kt`):
+
+1. A line-anchored `RichSpan` (`stickyAtStart = true`) whose style draws the gutter
+   marker (dot, numeral, bar) or tints the fence card.
+2. A `ParagraphStyle` indent baked into the line's `AnnotatedString`
+   (`BULLET_LIST_PARAGRAPH_STYLE` etc.).
+3. Optionally a baked-in `SpanStyle` (`CodeFence` bakes monospace).
+
+`LineBlockStyle` bundles these with the two serialization hooks: `markdownPrefix`
+(what export writes) and `markdownPattern` (what import recognizes). Registries:
+`LINE_BLOCK_STYLES` (prefix styles: quote, ordered, bullet, in match-priority order)
+and `ALL_BLOCK_STYLES` (adds `CodeFence`, which round-trips via ``` markers instead
+of a per-line prefix).
+
+Stacking rules live in `mutuallyExcluded(applied)`: the two list styles exclude each
+other, fence excludes everything, quote stacks with lists.
+
+### 2.3 Placeholder lines
+
+Horizontal rules and images are a different species: the line's *text* is a single
+space (`HR_PLACEHOLDER` / `IMAGE_PLACEHOLDER`) and the span **owns the whole line**,
+drawing the rule or image instead of the text (`BlockSpanStyle.replacesText()`).
+Nothing in the model prevented a line-block span from also sitting on such a line.
+
+### 2.4 Operations
+
+- `applyLineBlock(line, block)` / `demoteLineBlock(line, block)`: the per-line
+  primitives. Apply is idempotent, demotes conflicting styles first, attaches span
+  then rebuilds the line with the indent.
+- `TextEditManager.toggleLineBlock(lines: IntRange, block)`: the sweep behind every
+  toolbar button. On `main` it acted on **every line in the range**, direction chosen
+  by `anyOff = lines.any { !hasLineBlock(it, block) }` (mixed selection turns all
+  on). Records one atomic undo entry with per-line before/after content and spans.
+- Smart editing: Enter at the end of a block line continues the block onto the new
+  line (`applyLineBlock` on both halves of the split); Enter on an empty block line
+  exits the list; Backspace at column 0 demotes before merging.
+- Derived state: ordered-list numbers are **not stored**. `updateBookKeeping`
+  (`TextEditorState.kt:916-1004`) walks the lines and increments a run position,
+  resetting to zero at every non-OL line. Export does the same independently
+  (`runPositions` in `exportAsMarkdown`). Fence grouping is likewise derived from
+  contiguity, in export's open/close bookkeeping and in the renderer.
+
+### 2.5 Serialization
+
+Two importers/exporters share one attachment path:
+
+- **Markdown export**: takes one snapshot (`DocumentBlocks`), walks lines, prepends
+  `markdownPrefix` for each block style present on the line, converts the body via
+  `toMarkdown` (which escapes markdown specials in plain text: a literal `- ` at the
+  start of a plain paragraph exports as `\- ` and is safe).
+- **Markdown import**: a pre-pass over raw lines. Fence stripping first; then per
+  line: HR token check, standalone-image check, block-marker match
+  (`main`: **first matching style only**, marker stripped, line index recorded);
+  then the GFM parser over the residue; then `setText` (drops all spans) +
+  `applyDocumentBlocks` re-attaches rules, images, and blocks via `applyLineBlock`,
+  all in one revision.
+- **HTML** (`HtmlExtension`): same shape. `containersFor(line)` derives
+  `<blockquote>/<ul>/<ol>/<pre>` nesting from the same `DocumentBlocks` snapshot;
+  `importHtml` funnels into the same `applyDocumentBlocks`.
+
+The essential property: **the persisted form is markdown text; every block span must
+round-trip through a textual marker that import can unambiguously reverse.** The
+in-memory model was more permissive than the serialized form could express, and every
+gap between the two is a silent-corruption site (D2, D3).
+
+## 3. What we want (target properties)
+
+Stated as properties of the system rather than patches to functions.
+
+### P1. A validity definition, written down
+
+Classify lines into three kinds: **content**, **blank**, **placeholder** (rule or
+image, text owned by the span). A document is *valid* when:
+
+- Placeholder lines carry no line-block span (nothing to decorate; not serializable).
+- Per line, styles respect the stacking rules (at most one list style; fence alone;
+  quote may stack with one list).
+- Every block span is paired with its paragraph-indent on the same line.
+
+### P2. Round trip is the contract
+
+For every valid document: `import(export(doc))` preserves text and block structure,
+and `export(import(text))` is stable after one normalization pass. This should be a
+**property test** over generated documents (random lines, blanks, rules, images,
+stacked styles), not a growing pile of example tests. Every corruption bug so far is
+a violation of this property that an example test happened not to cover.
+
+### P3. Marker parsing mirrors marker emission, via one rule set
+
+Import's peeling and export's prefixing must be inverse images of the same stacking
+rules (`mutuallyExcluded`). Import peels only combinations that can legally coexist
+on one line: after peeling a list marker, only a quote could still be pending, never
+the other list style. Anything the model cannot represent stays literal text
+(protected by body escaping on the way back out).
+
+### P4. Invariants enforced at one chokepoint
+
+`main` enforced stacking inside `applyLineBlock` and nothing else anywhere. The
+branch scattered more guards across three layers, and each guard's blast radius
+surprised us. Choose one enforcement point:
+
+- **Option A, guarded primitives**: `applyLineBlock` is the sole gate (rejects
+  placeholder lines, resolves stacking); sweeps and importers trust it. Requires the
+  primitive to know *why* it is being called (user toggle vs import re-attachment),
+  which is what bit us with the HTML quote-around-`<hr>` case.
+- **Option B, commit-time normalization**: primitives stay permissive; a
+  normalization step at the `withAtomicEdit` commit boundary repairs violations
+  (drop block spans from placeholder lines, resolve stacking). One place, sees the
+  whole document, importer and toggle and smart-Enter all covered for free.
+- **Option C, policy at the sweep only**: primitives and importers stay as `main`;
+  only the user-facing toggle filters its target lines. Smallest surface, but
+  invariants are then only conventions, and importers can still construct invalid
+  documents (they do today: HTML can put a quote on a rule line).
+
+### P5. Toggle semantics defined by user intent, per direction and per style
+
+- **Clear direction: never filtered.** Removing a style from a selection removes it
+  from every line in the selection. There must be no reachable state that a toggle
+  cannot undo (the branch created two such states).
+- **Apply direction: per-style policy**, because the styles genuinely differ:
+  - *Fence*: contiguity is the point; every selected line joins the fence, blanks
+    included (a code block containing a blank line must be expressible).
+  - *Bullet / ordered / quote*: blank separator lines are arguably prose structure.
+    Whether to skip them is a **product decision, still open** (see §5): Word and
+    Google Docs turn blanks into empty list items; skipping them fragments ordered
+    numbering and reads oddly on toggle-off.
+- **Direction decided from the lines the apply-policy would act on**, but clearing
+  still sweeps the full range.
+- Policy keys off the **requested selection**, not the subset of it that happens to
+  exist, so a selection dragged past end-of-document behaves like the same selection
+  clipped.
+
+### P6. Run-sensitive styles are handled run-aware
+
+Ordered numbering and fence grouping are derived from contiguous runs. Any policy
+that can fragment a run (skipping a line mid-selection) changes meaning, not just
+appearance. Either policies must preserve runs for run-sensitive styles, or the
+derived-state walkers must learn to bridge gaps (e.g. OL numbering continuing across
+a blank line inside a list). Bridging is itself a model change with its own
+serialization consequences; do not do it casually.
+
+## 4. What we tried on this branch, and what broke
+
+Branch commit `2704f6f`, reviewed at high effort (10 findings, 7 confirmed by
+running the code). Three mechanisms were added; every confirmed regression traces to
+one of them.
+
+### Mechanism A: blank-line skip in `lineBlockTargets`
+
+Intent: stop D1 (markers on every separator). Implementation: multi-line sweeps
+filter to non-blank lines; single-line toggles exempt; both toggle directions and
+all four styles go through the filter.
+
+| Regression | Root cause |
+|---|---|
+| A block on a blank line survives a select-all clear and no multi-line toggle can ever remove it (Enter-continuation creates exactly such lines) | Filter applied to the clear direction |
+| A selected code block containing blank lines becomes several disjoint fences; a fence spanning a blank line is no longer creatable by selection | Filter applied to `CodeFence`, which needs contiguity |
+| Select-all ordered list over blank-separated paragraphs numbers `1. 1. 1.` | Filter fragments the run that numbering derives from |
+| A sweep whose range extends past EOF collapses to `present.size == 1` and re-acquires the blank-stamping behavior on a trailing empty line | Single-line exemption keyed off surviving lines, not the requested selection |
+
+Lesson: one filter for four styles × two directions was wrong on three of the eight
+combinations it silently changed.
+
+### Mechanism B: `acceptsLineBlock` guard (placeholder lines)
+
+Intent: fix D2 (rule/image destruction). Implementation: predicate rejecting lines
+carrying `HorizontalRuleSpanStyle`/`ImageBlockSpanStyle`, wired into **both**
+`lineBlockTargets` and the `applyLineBlock` primitive.
+
+| Regression | Root cause |
+|---|---|
+| HTML import of `<blockquote>a<hr>b</blockquote>` drops the quote from the `<hr>` line; export splits one quote into two around a bare rule, baked in on first save | Guard fires inside the primitive, which the HTML import path relies on to attach a quote to a rule line (valid in HTML, unrepresentable in our markdown) |
+| A block span that *already* sits on a rule/image line (host apps can construct this via public `addRichSpan`) becomes permanently un-removable | Guard filters `lineBlockTargets` in both directions, including clear |
+
+Also flagged: the predicate hardcodes the two styles instead of using the existing
+`BlockSpanStyle.replacesText()` classification, so the next placeholder style would
+silently lose the protection.
+
+Lesson: the guard is right as an *apply-time* rule for user toggles, wrong as a
+universal precondition. And it exposed a real modeling question: HTML can express a
+quote containing a rule; our markdown layer cannot. Refusing the span (branch) splits
+the quote; allowing it (main) corrupts the markdown round trip. Neither is correct;
+the model has to pick a representation (e.g. quote-on-placeholder is valid in-memory
+and markdown export handles it, or it is invalid and HTML import must normalize).
+
+### Mechanism C: multi-marker peel (`peelLineBlocks`)
+
+Intent: fix D3 (stacked `> - item`). Implementation: peel repeatedly, each style at
+most once.
+
+| Regression | Root cause |
+|---|---|
+| `- 1990. The year everything changed` peels `- ` then `1990. `, records both list styles; `applyDocumentBlocks` demotes one and the author's literal `1990. ` is silently deleted | "Each style at most once" is the wrong stop condition; the real rule is "peel only what can legally coexist", i.e. `mutuallyExcluded` |
+
+What held up: the D3 diagnosis itself, the direction-from-acted-lines idea (right
+idea, wrong filter set), body-text escaping as the safety net for plain lines, and
+the regression tests for D2/D3 round trips.
+
+### Adjacent known issues (out of scope, worth their own tickets)
+
+- Export of a document whose last line is a header appends a trailing blank line
+  that survives re-import (stable at +1).
+- Toggling a style off after a blanket apply does not restore styles lines carried
+  before the apply (undo does restore; conventional toolbar behavior).
+- `> ---` (a rule inside a quote) imports as a quote line whose body is the literal
+  `---`; related to the same representability question as Mechanism B.
+
+## 5. Decisions
+
+### Decided
+
+1. **Blank lines under a multi-line apply: do not skip them.** Match Word/Docs:
+   blanks become empty list items. D1 is declared a non-bug (it round-trips stably;
+   the reporter's real data loss was D2/D3/D4). This deletes Mechanism A entirely
+   and with it all four of its regressions. If empty-item noise proves to be a real
+   product complaint, it returns later as a per-style apply policy (§3 P5), designed
+   with run-awareness (§3 P6) from the start.
+2. **Enforcement point: commit-time normalization** at the `withAtomicEdit` commit
+   boundary (§3 P4 option B). The pass sees the whole draft once, right before
+   publish, and covers every attachment path (toggle, both importers, smart Enter,
+   host apps via the public `addRichSpan`, span re-anchoring after edits) without
+   any path needing to know the rules. Precision on healing: normalization repairs
+   invalid **span states**; it cannot restore text that already lost its span.
+   First-generation corrupted saves (`- ---`) are healed by the import change below;
+   second-generation escaped text (`\-\-\-`) is unrecoverable and stays literal.
+
+### Rationale for decision 3: peel first, then classify
+
+D4 shows `main` already corrupts quote-on-rule through markdown alone, so "keep the
+permissive model and do nothing" is not on the table. The resolution makes
+the model and the text form agree by fixing the **import order**: peel stacked
+markers off the line first (by the grammar below), then classify the residual body
+(HR token → rule placeholder + span; standalone image → image placeholder + span;
+otherwise text). Consequences:
+
+- `> ---` and `> ![alt](src)` become fully representable: quote **may** stack on a
+  placeholder line. Export already emits this form today; only import must learn it.
+- The HTML `<blockquote>a<hr>b</blockquote>` case stops being a conflict: the quote
+  span stays on the rule line, both exporters render it correctly.
+- List and fence spans on a placeholder line remain invalid (a bullet on a rule has
+  no meaning in the model) and are stripped by normalization.
+- A first-generation D2 save (`- ---`) heals on load: peel `- `, classify `---` as
+  a rule, normalization strips the bullet span. The rule comes back.
+
+The peel grammar mirrors emission exactly (§3 P3): styles peel in
+`LINE_BLOCK_STYLES` registry order (quote, then one list style), each at most once,
+and a style may only peel if it is not `mutuallyExcluded` with anything already
+peeled. This is what fixes Mechanism C's `- 1990. The year` text loss: after a list
+marker, the other list style is excluded, so `1990. ` stays in the body.
+
+3. **Placeholder stacking: quote may stack on placeholder lines; lists and fences
+   may not.** Import peels markers first, then classifies the residual body. `> ---`
+   and `> ![alt](src)` become representable and round-trip; normalization strips
+   only list/fence spans from placeholder lines.
+4. **Branch mechanics: reset to `main` and rebuild clean**, force-pushed to PR #57.
+5. **Property tests: yes.** Round-trip property testing over generated documents is
+   the regression gate for this subsystem, alongside the example tests.
+
+## 6. The plan as implemented
+
+1. **Import pipeline** (`MarkdownExtension.importMarkdown`): peel markers in
+   `LINE_BLOCK_STYLES` registry order, each style at most once, a style only
+   eligible when compatible (not mutually excluded) with everything already peeled.
+   This is a single forward pass that exactly mirrors the emission order. Then
+   classify the residual body: HR token or standalone image makes the line a
+   placeholder, recording the quote peel (if any) and dropping list peels; anything
+   else keeps all peels and the body goes to the GFM parser.
+2. **Commit-time normalization** (`TextEditorState`): every published revision
+   passes through a pure `DocumentSnapshot -> DocumentSnapshot` step that removes
+   list/fence spans from placeholder lines and rebuilds those lines without the
+   orphaned indent. No-op fast path when the document has no placeholder lines.
+   The `applyLineBlock` primitive stays permissive, as on `main`.
+3. **Toggle** (`TextEditManager.toggleLineBlock`): eligibility is per style, from
+   one span-set snapshot: every in-range line for `Blockquote`; every in-range
+   non-placeholder line for the others. Blank lines are always eligible. Both
+   directions act on the eligible set, and the direction is decided from it. This
+   preserves "clear is never blocked" because the only excluded lines are ones that
+   cannot carry the style at all.
+4. **Tests**: example tests for each defect and each decision, plus a seeded
+   generator-based round-trip property test (`export` then `import` then `export`
+   must be stable, text and block placement preserved).


### PR DESCRIPTION
Fixes #43.

This branch was rebuilt from `main` after a high-effort review of the first attempt surfaced seven confirmed regressions. The full analysis (original problem, survey of the prior code, target properties, what the first attempt broke, and the decisions behind this design) is in **`docs/design/line-blocks.md`**, committed first; the implementation commit follows it.

## The defects (all persisting to disk)

- **D1**: a select-all block toggle stamped its marker on every blank separator line. Noise, not corruption (`- ` round-trips stably). Resolved by decree: blanks become empty list items, as in Word and Google Docs.
- **D2**: markers on rule/image lines. Export wrote `- ---`; re-import matched the bullet pattern first, destroying the rule and leaving its literal dashes, escaped further on each save.
- **D3**: quote stacks with a list so export writes `> - item`, but import peeled only the outermost marker: the line came back as a quote whose text was `- item`, and the next save escaped the dash into the prose.
- **D4** (found during the redesign): a quote span on a rule line exports as `> ---`, which import read as a quote holding literal `---`. Reachable by pasting `<blockquote>a<hr>b</blockquote>` as HTML and saving as markdown, on `main`, no toggle involved.

## The design

- **Import peels stacked markers as the exact mirror of export**: registry order, each style at most once, only when compatible with what already peeled, then classifies the residual body. `> ---` and `> ![alt](src)` round-trip as quoted rule/image; a `- ---` save from an affected build heals back into its rule; `- 1990. plans` keeps the author's `1990. ` because the two list styles are mutually exclusive. A marker-shaped lead left in a peeled body is escaped so the parser cannot eat it.
- **Every published revision is normalized**: a placeholder line (blank text owned by a full-line span) takes only the styles that stack on it, regardless of which path attached others (toggle, importers, smart Enter, the public span API, span re-anchoring). Quote stacks on any placeholder (`> ---`); an image also takes one list style (`1. ![shot](url)` is a numbered figure); a line holding real text is never treated as a placeholder, so a span re-anchored by a line merge cannot strip the text's own formatting. The primitive stays permissive; there is exactly one enforcement point.
- **Toggles act on the selected lines that can carry the style and decide direction from that set**: blank lines included, placeholder lines counting only for blockquote. Clearing is never blocked, ordered lists number contiguously across a swept selection, and a fenced selection containing blank lines stays one fence.

Also fixed along the way: a lone empty quoted line exported as nothing, and a rule on line 0 lost its placeholder character to the markdown parser's leading-space rule.

## Verification

- New `LineBlockRoundTripPropertyTest`: 200 generated documents (blanks, rules, stacked styles, marker-lookalike bodies), asserting export/import preserves text and block placement and that a second export is identical. This gate found the two "also fixed" bugs above.
- Example tests: `LineBlockSweepTest` (13), `PlaceholderLineBlockTest` (10), stacked-marker cases in `BulletListSerializationTest`.
- Full desktop suite green; metadata and wasmJs targets compile.

