### PR TITLE
Skip the decoration relayout when there is nothing to decorate

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/DocumentBlocks.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/DocumentBlocks.kt
@@ -127,7 +127,10 @@ internal fun TextEditorState.applyDocumentBlocks(
 	richSpanManager.removeRichSpans(removed)
 	richSpanManager.addRichSpans(added)
 	if (rebuiltAnyLine) setLines(lines)
-	updateBookKeeping()
+	// Attaching a span is enough on its own to need the relayout, even with no line
+	// rebuilt: a rule or an image resolves its height from the spans on its line wrap,
+	// which only book-keeping works out.
+	if (added.isNotEmpty() || removed.isNotEmpty() || rebuiltAnyLine) updateBookKeeping()
 }
 
 /** The range covering [length] characters from the start of [line]. */

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/ImportRelayoutCostTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/ImportRelayoutCostTest.kt
@@ -25,8 +25,11 @@ import kotlin.test.assertEquals
  */
 class ImportRelayoutCostTest {
 
-	/** Whole-document layout passes an import runs: one for the text, one for the blocks. */
-	private val passesPerImport = 2
+	/** Layout passes a decorated import runs: one for the text, one for the decorations. */
+	private val decoratedImportPasses = 2
+
+	/** A document with nothing to decorate skips the second pass. */
+	private val plainImportPasses = 1
 
 	private class MeasureCounter {
 		var calls = 0
@@ -73,7 +76,27 @@ class ImportRelayoutCostTest {
 
 	@Test
 	fun `import measures the document a fixed number of times`() = runTest {
-		assertEquals(passesPerImport * 50, measuresToImport(bulletDocument(50)))
+		assertEquals(decoratedImportPasses * 50, measuresToImport(bulletDocument(50)))
+	}
+
+	@Test
+	fun `import of a document with nothing to decorate lays it out once`() = runTest {
+		val plain = (0 until 50).joinToString("\n") { "plain line $it" }
+		assertEquals(plainImportPasses * 50, measuresToImport(plain))
+	}
+
+	@Test
+	fun `a rule still gets the decoration pass with no block line to rebuild`() = runTest {
+		// A horizontal rule attaches a span without rebuilding any line, and its height
+		// is resolved from that span during book-keeping. Skipping the pass whenever no
+		// line changed would leave the rule unmeasured.
+		val withRule = "before\n---\nafter"
+		val state = TextEditorState(scope = this, measurer = countingMeasurer(MeasureCounter()))
+
+		assertEquals(decoratedImportPasses * 3, measuresToImport(withRule))
+		// Guard the arithmetic above: the document really is three lines.
+		MarkdownExtension(state).importMarkdown(withRule)
+		assertEquals(3, state.textLines.size)
 	}
 
 	@Test
@@ -106,6 +129,6 @@ class ImportRelayoutCostTest {
 		val state = editorWithCounter(counter)
 		MarkdownExtension(state).importMarkdown(markdown)
 
-		assertEquals(passesPerImport * state.textLines.size, counter.calls)
+		assertEquals(decoratedImportPasses * state.textLines.size, counter.calls)
 	}
 }


### PR DESCRIPTION
Closes #59.

## The defect

`applyDocumentBlocks` ended in an unconditional full-document `updateBookKeeping()`, so it re-measured every line even when it attached no spans and rebuilt no lines. `setLines` was already guarded by `rebuiltAnyLine`; the relayout was not.

This was introduced by #56. That change was a large win on decorated documents but regressed undecorated ones by 2x, because the relayout it added at the end of the bulk path ran whether or not the bulk path did anything.

## The fix

```kotlin
if (added.isNotEmpty() || removed.isNotEmpty() || rebuiltAnyLine) updateBookKeeping()
```

The guard has to cover the spans, not just `rebuiltAnyLine`. A horizontal rule or an image attaches a span without rebuilding any line, and resolves its height from that span during book-keeping — guarding on `rebuiltAnyLine` alone would leave a rule or image unmeasured until something else forced a pass. `a rule still gets the decoration pass with no block line to rebuild` covers exactly that, and I confirmed it fails against the narrower guard.

## Measured

Counting `TextMeasurer`, importing 50 lines:

| document | before #56 | on `main` | this PR |
|---|---|---|---|
| 50 bullets | 1,325 | 100 | 100 |
| 50 plain lines, no blocks | 50 | **100** | **50** |

The regression is gone and #47's win is untouched.

## Also fixed

Every rich paste whose blocks clip away outside the pasted range. `applyHtmlPasteBlocks` resolves the source document's block lines against the pasted range; pasting a single word into the middle of a line commonly leaves every block clipped, and the paste then paid a second whole-document pass on top of its own edit — proportional to total document size rather than to the paste. The `firstPastedLine > lastPastedLine` guard caught only the case where no pasted line was wholly owned by the source.

## Verification

`./gradlew check` passes. Three new/changed assertions in `ImportRelayoutCostTest`, which now distinguishes a decorated import (two passes) from a plain one (one pass).