### PR TITLE
Collapse an import's two layout passes into one

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
@@ -76,20 +76,22 @@ class HtmlExtension(
 			includeImages = provider != null,
 		)
 		// One revision, so a concurrent export can't catch the document loaded but
-		// not yet styled.
+		// not yet styled, and one relayout rather than one per import step.
 		editorState.withAtomicEdit {
-			editorState.setText(document.text)
-			editorState.applyDocumentBlocks(
-				horizontalRuleLines = document.horizontalRuleLines,
-				imageLines = if (provider == null) {
-					emptyMap()
-				} else {
-					document.imageLines.mapValues { (_, image) ->
-						ImageBlockSpanStyle(source = image.source, alt = image.alt, provider = provider)
-					}
-				},
-				blockLines = document.blockLines,
-			)
+			editorState.withDeferredBookKeeping {
+				editorState.setText(document.text)
+				editorState.applyDocumentBlocks(
+					horizontalRuleLines = document.horizontalRuleLines,
+					imageLines = if (provider == null) {
+						emptyMap()
+					} else {
+						document.imageLines.mapValues { (_, image) ->
+							ImageBlockSpanStyle(source = image.source, alt = image.alt, provider = provider)
+						}
+					},
+					blockLines = document.blockLines,
+				)
+			}
 		}
 	}
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
@@ -248,14 +248,17 @@ class MarkdownExtension(
 		val annotatedString = processedMarkdown.toAnnotatedStringFromMarkdown(markdownConfiguration)
 		// setText publishes the text with no spans and applyDocumentBlocks attaches them
 		// afterwards. As one revision, so a concurrent export can't catch the document
-		// fully loaded but entirely unstyled.
+		// fully loaded but entirely unstyled, and as one relayout, so the document isn't
+		// measured once bare and again decorated.
 		editorState.withAtomicEdit {
-			editorState.setText(annotatedString)
-			editorState.applyDocumentBlocks(
-				horizontalRuleLines = hrLineIndices,
-				imageLines = imageLines.toMap(),
-				blockLines = blockHits + (CodeFence to codeFenceLineIndices),
-			)
+			editorState.withDeferredBookKeeping {
+				editorState.setText(annotatedString)
+				editorState.applyDocumentBlocks(
+					horizontalRuleLines = hrLineIndices,
+					imageLines = imageLines.toMap(),
+					blockLines = blockHits + (CodeFence to codeFenceLineIndices),
+				)
+			}
 		}
 	}
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -187,6 +187,30 @@ class TextEditorState(
 		}
 	}
 
+	/** Nesting depth of [withDeferredBookKeeping]; relayout is suppressed above zero. */
+	private var deferredBookKeepingDepth = 0
+
+	/**
+	 * Runs [block] with relayout suppressed, then relays the whole document out once.
+	 *
+	 * For a bulk rewrite whose steps each end in their own [updateBookKeeping]: an
+	 * import replaces the text and then decorates it, and measuring the document
+	 * between those two only produces a layout the next step throws away.
+	 *
+	 * [block] must not read [lineOffsets] or anything derived from it (pixel
+	 * positions, content height): until it returns, they describe the document as it
+	 * stood before.
+	 */
+	internal fun <T> withDeferredBookKeeping(block: () -> T): T {
+		deferredBookKeepingDepth++
+		try {
+			return block()
+		} finally {
+			deferredBookKeepingDepth--
+			if (deferredBookKeepingDepth == 0) updateBookKeeping()
+		}
+	}
+
 	/**
 	 * Runs [action] once the outermost transaction has committed, or immediately when
 	 * there is none. For work that announces an edit to the outside world and must not
@@ -905,6 +929,9 @@ class TextEditorState(
 	}
 
 	internal fun updateBookKeeping(affectedLines: IntRange? = null) {
+		// A bulk rewrite runs one pass of its own once it is done; measuring per step
+		// only lays out a document the next step invalidates.
+		if (deferredBookKeepingDepth > 0) return
 		// Defer until the viewport has a real size; the 1×1 sentinel forces character-wide wraps.
 		if (viewportSize.width <= 1f || viewportSize.height <= 1f) return
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/ImportRelayoutCostTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/ImportRelayoutCostTest.kt
@@ -25,8 +25,8 @@ import kotlin.test.assertEquals
  */
 class ImportRelayoutCostTest {
 
-	/** Whole-document layout passes an import runs: one for the text, one for the blocks. */
-	private val passesPerImport = 2
+	/** Whole-document layout passes an import runs; the text and the blocks share one. */
+	private val passesPerImport = 1
 
 	private class MeasureCounter {
 		var calls = 0


### PR DESCRIPTION
**Draft.** Rebased onto `main` now that #56 has landed, so the diff here is only the deferral.

Split out of #56 because a high-effort review turned up three unresolved objections to the mechanism, none of which apply to the batching work that shipped in #56. Parking it here rather than dropping it, since the win is real and the objections look fixable.

## What it buys

After #56, an import runs two whole-document layout passes: `setText` measures the bare text, then `applyDocumentBlocks` measures it again with the blocks attached. The first result is never drawn — the second invalidates every line it touched. So an n-line import costs 2n measures where n would do.

`withDeferredBookKeeping` suppresses `updateBookKeeping` for the duration of a bulk rewrite and runs a single full pass when it unwinds. Both importers wrap their `setText` + `applyDocumentBlocks` pair in it. `ImportRelayoutCostTest` drops from `2 * lines` to `lines`.

`./gradlew check` passes.

## Why it isn't in #56

Three objections, all real properties of the code as written:

**1. The restoring pass runs from a `finally`, including on the throwing path.** Both importers nest `withAtomicEdit { withDeferredBookKeeping { … } }`. If the inner block throws, the deferral's `finally` runs first and lays out the half-applied draft; `withAtomicEdit`'s `finally` then rolls `content` back. The editor is left holding `_lineOffsets` for a document that no longer exists, and the next paint or cursor move indexes past the end of `textLines`.

**2. That same `finally` can mask the original exception.** `updateBookKeeping` only guards `textMeasurer.measure` against `IllegalArgumentException`; everything else it touches can throw freely, and a throw from a `finally` discards the in-flight exception. A meaningful import failure would surface as an unrelated layout stack trace.

**3. The suppression window is global, and dropped requests are never retried.** `updateBookKeeping` has callers outside the import — `onViewportSizeChange` (public), the `textMeasurer`/`textStyle`/`density` setters, `BasicTextEditor`'s block-height `snapshotFlow`. `deferredBookKeepingDepth` is a plain non-volatile `Int` with no thread confinement, and `importMarkdown`/`importHtml` are public non-suspend APIs a host will reasonably call off the composition thread. A viewport resize landing mid-import has its relayout swallowed, leaving the document measured at the old width with no re-run until the user types.

## Sketches for fixing them

- Run the restoring pass on the success path only, and let the exceptional path leave layout stale for the rolled-back content to be re-laid out by whatever handles the failure. Addresses 1 and 2.
- Or fold the deferral into `withAtomicEdit` so relayout is part of the commit rather than a second, independently-scoped mechanism. Probably the cleaner shape, and it makes the throwing path fall out correctly for free.
- Set a dirty flag instead of dropping suppressed requests, and honour it in the restoring pass, so a resize arriving mid-window is deferred rather than lost. Addresses 3. Thread-safety of the depth counter needs deciding separately — either document the API as main-thread-only or make the state safe for the off-thread import that hosts will actually write.

## Related

`applyDocumentBlocks` duplicating `applyLineBlock`'s stacking rules (raised in the same review, left open on #56) is entangled with this: the suggested fix there was to wrap the original per-line `applyLineBlock` loop in `withDeferredBookKeeping`, which only works if this PR's mechanism lands in a form worth trusting.