### PR TITLE
Suspend spell checking when a checker flags everything

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD025": false,
+  "MD052": false
+}

--- a/ComposeTextEditorSpellCheck/Module.md
+++ b/ComposeTextEditorSpellCheck/Module.md
@@ -71,11 +71,12 @@ state.suspension?.let { reason ->
 ```
 
 `suspension` is Compose state, so a banner like the one above recomposes on its own. A
-suspension is sticky: checking stays off until the checker is replaced (passing a new
-`spellChecker` to `rememberSpellCheckState` resumes automatically), a full check is
-explicitly requested via `resumeSpellChecking()` or `runFullSpellCheck()`, or checking
-is toggled back on with `setSpellCheckingEnabled(true)`. Pass `SpellCheckGuard.Disabled`
-to opt out entirely.
+suspension is sticky: automatic checking stays off until a full re-check completes with
+plausible results. Replacing the checker (passing a new `spellChecker` to
+`rememberSpellCheckState` re-checks automatically), calling `resumeSpellChecking()` or
+`runFullSpellCheck()`, and toggling checking back on with `setSpellCheckingEnabled(true)`
+all trigger that re-check; if the checker is still flagging everything, the suspension
+simply stays in place. Pass `SpellCheckGuard.Disabled` to opt out entirely.
 
 ## Choosing a backend
 

--- a/ComposeTextEditorSpellCheck/Module.md
+++ b/ComposeTextEditorSpellCheck/Module.md
@@ -45,10 +45,12 @@ suggestion menu for you. Toggle checking at runtime with
 A checker loaded with the wrong dictionary flags *every* word: the document turns
 into a wall of red squiggles and every lookup is wasted. The
 [SpellCheckGuard][com.darkrockstudios.texteditor.spellcheck.SpellCheckGuard] watches for
-that. When too large a share of a large-enough sample comes back misspelled — or more
-than `maxMisspellings` pile up — the state drops every squiggle and stops checking
-instead of flagging the whole document. A full check bails as soon as the sample is
-conclusive, so a big document isn't dragged through a checker that can't read it.
+that. When too large a share of the whole document comes back misspelled (or more
+than `maxMisspellings` pile up) the state drops every squiggle and stops checking
+instead of flagging everything. The ratio is judged against the full document's word
+count, so a foreign-language passage inside an otherwise fine document never trips
+it, and a full check still bails as soon as the outcome is decided, so a big
+document isn't dragged through a checker that can't read it.
 
 ```kotlin
 val state = rememberSpellCheckState(
@@ -60,19 +62,20 @@ state.suspension?.let { reason ->
     Text(
         when (reason) {
             is SpellCheckSuspension.LikelyWrongLanguage ->
-                "Spell checking paused — the dictionary may not match this document's language."
+                "Spell checking paused: the dictionary may not match this document's language."
             is SpellCheckSuspension.TooManyMisspellings ->
-                "Spell checking paused — too many misspellings."
+                "Spell checking paused: too many misspellings."
         }
     )
 }
 ```
 
 `suspension` is Compose state, so a banner like the one above recomposes on its own. A
-suspension is sticky — checking stays off until the checker is replaced (passing a new
-`spellChecker` to `rememberSpellCheckState` resumes automatically), `resumeSpellChecking()`
-is called, or checking is toggled back on with `setSpellCheckingEnabled(true)`. Pass
-`SpellCheckGuard.Disabled` to opt out entirely.
+suspension is sticky: checking stays off until the checker is replaced (passing a new
+`spellChecker` to `rememberSpellCheckState` resumes automatically), a full check is
+explicitly requested via `resumeSpellChecking()` or `runFullSpellCheck()`, or checking
+is toggled back on with `setSpellCheckingEnabled(true)`. Pass `SpellCheckGuard.Disabled`
+to opt out entirely.
 
 ## Choosing a backend
 

--- a/ComposeTextEditorSpellCheck/Module.md
+++ b/ComposeTextEditorSpellCheck/Module.md
@@ -40,6 +40,40 @@ suggestion menu for you. Toggle checking at runtime with
 `state.setSpellCheckingEnabled(...)`, or fetch suggestions yourself via
 `state.getSuggestions(word)`.
 
+## Wrong-language protection
+
+A checker loaded with the wrong dictionary flags *every* word: the document turns
+into a wall of red squiggles and every lookup is wasted. The
+[SpellCheckGuard][com.darkrockstudios.texteditor.spellcheck.SpellCheckGuard] watches for
+that. When too large a share of a large-enough sample comes back misspelled — or more
+than `maxMisspellings` pile up — the state drops every squiggle and stops checking
+instead of flagging the whole document. A full check bails as soon as the sample is
+conclusive, so a big document isn't dragged through a checker that can't read it.
+
+```kotlin
+val state = rememberSpellCheckState(
+    spellChecker = spellChecker,
+    guard = SpellCheckGuard(maxMisspellings = 500, maxFlaggedRatio = 0.7f),
+)
+
+state.suspension?.let { reason ->
+    Text(
+        when (reason) {
+            is SpellCheckSuspension.LikelyWrongLanguage ->
+                "Spell checking paused — the dictionary may not match this document's language."
+            is SpellCheckSuspension.TooManyMisspellings ->
+                "Spell checking paused — too many misspellings."
+        }
+    )
+}
+```
+
+`suspension` is Compose state, so a banner like the one above recomposes on its own. A
+suspension is sticky — checking stays off until the checker is replaced (passing a new
+`spellChecker` to `rememberSpellCheckState` resumes automatically), `resumeSpellChecking()`
+is called, or checking is toggled back on with `setSpellCheckingEnabled(true)`. Pass
+`SpellCheckGuard.Disabled` to opt out entirely.
+
 ## Choosing a backend
 
 [EditorSpellChecker][com.darkrockstudios.texteditor.spellcheck.api.EditorSpellChecker] is
@@ -81,8 +115,10 @@ The spell-checking
 editor: [SpellCheckingTextEditor][com.darkrockstudios.texteditor.spellcheck.SpellCheckingTextEditor],
 the [SpellCheckState][com.darkrockstudios.texteditor.spellcheck.SpellCheckState] holder
 and its [rememberSpellCheckState][com.darkrockstudios.texteditor.spellcheck.rememberSpellCheckState]
-factory, and the [SpellCheckMode][com.darkrockstudios.texteditor.spellcheck.SpellCheckMode]
-(word vs. sentence) selector.
+factory, the [SpellCheckMode][com.darkrockstudios.texteditor.spellcheck.SpellCheckMode]
+(word vs. sentence) selector, and the
+[SpellCheckGuard][com.darkrockstudios.texteditor.spellcheck.SpellCheckGuard] that suspends
+checking when a checker starts flagging everything.
 
 # Package com.darkrockstudios.texteditor.spellcheck.api
 

--- a/ComposeTextEditorSpellCheck/Module.md
+++ b/ComposeTextEditorSpellCheck/Module.md
@@ -42,15 +42,16 @@ suggestion menu for you. Toggle checking at runtime with
 
 ## Wrong-language protection
 
-A checker loaded with the wrong dictionary flags *every* word: the document turns
-into a wall of red squiggles and every lookup is wasted. The
-[SpellCheckGuard][com.darkrockstudios.texteditor.spellcheck.SpellCheckGuard] watches for
-that. When too large a share of the whole document comes back misspelled (or more
-than `maxMisspellings` pile up) the state drops every squiggle and stops checking
-instead of flagging everything. The ratio is judged against the full document's word
-count, so a foreign-language passage inside an otherwise fine document never trips
-it, and a full check still bails as soon as the outcome is decided, so a big
-document isn't dragged through a checker that can't read it.
+A checker loaded with the wrong dictionary flags *every* word: the document
+turns into a wall of red squiggles and every lookup is wasted. The
+[SpellCheckGuard][com.darkrockstudios.texteditor.spellcheck.SpellCheckGuard]
+watches for that. When too large a share of the whole document comes back
+misspelled (or more than `maxMisspellings` pile up) the state drops every
+squiggle and stops checking instead of flagging everything. The ratio is
+judged against the full document's word count, so a foreign-language passage
+inside an otherwise fine document never trips it, and a full check still
+bails as soon as the outcome is decided, so a big document isn't dragged
+through a checker that can't read it.
 
 ```kotlin
 val state = rememberSpellCheckState(
@@ -62,21 +63,22 @@ state.suspension?.let { reason ->
     Text(
         when (reason) {
             is SpellCheckSuspension.LikelyWrongLanguage ->
-                "Spell checking paused: the dictionary may not match this document's language."
+                "Spell check paused: wrong dictionary language?"
             is SpellCheckSuspension.TooManyMisspellings ->
-                "Spell checking paused: too many misspellings."
+                "Spell check paused: too many misspellings."
         }
     )
 }
 ```
 
-`suspension` is Compose state, so a banner like the one above recomposes on its own. A
-suspension is sticky: automatic checking stays off until a full re-check completes with
-plausible results. Replacing the checker (passing a new `spellChecker` to
-`rememberSpellCheckState` re-checks automatically), calling `resumeSpellChecking()` or
-`runFullSpellCheck()`, and toggling checking back on with `setSpellCheckingEnabled(true)`
-all trigger that re-check; if the checker is still flagging everything, the suspension
-simply stays in place. Pass `SpellCheckGuard.Disabled` to opt out entirely.
+`suspension` is Compose state, so a banner like the one above recomposes on
+its own. A suspension is sticky: automatic checking stays off until a full
+re-check completes with plausible results. Replacing the checker (passing a
+new `spellChecker` to `rememberSpellCheckState` re-checks automatically),
+calling `resumeSpellChecking()` or `runFullSpellCheck()`, and toggling
+checking back on with `setSpellCheckingEnabled(true)` all trigger that
+re-check; if the checker is still flagging everything, the suspension simply
+stays in place. Pass `SpellCheckGuard.Disabled` to opt out entirely.
 
 ## Choosing a backend
 
@@ -119,10 +121,11 @@ The spell-checking
 editor: [SpellCheckingTextEditor][com.darkrockstudios.texteditor.spellcheck.SpellCheckingTextEditor],
 the [SpellCheckState][com.darkrockstudios.texteditor.spellcheck.SpellCheckState] holder
 and its [rememberSpellCheckState][com.darkrockstudios.texteditor.spellcheck.rememberSpellCheckState]
-factory, the [SpellCheckMode][com.darkrockstudios.texteditor.spellcheck.SpellCheckMode]
+factory, the
+[SpellCheckMode][com.darkrockstudios.texteditor.spellcheck.SpellCheckMode]
 (word vs. sentence) selector, and the
-[SpellCheckGuard][com.darkrockstudios.texteditor.spellcheck.SpellCheckGuard] that suspends
-checking when a checker starts flagging everything.
+[SpellCheckGuard][com.darkrockstudios.texteditor.spellcheck.SpellCheckGuard]
+that suspends checking when a checker starts flagging everything.
 
 # Package com.darkrockstudios.texteditor.spellcheck.api
 

--- a/ComposeTextEditorSpellCheck/build.gradle.kts
+++ b/ComposeTextEditorSpellCheck/build.gradle.kts
@@ -87,6 +87,9 @@ kotlin {
 				implementation(libs.mockk)
 				implementation(libs.kotlinx.coroutines.test)
 				implementation(libs.kotlinx.coroutines.test.jvm)
+				@OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+				implementation(compose.uiTest)
+				implementation(compose.desktop.currentOs)
 
 				implementation(libs.symspellkt)
 				implementation(libs.platform.spellchecker)

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckGuard.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckGuard.kt
@@ -12,14 +12,15 @@ package com.darkrockstudios.texteditor.spellcheck
  * @property maxMisspellings The most flagged items that may accumulate before checking is
  *   suspended. Counts misspelled words in [SpellCheckMode.Word] and corrections in
  *   [SpellCheckMode.Sentence].
- * @property maxFlaggedRatio The fraction of checked items that may be flagged before the
- *   checker is presumed to be checking the wrong language. Only applied once the sample is
- *   large enough to be meaningful — see [minWordSample] and [minSentenceSample].
- * @property minWordSample How many words a full [SpellCheckMode.Word] check must evaluate
- *   before [maxFlaggedRatio] is applied. Documents shorter than this are never suspended by
- *   ratio; a handful of squiggles is not worth a false positive.
- * @property minSentenceSample How many sentences a full [SpellCheckMode.Sentence] check must
- *   evaluate before [maxFlaggedRatio] is applied.
+ * @property maxFlaggedRatio The fraction of the document that may be flagged before the
+ *   checker is presumed to be checking the wrong language. Judged against the whole
+ *   document's word (or sentence) count, and only once the document is large enough to be
+ *   meaningful; see [minWordSample] and [minSentenceSample].
+ * @property minWordSample How many checkable words the document must contain before
+ *   [maxFlaggedRatio] is applied in [SpellCheckMode.Word]. Documents shorter than this are
+ *   never suspended by ratio; a handful of squiggles is not worth a false positive.
+ * @property minSentenceSample How many sentences the document must contain before
+ *   [maxFlaggedRatio] is applied in [SpellCheckMode.Sentence].
  */
 data class SpellCheckGuard(
 	val maxMisspellings: Int = DEFAULT_MAX_MISSPELLINGS,
@@ -55,8 +56,10 @@ data class SpellCheckGuard(
 /**
  * Why spell checking suspended itself. See [SpellCheckGuard].
  *
- * A suspension is sticky: checking stays off until the checker is replaced or
- * [SpellCheckState.resumeSpellChecking] is called, so a wrong-language checker isn't asked
+ * A suspension is sticky: checking stays off until the checker is replaced, a full check is
+ * explicitly requested ([SpellCheckState.resumeSpellChecking] or
+ * [SpellCheckState.runFullSpellCheck]), or checking is re-enabled via
+ * [SpellCheckState.setSpellCheckingEnabled]. This way a wrong-language checker isn't asked
  * to re-scan the document on every keystroke.
  */
 sealed interface SpellCheckSuspension {
@@ -64,8 +67,9 @@ sealed interface SpellCheckSuspension {
 	 * Nearly everything checked came back wrong, which usually means the checker's dictionary
 	 * doesn't match the document's language.
 	 *
-	 * @property checked How many items were evaluated (words or sentences, per [SpellCheckMode]).
-	 * @property flagged How many of those were flagged.
+	 * @property checked The sample the ratio was judged against: the document's checkable
+	 *   words or sentences, per [SpellCheckMode].
+	 * @property flagged How many flagged items the guard had seen when it tripped.
 	 */
 	data class LikelyWrongLanguage(val checked: Int, val flagged: Int) : SpellCheckSuspension
 

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckGuard.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckGuard.kt
@@ -1,0 +1,106 @@
+package com.darkrockstudios.texteditor.spellcheck
+
+/**
+ * Sanity limits that stop spell checking when its results stop looking plausible.
+ *
+ * The case this primarily guards against is a checker loaded with the wrong language: every
+ * word comes back misspelled, the document turns into a wall of red squiggles, and every
+ * lookup is wasted work. When a limit is exceeded, [SpellCheckState] drops all spell-check
+ * decorations and suspends checking (see [SpellCheckSuspension]) instead of flagging the
+ * whole document.
+ *
+ * @property maxMisspellings The most flagged items that may accumulate before checking is
+ *   suspended. Counts misspelled words in [SpellCheckMode.Word] and corrections in
+ *   [SpellCheckMode.Sentence].
+ * @property maxFlaggedRatio The fraction of checked items that may be flagged before the
+ *   checker is presumed to be checking the wrong language. Only applied once the sample is
+ *   large enough to be meaningful — see [minWordSample] and [minSentenceSample].
+ * @property minWordSample How many words a full [SpellCheckMode.Word] check must evaluate
+ *   before [maxFlaggedRatio] is applied. Documents shorter than this are never suspended by
+ *   ratio; a handful of squiggles is not worth a false positive.
+ * @property minSentenceSample How many sentences a full [SpellCheckMode.Sentence] check must
+ *   evaluate before [maxFlaggedRatio] is applied.
+ */
+data class SpellCheckGuard(
+	val maxMisspellings: Int = DEFAULT_MAX_MISSPELLINGS,
+	val maxFlaggedRatio: Float = DEFAULT_MAX_FLAGGED_RATIO,
+	val minWordSample: Int = DEFAULT_MIN_WORD_SAMPLE,
+	val minSentenceSample: Int = DEFAULT_MIN_SENTENCE_SAMPLE,
+) {
+	init {
+		require(maxMisspellings > 0) { "maxMisspellings must be positive, was $maxMisspellings" }
+		require(minWordSample > 0) { "minWordSample must be positive, was $minWordSample" }
+		require(minSentenceSample > 0) { "minSentenceSample must be positive, was $minSentenceSample" }
+		require(maxFlaggedRatio in 0f..1f) { "maxFlaggedRatio must be in 0..1, was $maxFlaggedRatio" }
+	}
+
+	companion object {
+		const val DEFAULT_MAX_MISSPELLINGS = 500
+		const val DEFAULT_MAX_FLAGGED_RATIO = 0.7f
+		const val DEFAULT_MIN_WORD_SAMPLE = 40
+		const val DEFAULT_MIN_SENTENCE_SAMPLE = 8
+
+		/** The limits applied unless a caller supplies its own. */
+		val Default = SpellCheckGuard()
+
+		/** Limits that can never be reached: spell checking is never suspended on its own. */
+		val Disabled = SpellCheckGuard(
+			maxMisspellings = Int.MAX_VALUE,
+			minWordSample = Int.MAX_VALUE,
+			minSentenceSample = Int.MAX_VALUE,
+		)
+	}
+}
+
+/**
+ * Why spell checking suspended itself. See [SpellCheckGuard].
+ *
+ * A suspension is sticky: checking stays off until the checker is replaced or
+ * [SpellCheckState.resumeSpellChecking] is called, so a wrong-language checker isn't asked
+ * to re-scan the document on every keystroke.
+ */
+sealed interface SpellCheckSuspension {
+	/**
+	 * Nearly everything checked came back wrong, which usually means the checker's dictionary
+	 * doesn't match the document's language.
+	 *
+	 * @property checked How many items were evaluated (words or sentences, per [SpellCheckMode]).
+	 * @property flagged How many of those were flagged.
+	 */
+	data class LikelyWrongLanguage(val checked: Int, val flagged: Int) : SpellCheckSuspension
+
+	/**
+	 * More flagged items accumulated than [SpellCheckGuard.maxMisspellings] allows.
+	 *
+	 * @property flagged How many flagged items had accumulated.
+	 * @property limit The limit that was exceeded.
+	 */
+	data class TooManyMisspellings(val flagged: Int, val limit: Int) : SpellCheckSuspension
+}
+
+/** Trips when more than [SpellCheckGuard.maxMisspellings] items have been flagged. */
+internal fun SpellCheckGuard.evaluateCount(flagged: Int): SpellCheckSuspension? =
+	if (flagged > maxMisspellings) {
+		SpellCheckSuspension.TooManyMisspellings(flagged, maxMisspellings)
+	} else {
+		null
+	}
+
+/** Trips when too large a share of a large enough word sample is flagged. */
+internal fun SpellCheckGuard.evaluateWordRatio(checked: Int, flagged: Int): SpellCheckSuspension? =
+	evaluateRatio(checked, flagged, minWordSample)
+
+/** Trips when too large a share of a large enough sentence sample is flagged. */
+internal fun SpellCheckGuard.evaluateSentenceRatio(checked: Int, flagged: Int): SpellCheckSuspension? =
+	evaluateRatio(checked, flagged, minSentenceSample)
+
+private fun SpellCheckGuard.evaluateRatio(
+	checked: Int,
+	flagged: Int,
+	minSample: Int,
+): SpellCheckSuspension? =
+	if (checked >= minSample && flagged > checked * maxFlaggedRatio) {
+		SpellCheckSuspension.LikelyWrongLanguage(checked, flagged)
+	} else {
+		null
+	}

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckGuard.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckGuard.kt
@@ -56,11 +56,11 @@ data class SpellCheckGuard(
 /**
  * Why spell checking suspended itself. See [SpellCheckGuard].
  *
- * A suspension is sticky: checking stays off until the checker is replaced, a full check is
- * explicitly requested ([SpellCheckState.resumeSpellChecking] or
- * [SpellCheckState.runFullSpellCheck]), or checking is re-enabled via
- * [SpellCheckState.setSpellCheckingEnabled]. This way a wrong-language checker isn't asked
- * to re-scan the document on every keystroke.
+ * A suspension is sticky: automatic checking stays off so a wrong-language checker isn't
+ * asked to re-scan the document on every keystroke. A full re-check (a replaced checker,
+ * [SpellCheckState.resumeSpellChecking], [SpellCheckState.runFullSpellCheck], or re-enabling
+ * via [SpellCheckState.setSpellCheckingEnabled]) re-tries the checker and lifts the
+ * suspension once a scan completes with plausible results.
  */
 sealed interface SpellCheckSuspension {
 	/**

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckState.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckState.kt
@@ -65,8 +65,9 @@ class SpellCheckState(
 	 * Why the [guard] suspended spell checking, or `null` while checking is running normally.
 	 *
 	 * Observable from composition, so UI can surface "spell checking paused: the dictionary may
-	 * not match this document's language". Cleared by [resumeSpellChecking], an explicit
-	 * [runFullSpellCheck], or [setSpellCheckingEnabled] with `true`.
+	 * not match this document's language". A full re-check ([resumeSpellChecking], an explicit
+	 * [runFullSpellCheck], or [setSpellCheckingEnabled] with `true`) re-tries the checker and
+	 * lifts this once a scan completes with plausible results.
 	 */
 	var suspension: SpellCheckSuspension? by mutableStateOf(null)
 		private set
@@ -75,8 +76,8 @@ class SpellCheckState(
 	 * Enable or disable spell checking.
 	 *
 	 * Enabling triggers a full re-check when checking was previously disabled or suspended by
-	 * the [guard], clearing any [suspension]; disabling clears all existing spell-check
-	 * decorations.
+	 * the [guard]; a clean re-check lifts any [suspension]. Disabling clears all existing
+	 * spell-check decorations.
 	 *
 	 * @param value The new enabled state.
 	 */
@@ -91,11 +92,11 @@ class SpellCheckState(
 	}
 
 	/**
-	 * Clear a [suspension] and re-check the document.
+	 * Re-check the document, lifting a [suspension] if the results come back plausible.
 	 *
 	 * Intended for after the underlying problem is addressed, typically by swapping
 	 * [spellChecker] for one with the right language. Re-checking with the same checker over
-	 * the same text will simply trip the [guard] again.
+	 * the same text will simply trip the [guard] again, and the suspension stays in place.
 	 */
 	suspend fun resumeSpellChecking() {
 		runFullSpellCheck()
@@ -213,12 +214,12 @@ class SpellCheckState(
 	/**
 	 * Run full spell check based on the current mode.
 	 *
-	 * An explicit full check is a fresh chance for the checker: any [guard] [suspension] is
-	 * cleared before scanning, and the scan may trip the guard again if the results still look
-	 * implausible. No-op while checking is disabled via [setSpellCheckingEnabled].
+	 * An explicit full check is a fresh chance for the checker: it scans even while the [guard]
+	 * has checking suspended, and a clean completion lifts the [suspension]. Implausible
+	 * results trip the guard again, leaving the suspension in place the whole time rather than
+	 * flickering it off and on. No-op while checking is disabled via [setSpellCheckingEnabled].
 	 */
 	suspend fun runFullSpellCheck() {
-		suspension = null
 		when (spellCheckMode) {
 			SpellCheckMode.Word -> runFullWordCheck()
 			SpellCheckMode.Sentence -> runFullSentenceCheck()
@@ -241,7 +242,7 @@ class SpellCheckState(
 	 */
 	private suspend fun runFullWordCheck() {
 		val sp = spellChecker ?: return
-		if (canSpellCheck().not()) return
+		if (spellCheckingEnabled.not()) return
 
 		println("Running full Word Spell Check")
 
@@ -268,9 +269,11 @@ class SpellCheckState(
 			}
 		}
 
-		// A concurrent partial check may have tripped the guard while this check was
-		// suspended on lookups; adding spans now would undo its cleanup.
-		if (canSpellCheck().not()) return
+		// Re-check after the async lookups: a concurrent disable must not have its
+		// clearing undone by this swap. A concurrent guard trip, in contrast, is
+		// superseded; this scan just judged the whole document and passed.
+		if (spellCheckingEnabled.not()) return
+		suspension = null
 
 		// Swap atomically: no suspension points between removal and re-add.
 		textState.apply {
@@ -289,7 +292,7 @@ class SpellCheckState(
 	 */
 	private suspend fun runFullSentenceCheck() {
 		val sp = spellChecker ?: return
-		if (canSpellCheck().not()) return
+		if (spellCheckingEnabled.not()) return
 
 		println("Running full Sentence Spell Check")
 
@@ -314,9 +317,11 @@ class SpellCheckState(
 			}
 		}
 
-		// A concurrent partial check may have tripped the guard while this check was
-		// suspended on lookups; adding spans now would undo its cleanup.
-		if (canSpellCheck().not()) return
+		// Re-check after the async lookups: a concurrent disable must not have its
+		// clearing undone by this swap. A concurrent guard trip, in contrast, is
+		// superseded; this scan just judged the whole document and passed.
+		if (spellCheckingEnabled.not()) return
+		suspension = null
 
 		textState.apply {
 			richSpanManager.getAllRichSpans()

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckState.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckState.kt
@@ -1,5 +1,8 @@
 package com.darkrockstudios.texteditor.spellcheck
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.util.fastForEach
 import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.richstyle.RichSpan
@@ -43,22 +46,36 @@ enum class SpellCheckMode {
  * @param enableSpellChecking Whether spell checking is active initially; exposed via
  *   [spellCheckingEnabled].
  * @property spellCheckMode Whether checking operates per-word or per-sentence; see [SpellCheckMode].
+ * @property guard Sanity limits that suspend checking when its results stop looking plausible —
+ *   most importantly a checker loaded with the wrong language, which flags every word. See
+ *   [SpellCheckGuard] and [suspension]; pass [SpellCheckGuard.Disabled] to opt out.
  */
 class SpellCheckState(
 	val textState: TextEditorState,
 	var spellChecker: EditorSpellChecker?,
 	enableSpellChecking: Boolean = true,
 	var spellCheckMode: SpellCheckMode = SpellCheckMode.Word,
+	var guard: SpellCheckGuard = SpellCheckGuard.Default,
 ) {
 	/** Whether spell checking is currently active. Toggle via [setSpellCheckingEnabled]. */
 	var spellCheckingEnabled: Boolean = enableSpellChecking
 		private set
 
 	/**
+	 * Why the [guard] suspended spell checking, or `null` while checking is running normally.
+	 *
+	 * Observable from composition, so UI can surface "spell checking paused — the dictionary may
+	 * not match this document's language". Cleared by [resumeSpellChecking] or by re-enabling
+	 * checking via [setSpellCheckingEnabled].
+	 */
+	var suspension: SpellCheckSuspension? by mutableStateOf(null)
+		private set
+
+	/**
 	 * Enable or disable spell checking.
 	 *
-	 * Enabling when previously disabled triggers a full re-check; disabling clears all existing
-	 * spell-check decorations.
+	 * Enabling when previously disabled triggers a full re-check and clears any [suspension];
+	 * disabling clears all existing spell-check decorations.
 	 *
 	 * @param value The new enabled state.
 	 */
@@ -66,10 +83,36 @@ class SpellCheckState(
 		val wasEnabled = spellCheckingEnabled
 		spellCheckingEnabled = value
 		if (value && !wasEnabled) {
+			suspension = null
 			runFullSpellCheck()
 		} else if (!value) {
 			clearSpellCheck()
 		}
+	}
+
+	/**
+	 * Clear a [suspension] and re-check the document.
+	 *
+	 * Intended for after the underlying problem is addressed — typically swapping [spellChecker]
+	 * for one with the right language. Re-checking with the same checker over the same text will
+	 * simply trip the [guard] again.
+	 */
+	suspend fun resumeSpellChecking() {
+		suspension = null
+		runFullSpellCheck()
+	}
+
+	/** Checks only run when the caller wants them and the guard hasn't tripped. */
+	private fun canSpellCheck(): Boolean = spellCheckingEnabled && suspension == null
+
+	/**
+	 * Drop every decoration and stop checking until the checker changes or the caller calls
+	 * [resumeSpellChecking].
+	 */
+	private fun suspendSpellChecking(reason: SpellCheckSuspension) {
+		println("Suspending spell check: $reason")
+		clearSpellCheck()
+		suspension = reason
 	}
 
 	private var lastTextHash = -1
@@ -195,15 +238,30 @@ class SpellCheckState(
 	 */
 	private suspend fun runFullWordCheck() {
 		val sp = spellChecker ?: return
-		if (spellCheckingEnabled.not()) return
+		if (canSpellCheck().not()) return
 
 		println("Running full Word Spell Check")
 
 		// Compute the misspellings under suspension WITHOUT touching spans. A
 		// cancellation here (e.g. a recomposition restarting the check) leaves the
 		// existing spans intact rather than wiping them.
-		val candidates = textState.wordSegments().filter(::shouldSpellCheck).toList()
-		val misspelled = candidates.filterNot { sp.isCorrectWord(it.text) }
+		val misspelled = mutableListOf<WordSegment>()
+		var checked = 0
+		for (candidate in textState.wordSegments().filter(::shouldSpellCheck)) {
+			checked++
+			if (sp.isCorrectWord(candidate.text).not()) {
+				misspelled.add(candidate)
+			}
+
+			// Evaluated as we go so a wrong-language checker doesn't get dragged
+			// through every word of a large document before we give up on it.
+			val trip = guard.evaluateCount(misspelled.size)
+				?: guard.evaluateWordRatio(checked, misspelled.size)
+			if (trip != null) {
+				suspendSpellChecking(trip)
+				return
+			}
+		}
 
 		// Swap atomically: no suspension points between removal and re-add.
 		textState.apply {
@@ -222,14 +280,29 @@ class SpellCheckState(
 	 */
 	private suspend fun runFullSentenceCheck() {
 		val sp = spellChecker ?: return
-		if (spellCheckingEnabled.not()) return
+		if (canSpellCheck().not()) return
 
 		println("Running full Sentence Spell Check")
 
 		// Compute corrections under suspension first; only mutate spans once the
 		// async work is done, so a cancellation can't leave the document wiped.
-		val corrections = textState.sentenceSegments().toList().flatMap { sentence ->
-			sp.checkSentence(sentence.text, sentence.range)
+		val corrections = mutableListOf<Correction>()
+		var checked = 0
+		var flaggedSentences = 0
+		for (sentence in textState.sentenceSegments()) {
+			checked++
+			val found = sp.checkSentence(sentence.text, sentence.range)
+			if (found.isNotEmpty()) flaggedSentences++
+			corrections.addAll(found)
+
+			// Evaluated as we go so a wrong-language checker doesn't get dragged
+			// through every sentence of a large document before we give up on it.
+			val trip = guard.evaluateCount(corrections.size)
+				?: guard.evaluateSentenceRatio(checked, flaggedSentences)
+			if (trip != null) {
+				suspendSpellChecking(trip)
+				return
+			}
 		}
 
 		textState.apply {
@@ -245,7 +318,7 @@ class SpellCheckState(
 
 	private suspend fun runPartialWordCheck(range: TextEditorRange) {
 		val sp = spellChecker ?: return
-		if (spellCheckingEnabled.not()) return
+		if (canSpellCheck().not()) return
 
 		// Compute misspellings under suspension before touching spans, so a
 		// cancellation leaves the range's existing spans intact.
@@ -259,6 +332,10 @@ class SpellCheckState(
 		removeMissSpellingsInRange(range)
 		misspelled.forEach { textState.addRichSpan(it.range, SpellCheckStyle) }
 		misspelledWords.addAll(misspelled)
+
+		// A partial check's sample is far too small to judge the ratio on, but the
+		// running total still has to stay under the cap as edits pile up.
+		guard.evaluateCount(misspelledWords.size)?.let { suspendSpellChecking(it) }
 	}
 
 	/**
@@ -266,7 +343,7 @@ class SpellCheckState(
 	 */
 	private suspend fun runPartialSentenceCheck(range: TextEditorRange) {
 		val sp = spellChecker ?: return
-		if (spellCheckingEnabled.not()) return
+		if (canSpellCheck().not()) return
 
 		// Compute corrections under suspension before touching spans, so a
 		// cancellation leaves the range's existing spans intact.
@@ -281,17 +358,25 @@ class SpellCheckState(
 		removeSentenceCorrectionsInRange(range)
 		corrections.forEach { textState.addRichSpan(it.range, SpellCheckStyle) }
 		sentenceCorrections.addAll(corrections)
+
+		// A partial check's sample is far too small to judge the ratio on, but the
+		// running total still has to stay under the cap as edits pile up.
+		guard.evaluateCount(sentenceCorrections.size)?.let { suspendSpellChecking(it) }
 	}
 
 	/**
 	 * Run spell check on a specific word segment.
 	 * This will remove any existing spell check spans for the word and add a new one if misspelled.
 	 *
+	 * Returns false without touching the document while checking is disabled or the [guard] has
+	 * suspended it.
+	 *
 	 * @param segment The word segment to check
 	 * @return true if the word is misspelled and a new span was added, false otherwise
 	 */
 	suspend fun checkWordSegment(segment: WordSegment): Boolean {
 		val sp = spellChecker ?: return false
+		if (canSpellCheck().not()) return false
 
 		// Resolve the async lookup first; only mutate spans afterward so a
 		// cancellation can't leave the word's span removed-but-not-restored.
@@ -310,7 +395,10 @@ class SpellCheckState(
 			}
 		}
 
-		return !isSpelledCorrectly
+		// One more word can be the one that pushes the running total over the cap.
+		guard.evaluateCount(misspelledWords.size)?.let { suspendSpellChecking(it) }
+
+		return !isSpelledCorrectly && suspension == null
 	}
 
 	private fun shouldSpellCheck(segment: WordSegment): Boolean {

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckState.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckState.kt
@@ -46,7 +46,7 @@ enum class SpellCheckMode {
  * @param enableSpellChecking Whether spell checking is active initially; exposed via
  *   [spellCheckingEnabled].
  * @property spellCheckMode Whether checking operates per-word or per-sentence; see [SpellCheckMode].
- * @property guard Sanity limits that suspend checking when its results stop looking plausible —
+ * @property guard Sanity limits that suspend checking when its results stop looking plausible,
  *   most importantly a checker loaded with the wrong language, which flags every word. See
  *   [SpellCheckGuard] and [suspension]; pass [SpellCheckGuard.Disabled] to opt out.
  */
@@ -64,9 +64,9 @@ class SpellCheckState(
 	/**
 	 * Why the [guard] suspended spell checking, or `null` while checking is running normally.
 	 *
-	 * Observable from composition, so UI can surface "spell checking paused — the dictionary may
-	 * not match this document's language". Cleared by [resumeSpellChecking] or by re-enabling
-	 * checking via [setSpellCheckingEnabled].
+	 * Observable from composition, so UI can surface "spell checking paused: the dictionary may
+	 * not match this document's language". Cleared by [resumeSpellChecking], an explicit
+	 * [runFullSpellCheck], or [setSpellCheckingEnabled] with `true`.
 	 */
 	var suspension: SpellCheckSuspension? by mutableStateOf(null)
 		private set
@@ -74,16 +74,16 @@ class SpellCheckState(
 	/**
 	 * Enable or disable spell checking.
 	 *
-	 * Enabling when previously disabled triggers a full re-check and clears any [suspension];
-	 * disabling clears all existing spell-check decorations.
+	 * Enabling triggers a full re-check when checking was previously disabled or suspended by
+	 * the [guard], clearing any [suspension]; disabling clears all existing spell-check
+	 * decorations.
 	 *
 	 * @param value The new enabled state.
 	 */
 	suspend fun setSpellCheckingEnabled(value: Boolean) {
 		val wasEnabled = spellCheckingEnabled
 		spellCheckingEnabled = value
-		if (value && !wasEnabled) {
-			suspension = null
+		if (value && (!wasEnabled || suspension != null)) {
 			runFullSpellCheck()
 		} else if (!value) {
 			clearSpellCheck()
@@ -93,24 +93,22 @@ class SpellCheckState(
 	/**
 	 * Clear a [suspension] and re-check the document.
 	 *
-	 * Intended for after the underlying problem is addressed — typically swapping [spellChecker]
-	 * for one with the right language. Re-checking with the same checker over the same text will
-	 * simply trip the [guard] again.
+	 * Intended for after the underlying problem is addressed, typically by swapping
+	 * [spellChecker] for one with the right language. Re-checking with the same checker over
+	 * the same text will simply trip the [guard] again.
 	 */
 	suspend fun resumeSpellChecking() {
-		suspension = null
 		runFullSpellCheck()
 	}
 
-	/** Checks only run when the caller wants them and the guard hasn't tripped. */
+	/** Automatic checks only run when checking is enabled and the guard hasn't tripped. */
 	private fun canSpellCheck(): Boolean = spellCheckingEnabled && suspension == null
 
 	/**
-	 * Drop every decoration and stop checking until the checker changes or the caller calls
-	 * [resumeSpellChecking].
+	 * Drop every decoration and stop automatic checking until the checker changes or a caller
+	 * explicitly resumes (see [suspension]).
 	 */
 	private fun suspendSpellChecking(reason: SpellCheckSuspension) {
-		println("Suspending spell check: $reason")
 		clearSpellCheck()
 		suspension = reason
 	}
@@ -214,8 +212,13 @@ class SpellCheckState(
 
 	/**
 	 * Run full spell check based on the current mode.
+	 *
+	 * An explicit full check is a fresh chance for the checker: any [guard] [suspension] is
+	 * cleared before scanning, and the scan may trip the guard again if the results still look
+	 * implausible. No-op while checking is disabled via [setSpellCheckingEnabled].
 	 */
 	suspend fun runFullSpellCheck() {
+		suspension = null
 		when (spellCheckMode) {
 			SpellCheckMode.Word -> runFullWordCheck()
 			SpellCheckMode.Sentence -> runFullSentenceCheck()
@@ -245,23 +248,29 @@ class SpellCheckState(
 		// Compute the misspellings under suspension WITHOUT touching spans. A
 		// cancellation here (e.g. a recomposition restarting the check) leaves the
 		// existing spans intact rather than wiping them.
+		val candidates = textState.wordSegments().filter(::shouldSpellCheck).toList()
 		val misspelled = mutableListOf<WordSegment>()
-		var checked = 0
-		for (candidate in textState.wordSegments().filter(::shouldSpellCheck)) {
-			checked++
+		for (candidate in candidates) {
 			if (sp.isCorrectWord(candidate.text).not()) {
 				misspelled.add(candidate)
 			}
 
-			// Evaluated as we go so a wrong-language checker doesn't get dragged
-			// through every word of a large document before we give up on it.
+			// The ratio is judged against the whole document's word count, so a run of
+			// foreign words (an epigraph, a code block) can't condemn an otherwise fine
+			// document. Mid-loop the flagged count is a lower bound on the final one,
+			// making this an early bail that only fires once the document-wide outcome
+			// is already decided.
 			val trip = guard.evaluateCount(misspelled.size)
-				?: guard.evaluateWordRatio(checked, misspelled.size)
+				?: guard.evaluateWordRatio(candidates.size, misspelled.size)
 			if (trip != null) {
 				suspendSpellChecking(trip)
 				return
 			}
 		}
+
+		// A concurrent partial check may have tripped the guard while this check was
+		// suspended on lookups; adding spans now would undo its cleanup.
+		if (canSpellCheck().not()) return
 
 		// Swap atomically: no suspension points between removal and re-add.
 		textState.apply {
@@ -286,24 +295,28 @@ class SpellCheckState(
 
 		// Compute corrections under suspension first; only mutate spans once the
 		// async work is done, so a cancellation can't leave the document wiped.
+		val sentences = textState.sentenceSegments().toList()
 		val corrections = mutableListOf<Correction>()
-		var checked = 0
 		var flaggedSentences = 0
-		for (sentence in textState.sentenceSegments()) {
-			checked++
+		for (sentence in sentences) {
 			val found = sp.checkSentence(sentence.text, sentence.range)
 			if (found.isNotEmpty()) flaggedSentences++
 			corrections.addAll(found)
 
-			// Evaluated as we go so a wrong-language checker doesn't get dragged
-			// through every sentence of a large document before we give up on it.
+			// Judged against the whole document's sentence count; mid-loop the flagged
+			// count is a lower bound, so this early bail only fires once the
+			// document-wide outcome is already decided.
 			val trip = guard.evaluateCount(corrections.size)
-				?: guard.evaluateSentenceRatio(checked, flaggedSentences)
+				?: guard.evaluateSentenceRatio(sentences.size, flaggedSentences)
 			if (trip != null) {
 				suspendSpellChecking(trip)
 				return
 			}
 		}
+
+		// A concurrent partial check may have tripped the guard while this check was
+		// suspended on lookups; adding spans now would undo its cleanup.
+		if (canSpellCheck().not()) return
 
 		textState.apply {
 			richSpanManager.getAllRichSpans()
@@ -325,6 +338,10 @@ class SpellCheckState(
 		val candidates = textState.wordSegmentsInRange(range).filter(::shouldSpellCheck)
 		val misspelled = candidates.filterNot { sp.isCorrectWord(it.text) }
 
+		// A concurrent check may have tripped the guard while this check was suspended
+		// on lookups; adding spans now would undo its cleanup.
+		if (canSpellCheck().not()) return
+
 		// Swap atomically: no suspension points between removal and re-add.
 		textState.richSpanManager.getSpansInRange(range)
 			.filter { it.style is SpellCheckStyle }
@@ -333,9 +350,14 @@ class SpellCheckState(
 		misspelled.forEach { textState.addRichSpan(it.range, SpellCheckStyle) }
 		misspelledWords.addAll(misspelled)
 
-		// A partial check's sample is far too small to judge the ratio on, but the
-		// running total still has to stay under the cap as edits pile up.
-		guard.evaluateCount(misspelledWords.size)?.let { suspendSpellChecking(it) }
+		// Judge the whole document after folding this range in, so a wrong-language
+		// checker is caught even when the document was built up by typing. Live spans
+		// are counted rather than the bookkeeping lists: the span manager keeps their
+		// positions correct across edits, so they can't accumulate stale duplicates.
+		val flagged = spellCheckSpanCount()
+		val trip = guard.evaluateCount(flagged)
+			?: guard.evaluateWordRatio(documentWordCount(), flagged)
+		trip?.let { suspendSpellChecking(it) }
 	}
 
 	/**
@@ -351,6 +373,10 @@ class SpellCheckState(
 			sp.checkSentence(sentence.text, sentence.range)
 		}
 
+		// A concurrent check may have tripped the guard while this check was suspended
+		// on lookups; adding spans now would undo its cleanup.
+		if (canSpellCheck().not()) return
+
 		// Swap atomically: no suspension points between removal and re-add.
 		textState.richSpanManager.getSpansInRange(range)
 			.filter { it.style is SpellCheckStyle }
@@ -359,47 +385,65 @@ class SpellCheckState(
 		corrections.forEach { textState.addRichSpan(it.range, SpellCheckStyle) }
 		sentenceCorrections.addAll(corrections)
 
-		// A partial check's sample is far too small to judge the ratio on, but the
-		// running total still has to stay under the cap as edits pile up.
-		guard.evaluateCount(sentenceCorrections.size)?.let { suspendSpellChecking(it) }
+		// Judge the whole document after folding this range in. Live spans are counted
+		// rather than the bookkeeping lists: the span manager keeps their positions
+		// correct across edits, so they can't accumulate stale duplicates.
+		val sentences = textState.sentenceSegments().toList()
+		val flaggedSentences = sentences.count { sentence ->
+			textState.getRichSpansInRange(sentence.range).any { it.style is SpellCheckStyle }
+		}
+		val trip = guard.evaluateCount(spellCheckSpanCount())
+			?: guard.evaluateSentenceRatio(sentences.size, flaggedSentences)
+		trip?.let { suspendSpellChecking(it) }
 	}
 
 	/**
 	 * Run spell check on a specific word segment.
 	 * This will remove any existing spell check spans for the word and add a new one if misspelled.
 	 *
-	 * Returns false without touching the document while checking is disabled or the [guard] has
-	 * suspended it.
+	 * The lookup always runs, but the document is only decorated while checking is enabled and
+	 * not suspended by the [guard].
 	 *
 	 * @param segment The word segment to check
-	 * @return true if the word is misspelled and a new span was added, false otherwise
+	 * @return true if the word is misspelled, false otherwise
 	 */
 	suspend fun checkWordSegment(segment: WordSegment): Boolean {
 		val sp = spellChecker ?: return false
-		if (canSpellCheck().not()) return false
 
 		// Resolve the async lookup first; only mutate spans afterward so a
 		// cancellation can't leave the word's span removed-but-not-restored.
 		val isSpelledCorrectly = sp.isCorrectWord(segment.text)
 
-		removeMissSpellingsInRange(segment.range)
-		textState.apply {
-			getRichSpansInRange(segment.range)
-				.filter { it.style is SpellCheckStyle }
-				.forEach { removeRichSpan(it) }
+		if (canSpellCheck()) {
+			removeMissSpellingsInRange(segment.range)
+			textState.apply {
+				getRichSpansInRange(segment.range)
+					.filter { it.style is SpellCheckStyle }
+					.forEach { removeRichSpan(it) }
 
-			if (!isSpelledCorrectly) {
-				addRichSpan(segment.range, SpellCheckStyle)
-				misspelledWords.removeAll { it.range == segment.range }
-				misspelledWords.add(segment)
+				if (!isSpelledCorrectly) {
+					addRichSpan(segment.range, SpellCheckStyle)
+					misspelledWords.removeAll { it.range == segment.range }
+					misspelledWords.add(segment)
+				}
 			}
+
+			// One more word can be the one that pushes the total over the cap.
+			guard.evaluateCount(spellCheckSpanCount())?.let { suspendSpellChecking(it) }
 		}
 
-		// One more word can be the one that pushes the running total over the cap.
-		guard.evaluateCount(misspelledWords.size)?.let { suspendSpellChecking(it) }
-
-		return !isSpelledCorrectly && suspension == null
+		return !isSpelledCorrectly
 	}
+
+	/**
+	 * Live spell-check decorations on the document. The span manager keeps span positions
+	 * correct across edits, so this is the honest flag count for [guard] decisions.
+	 */
+	private fun spellCheckSpanCount(): Int =
+		textState.richSpanManager.getAllRichSpans().count { it.style is SpellCheckStyle }
+
+	private fun documentWordCount(): Int =
+		textState.wordSegments().count(::shouldSpellCheck)
 
 	private fun shouldSpellCheck(segment: WordSegment): Boolean {
 		// Skip segments that are purely numeric

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/rememberSpellCheckState.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/rememberSpellCheckState.kt
@@ -10,15 +10,17 @@ import com.darkrockstudios.texteditor.state.rememberTextEditorState
 /**
  * Remembers a [SpellCheckState] for the editor.
  *
- * Pass a STABLE [spellChecker] instance — `remember` it across recompositions and
+ * Pass a STABLE [spellChecker] instance: `remember` it across recompositions and
  * only create a new one when the underlying dictionary actually changes. A fresh
  * instance every recomposition re-keys the full-rescan effect below and re-scans
- * the whole document on each frame. (Re-scans are cancellation-safe and won't lose
- * spans, but the churn is pure waste.)
+ * the whole document on each frame. Re-scans are cancellation-safe and won't lose
+ * spans, but the churn is pure waste, and it also clears any guard suspension each
+ * frame, defeating the suspension's stickiness.
  *
  * @param guard Sanity limits that suspend checking when its results stop looking plausible;
- *   see [SpellCheckGuard] and [SpellCheckState.suspension]. A new [spellChecker] clears any
- *   suspension, since swapping the checker is how a wrong-language one gets fixed.
+ *   see [SpellCheckGuard] and [SpellCheckState.suspension]. Changing [guard] or [spellChecker]
+ *   on recomposition clears any standing suspension, since swapping the checker (or loosening
+ *   the limits) is how a wrong-language suspension gets fixed.
  */
 @Composable
 fun rememberSpellCheckState(
@@ -33,19 +35,34 @@ fun rememberSpellCheckState(
 		SpellCheckState(richTextState, spellChecker, enableSpellChecking, spellCheckMode, guard)
 	}
 
-	// Run SpellCheck as soon as it is ready. A different checker is a fresh chance for
-	// the guard, so `resumeSpellChecking` rather than a plain re-check: the new checker
-	// may well be the right-language one the previous suspension was asking for.
+	// Run SpellCheck as soon as it is ready. A full check clears any guard suspension,
+	// so a replacement checker gets a fresh chance: it may well be the right-language
+	// one the previous suspension was asking for.
 	LaunchedEffect(spellChecker) {
 		if (spellChecker != null) {
 			state.spellChecker = spellChecker
-			state.resumeSpellChecking()
+			state.runFullSpellCheck()
 		}
 	}
 
-	// Propagate enableSpellChecking changes to the state so callers can toggle it on recomposition
+	// Propagate guard changes to the remembered state. A laxer guard can make a
+	// standing suspension obsolete, so re-check under the new limits.
+	LaunchedEffect(guard) {
+		if (state.guard != guard) {
+			state.guard = guard
+			if (state.suspension != null) {
+				state.resumeSpellChecking()
+			}
+		}
+	}
+
+	// Propagate enableSpellChecking changes to the state so callers can toggle it on
+	// recomposition. The initial value was applied by the constructor; skipping it here
+	// keeps this from re-running the full check the checker effect already started.
 	LaunchedEffect(enableSpellChecking) {
-		state.setSpellCheckingEnabled(enableSpellChecking)
+		if (state.spellCheckingEnabled != enableSpellChecking) {
+			state.setSpellCheckingEnabled(enableSpellChecking)
+		}
 	}
 
 	return state

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/rememberSpellCheckState.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/rememberSpellCheckState.kt
@@ -13,14 +13,15 @@ import com.darkrockstudios.texteditor.state.rememberTextEditorState
  * Pass a STABLE [spellChecker] instance: `remember` it across recompositions and
  * only create a new one when the underlying dictionary actually changes. A fresh
  * instance every recomposition re-keys the full-rescan effect below and re-scans
- * the whole document on each frame. Re-scans are cancellation-safe and won't lose
- * spans, but the churn is pure waste, and it also clears any guard suspension each
- * frame, defeating the suspension's stickiness.
+ * the whole document on each frame. Re-scans are cancellation-safe, bail at the
+ * guard's trip point, and never lift a suspension unless they complete with
+ * plausible results, but the churn is pure waste.
  *
  * @param guard Sanity limits that suspend checking when its results stop looking plausible;
  *   see [SpellCheckGuard] and [SpellCheckState.suspension]. Changing [guard] or [spellChecker]
- *   on recomposition clears any standing suspension, since swapping the checker (or loosening
- *   the limits) is how a wrong-language suspension gets fixed.
+ *   on recomposition triggers a re-check that lifts any standing suspension when its results
+ *   come back clean, since swapping the checker (or loosening the limits) is how a
+ *   wrong-language suspension gets fixed.
  */
 @Composable
 fun rememberSpellCheckState(
@@ -35,9 +36,10 @@ fun rememberSpellCheckState(
 		SpellCheckState(richTextState, spellChecker, enableSpellChecking, spellCheckMode, guard)
 	}
 
-	// Run SpellCheck as soon as it is ready. A full check clears any guard suspension,
-	// so a replacement checker gets a fresh chance: it may well be the right-language
-	// one the previous suspension was asking for.
+	// Run SpellCheck as soon as it is ready. A full check scans even while suspended
+	// and lifts the suspension only on plausible results, so a replacement checker
+	// gets a fresh chance (it may well be the right-language one the previous
+	// suspension was asking for) without the banner flickering when it isn't.
 	LaunchedEffect(spellChecker) {
 		if (spellChecker != null) {
 			state.spellChecker = spellChecker

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/rememberSpellCheckState.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/rememberSpellCheckState.kt
@@ -15,6 +15,10 @@ import com.darkrockstudios.texteditor.state.rememberTextEditorState
  * instance every recomposition re-keys the full-rescan effect below and re-scans
  * the whole document on each frame. (Re-scans are cancellation-safe and won't lose
  * spans, but the churn is pure waste.)
+ *
+ * @param guard Sanity limits that suspend checking when its results stop looking plausible;
+ *   see [SpellCheckGuard] and [SpellCheckState.suspension]. A new [spellChecker] clears any
+ *   suspension, since swapping the checker is how a wrong-language one gets fixed.
  */
 @Composable
 fun rememberSpellCheckState(
@@ -22,15 +26,20 @@ fun rememberSpellCheckState(
 	initialText: AnnotatedString? = null,
 	enableSpellChecking: Boolean = true,
 	spellCheckMode: SpellCheckMode = SpellCheckMode.Word,
+	guard: SpellCheckGuard = SpellCheckGuard.Default,
 ): SpellCheckState {
 	val richTextState = rememberTextEditorState(initialText)
-	val state = remember { SpellCheckState(richTextState, spellChecker, enableSpellChecking, spellCheckMode) }
+	val state = remember {
+		SpellCheckState(richTextState, spellChecker, enableSpellChecking, spellCheckMode, guard)
+	}
 
-	// Run SpellCheck as soon as it is ready
+	// Run SpellCheck as soon as it is ready. A different checker is a fresh chance for
+	// the guard, so `resumeSpellChecking` rather than a plain re-check: the new checker
+	// may well be the right-language one the previous suspension was asking for.
 	LaunchedEffect(spellChecker) {
 		if (spellChecker != null) {
 			state.spellChecker = spellChecker
-			state.runFullSpellCheck()
+			state.resumeSpellChecking()
 		}
 	}
 

--- a/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/SpellCheckGuardTest.kt
+++ b/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/SpellCheckGuardTest.kt
@@ -7,8 +7,6 @@ import androidx.compose.ui.text.TextMeasurer
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.richstyle.SpellCheckStyle
-import com.darkrockstudios.texteditor.spellcheck.api.EditorSpellChecker
-import com.darkrockstudios.texteditor.spellcheck.api.Suggestion
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.WordSegment
 import io.mockk.every
@@ -17,8 +15,8 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import utils.CountingSpellChecker
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -29,7 +27,7 @@ import kotlin.test.assertTrue
  */
 class SpellCheckGuardTest {
 	private lateinit var textState: TextEditorState
-	private lateinit var spellChecker: GuardMockSpellChecker
+	private lateinit var spellChecker: CountingSpellChecker
 
 	@Before
 	fun setup() {
@@ -55,7 +53,7 @@ class SpellCheckGuardTest {
 			measurer = textMeasurer,
 			initialText = null,
 		)
-		spellChecker = GuardMockSpellChecker()
+		spellChecker = CountingSpellChecker()
 	}
 
 	@Test
@@ -68,12 +66,13 @@ class SpellCheckGuardTest {
 		state.runFullSpellCheck()
 
 		val suspension = assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+		assertEquals(60, suspension.checked, "The ratio must be judged against the whole document")
 		assertTrue(suspension.flagged > suspension.checked * SpellCheckGuard.DEFAULT_MAX_FLAGGED_RATIO)
 		assertEquals(0, spellCheckSpanCount(), "A suspended check must not leave the document red")
 	}
 
 	@Test
-	fun `full check gives up before checking the whole document`() = runTest {
+	fun `full check gives up once the outcome is decided`() = runTest {
 		textState.setText(words(500).joinToString(" "))
 		spellChecker.correctWords = emptySet()
 		val state = SpellCheckState(textState, spellChecker)
@@ -81,9 +80,11 @@ class SpellCheckGuardTest {
 		state.runFullSpellCheck()
 
 		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+		// With everything flagged, the document-wide ratio is decided as soon as
+		// flagged exceeds total * ratio; the rest of the document is never checked.
 		assertTrue(
-			spellChecker.lookups < 100,
-			"Should bail shortly after the sample threshold, did ${spellChecker.lookups} lookups",
+			spellChecker.lookups < 400,
+			"Should bail once the ratio can no longer pass, did ${spellChecker.lookups} lookups",
 		)
 	}
 
@@ -98,6 +99,21 @@ class SpellCheckGuardTest {
 
 		assertNull(state.suspension)
 		assertEquals(3, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `a foreign passage in a large document does not suspend checking`() = runTest {
+		val words = words(200)
+		textState.setText(words.joinToString(" "))
+		// The first 45 words are "foreign": far past the old prefix threshold, but a
+		// small fraction of the document.
+		spellChecker.correctWords = words.drop(45).toSet()
+		val state = SpellCheckState(textState, spellChecker)
+
+		state.runFullSpellCheck()
+
+		assertNull(state.suspension, "A local run of flagged words must not condemn the document")
+		assertEquals(45, spellCheckSpanCount())
 	}
 
 	@Test
@@ -116,7 +132,7 @@ class SpellCheckGuardTest {
 	}
 
 	@Test
-	fun `checking stays off while suspended`() = runTest {
+	fun `partial checks stay off while suspended`() = runTest {
 		textState.setText(words(60).joinToString(" "))
 		spellChecker.correctWords = emptySet()
 		val state = SpellCheckState(textState, spellChecker)
@@ -124,11 +140,24 @@ class SpellCheckGuardTest {
 		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
 
 		val lookupsWhenSuspended = spellChecker.lookups
-		state.runFullSpellCheck()
 		state.runPartialSpellCheck(wholeFirstLine())
 
-		assertEquals(lookupsWhenSuspended, spellChecker.lookups, "No further lookups while suspended")
+		assertEquals(lookupsWhenSuspended, spellChecker.lookups, "No lookups while suspended")
 		assertEquals(0, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `a partial check trips the wrong-language ratio`() = runTest {
+		// No initial full check: the document was "built up by typing" and only
+		// partial checks ever ran.
+		textState.setText(words(60).joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker)
+
+		state.runPartialSpellCheck(wholeFirstLine())
+
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+		assertEquals(0, spellCheckSpanCount(), "Tripping must clear every squiggle")
 	}
 
 	@Test
@@ -136,7 +165,7 @@ class SpellCheckGuardTest {
 		val words = words(30)
 		textState.setText(words.joinToString(" "))
 		spellChecker.correctWords = emptySet()
-		// Ratio can't trip here — only the absolute cap.
+		// Ratio can't trip here, only the absolute cap.
 		val state = SpellCheckState(
 			textState,
 			spellChecker,
@@ -173,11 +202,45 @@ class SpellCheckGuardTest {
 		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
 
 		// The fix for a wrong-language checker: swap in the right one.
-		state.spellChecker = GuardMockSpellChecker(correctWords = words.drop(2).toSet())
+		state.spellChecker = CountingSpellChecker(correctWords = words.drop(2).toSet())
 		state.resumeSpellChecking()
 
 		assertNull(state.suspension)
 		assertEquals(2, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `an explicit full check clears a suspension and re-checks`() = runTest {
+		val words = words(60)
+		textState.setText(words.joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker)
+		state.runFullSpellCheck()
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+
+		// The same checker instance was fixed in place (e.g. a dictionary reload).
+		spellChecker.correctWords = words.toSet()
+		state.runFullSpellCheck()
+
+		assertNull(state.suspension)
+		assertEquals(0, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `enabling checking while suspended clears the suspension`() = runTest {
+		val words = words(60)
+		textState.setText(words.joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker)
+		state.runFullSpellCheck()
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+
+		// Checking never went through false: the documented single-call recovery.
+		spellChecker.correctWords = words.toSet()
+		state.setSpellCheckingEnabled(true)
+
+		assertNull(state.suspension)
+		assertEquals(0, spellCheckSpanCount())
 	}
 
 	@Test
@@ -198,12 +261,13 @@ class SpellCheckGuardTest {
 	}
 
 	@Test
-	fun `word segment checks are inert while suspended`() = runTest {
+	fun `word segment checks answer but leave the document alone while suspended`() = runTest {
 		val words = words(60)
 		textState.setText(words.joinToString(" "))
 		spellChecker.correctWords = emptySet()
 		val state = SpellCheckState(textState, spellChecker)
 		state.runFullSpellCheck()
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
 
 		val segment = WordSegment(
 			text = words.first(),
@@ -213,8 +277,11 @@ class SpellCheckGuardTest {
 			),
 		)
 
-		assertFalse(state.checkWordSegment(segment))
-		assertEquals(0, spellCheckSpanCount())
+		assertTrue(
+			state.checkWordSegment(segment),
+			"An on-demand check must still answer truthfully",
+		)
+		assertEquals(0, spellCheckSpanCount(), "No decorations while suspended")
 	}
 
 	private fun spellCheckSpanCount(): Int =
@@ -227,23 +294,4 @@ class SpellCheckGuardTest {
 
 	/** Distinct, layout-independent words so segmentation yields exactly [count] segments. */
 	private fun words(count: Int): List<String> = List(count) { "wordnumber$it" }
-}
-
-private class GuardMockSpellChecker(
-	var correctWords: Set<String> = emptySet(),
-) : EditorSpellChecker {
-	/** How many word lookups the checker was asked for; proves the guard bails early. */
-	var lookups: Int = 0
-		private set
-
-	override suspend fun isCorrectWord(word: String): Boolean {
-		lookups++
-		return correctWords.contains(word)
-	}
-
-	override suspend fun suggestions(
-		input: String,
-		scope: EditorSpellChecker.Scope,
-		closestOnly: Boolean,
-	): List<Suggestion> = emptyList()
 }

--- a/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/SpellCheckGuardTest.kt
+++ b/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/SpellCheckGuardTest.kt
@@ -1,0 +1,249 @@
+package com.darkrockstudios.texteditor.spellcheck
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.MultiParagraph
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextMeasurer
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.richstyle.SpellCheckStyle
+import com.darkrockstudios.texteditor.spellcheck.api.EditorSpellChecker
+import com.darkrockstudios.texteditor.spellcheck.api.Suggestion
+import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.state.WordSegment
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the [SpellCheckGuard]: the protection against a checker whose dictionary doesn't match
+ * the document's language, which otherwise flags every single word.
+ */
+class SpellCheckGuardTest {
+	private lateinit var textState: TextEditorState
+	private lateinit var spellChecker: GuardMockSpellChecker
+
+	@Before
+	fun setup() {
+		val textMeasurer = mockk<TextMeasurer>()
+		every {
+			textMeasurer.measure(text = any<AnnotatedString>(), constraints = any())
+		} answers {
+			mockk<TextLayoutResult>().apply {
+				every { getLineStart(any()) } returns 0
+				every { getLineEnd(any()) } returns 5
+				every { lineCount } returns 1
+				every { multiParagraph } answers {
+					mockk<MultiParagraph>().apply {
+						every { lineCount } returns 1
+						every { getLineHeight(any()) } returns 10f
+					}
+				}
+			}
+		}
+
+		textState = TextEditorState(
+			scope = TestScope(),
+			measurer = textMeasurer,
+			initialText = null,
+		)
+		spellChecker = GuardMockSpellChecker()
+	}
+
+	@Test
+	fun `full check suspends when a wrong-language checker flags everything`() = runTest {
+		val words = words(60)
+		textState.setText(words.joinToString(" "))
+		spellChecker.correctWords = emptySet() // every word comes back wrong
+		val state = SpellCheckState(textState, spellChecker)
+
+		state.runFullSpellCheck()
+
+		val suspension = assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+		assertTrue(suspension.flagged > suspension.checked * SpellCheckGuard.DEFAULT_MAX_FLAGGED_RATIO)
+		assertEquals(0, spellCheckSpanCount(), "A suspended check must not leave the document red")
+	}
+
+	@Test
+	fun `full check gives up before checking the whole document`() = runTest {
+		textState.setText(words(500).joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker)
+
+		state.runFullSpellCheck()
+
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+		assertTrue(
+			spellChecker.lookups < 100,
+			"Should bail shortly after the sample threshold, did ${spellChecker.lookups} lookups",
+		)
+	}
+
+	@Test
+	fun `an ordinary document with a few typos is left alone`() = runTest {
+		val words = words(60)
+		textState.setText(words.joinToString(" "))
+		spellChecker.correctWords = words.drop(3).toSet() // 3 real typos
+		val state = SpellCheckState(textState, spellChecker)
+
+		state.runFullSpellCheck()
+
+		assertNull(state.suspension)
+		assertEquals(3, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `a short document is never suspended by ratio`() = runTest {
+		val words = words(10)
+		textState.setText(words.joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker)
+
+		state.runFullSpellCheck()
+
+		// Too small a sample to conclude anything from: a handful of squiggles is not
+		// worth a false positive.
+		assertNull(state.suspension)
+		assertEquals(10, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `checking stays off while suspended`() = runTest {
+		textState.setText(words(60).joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker)
+		state.runFullSpellCheck()
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+
+		val lookupsWhenSuspended = spellChecker.lookups
+		state.runFullSpellCheck()
+		state.runPartialSpellCheck(wholeFirstLine())
+
+		assertEquals(lookupsWhenSuspended, spellChecker.lookups, "No further lookups while suspended")
+		assertEquals(0, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `the misspelling cap suspends checking on its own`() = runTest {
+		val words = words(30)
+		textState.setText(words.joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		// Ratio can't trip here — only the absolute cap.
+		val state = SpellCheckState(
+			textState,
+			spellChecker,
+			guard = SpellCheckGuard(maxMisspellings = 10, minWordSample = Int.MAX_VALUE),
+		)
+
+		state.runFullSpellCheck()
+
+		val suspension = assertIs<SpellCheckSuspension.TooManyMisspellings>(state.suspension)
+		assertEquals(10, suspension.limit)
+		assertEquals(11, suspension.flagged)
+		assertEquals(0, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `a disabled guard never suspends`() = runTest {
+		textState.setText(words(60).joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker, guard = SpellCheckGuard.Disabled)
+
+		state.runFullSpellCheck()
+
+		assertNull(state.suspension)
+		assertEquals(60, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `resuming re-checks with the replacement checker`() = runTest {
+		val words = words(60)
+		textState.setText(words.joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker)
+		state.runFullSpellCheck()
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+
+		// The fix for a wrong-language checker: swap in the right one.
+		state.spellChecker = GuardMockSpellChecker(correctWords = words.drop(2).toSet())
+		state.resumeSpellChecking()
+
+		assertNull(state.suspension)
+		assertEquals(2, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `re-enabling checking clears a suspension`() = runTest {
+		val words = words(60)
+		textState.setText(words.joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker)
+		state.runFullSpellCheck()
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+
+		state.setSpellCheckingEnabled(false)
+		spellChecker.correctWords = words.toSet()
+		state.setSpellCheckingEnabled(true)
+
+		assertNull(state.suspension)
+		assertEquals(0, spellCheckSpanCount())
+	}
+
+	@Test
+	fun `word segment checks are inert while suspended`() = runTest {
+		val words = words(60)
+		textState.setText(words.joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker)
+		state.runFullSpellCheck()
+
+		val segment = WordSegment(
+			text = words.first(),
+			range = TextEditorRange(
+				start = CharLineOffset(0, 0),
+				end = CharLineOffset(0, words.first().length),
+			),
+		)
+
+		assertFalse(state.checkWordSegment(segment))
+		assertEquals(0, spellCheckSpanCount())
+	}
+
+	private fun spellCheckSpanCount(): Int =
+		textState.richSpanManager.getAllRichSpans().count { it.style is SpellCheckStyle }
+
+	private fun wholeFirstLine(): TextEditorRange = TextEditorRange(
+		start = CharLineOffset(0, 0),
+		end = CharLineOffset(0, textState.textLines[0].length),
+	)
+
+	/** Distinct, layout-independent words so segmentation yields exactly [count] segments. */
+	private fun words(count: Int): List<String> = List(count) { "wordnumber$it" }
+}
+
+private class GuardMockSpellChecker(
+	var correctWords: Set<String> = emptySet(),
+) : EditorSpellChecker {
+	/** How many word lookups the checker was asked for; proves the guard bails early. */
+	var lookups: Int = 0
+		private set
+
+	override suspend fun isCorrectWord(word: String): Boolean {
+		lookups++
+		return correctWords.contains(word)
+	}
+
+	override suspend fun suggestions(
+		input: String,
+		scope: EditorSpellChecker.Scope,
+		closestOnly: Boolean,
+	): List<Suggestion> = emptyList()
+}

--- a/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/SpellCheckGuardTest.kt
+++ b/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/SpellCheckGuardTest.kt
@@ -227,6 +227,24 @@ class SpellCheckGuardTest {
 	}
 
 	@Test
+	fun `an explicit full check with a still-bad checker stays suspended`() = runTest {
+		textState.setText(words(60).joinToString(" "))
+		spellChecker.correctWords = emptySet()
+		val state = SpellCheckState(textState, spellChecker)
+		state.runFullSpellCheck()
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+
+		val lookupsBefore = spellChecker.lookups
+		state.runFullSpellCheck()
+
+		// The checker got its re-try, but implausible results keep the suspension in
+		// place the whole time rather than flickering it off and on.
+		assertTrue(spellChecker.lookups > lookupsBefore, "The re-check must actually re-try")
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+		assertEquals(0, spellCheckSpanCount())
+	}
+
+	@Test
 	fun `enabling checking while suspended clears the suspension`() = runTest {
 		val words = words(60)
 		textState.setText(words.joinToString(" "))

--- a/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/e2e/SpellCheckGuardE2eTest.kt
+++ b/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/e2e/SpellCheckGuardE2eTest.kt
@@ -1,7 +1,17 @@
 package e2e
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.richstyle.SpellCheckStyle
 import com.darkrockstudios.texteditor.spellcheck.SpellCheckGuard
+import com.darkrockstudios.texteditor.spellcheck.SpellCheckState
 import com.darkrockstudios.texteditor.spellcheck.SpellCheckSuspension
+import com.darkrockstudios.texteditor.spellcheck.SpellCheckingTextEditor
+import com.darkrockstudios.texteditor.spellcheck.rememberSpellCheckState
 import utils.CountingSpellChecker
 import utils.spellCheckUiTest
 import kotlin.test.Test
@@ -99,5 +109,32 @@ class SpellCheckGuardE2eTest {
 			assertEquals(5, suspension.limit)
 			assertEquals(0, spellCheckSpanCount, "Tripping the cap must clear every squiggle")
 		}
+	}
+
+	@OptIn(ExperimentalTestApi::class)
+	@Test
+	fun `swapping in a laxer guard on recomposition lifts the suspension`() = runSkikoComposeUiTest {
+		val checker = CountingSpellChecker()
+		val text = List(60) { "wordnumber$it" }.joinToString(" ")
+		lateinit var state: SpellCheckState
+		var guard by mutableStateOf(SpellCheckGuard.Default)
+		setContent {
+			state = rememberSpellCheckState(
+				spellChecker = checker,
+				initialText = AnnotatedString(text),
+				guard = guard,
+			)
+			SpellCheckingTextEditor(spellChecker = checker, state = state)
+		}
+		waitForIdle()
+		assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+
+		guard = SpellCheckGuard.Disabled
+		waitForIdle()
+
+		assertNull(state.suspension, "A guard changed on recomposition must take effect")
+		val spans = state.textState.richSpanManager.getAllRichSpans()
+			.count { it.style is SpellCheckStyle }
+		assertEquals(60, spans, "The disabled guard re-check must restore the squiggles")
 	}
 }

--- a/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/e2e/SpellCheckGuardE2eTest.kt
+++ b/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/e2e/SpellCheckGuardE2eTest.kt
@@ -1,0 +1,103 @@
+package e2e
+
+import com.darkrockstudios.texteditor.spellcheck.SpellCheckGuard
+import com.darkrockstudios.texteditor.spellcheck.SpellCheckSuspension
+import utils.CountingSpellChecker
+import utils.spellCheckUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for the [SpellCheckGuard] through the real editor stack:
+ * a composed [SpellCheckingTextEditor][com.darkrockstudios.texteditor.spellcheck.SpellCheckingTextEditor],
+ * real key events, and the debounced partial-check pipeline.
+ */
+class SpellCheckGuardE2eTest {
+
+	/** Distinct, layout-independent words so segmentation yields exactly [count] segments. */
+	private fun words(count: Int): List<String> = List(count) { "wordnumber$it" }
+
+	@Test
+	fun `a wrong-language checker suspends checking and leaves no squiggles`() {
+		val checker = CountingSpellChecker(correctWords = emptySet())
+
+		spellCheckUiTest(
+			spellChecker = checker,
+			initialText = words(60).joinToString(" "),
+		) {
+			val suspension = assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+			assertTrue(suspension.flagged > 0)
+			assertEquals(0, spellCheckSpanCount, "A suspended check must not leave the document red")
+			assertTrue(
+				checker.lookups < 60,
+				"Should bail before checking the whole document, did ${checker.lookups} lookups",
+			)
+		}
+	}
+
+	@Test
+	fun `an ordinary document with a few typos gets squiggles, not a suspension`() {
+		val words = words(60)
+		val checker = CountingSpellChecker(correctWords = words.drop(3).toSet())
+
+		spellCheckUiTest(
+			spellChecker = checker,
+			initialText = words.joinToString(" "),
+		) {
+			assertNull(state.suspension)
+			assertEquals(3, spellCheckSpanCount)
+		}
+	}
+
+	@Test
+	fun `typing while suspended stays inert`() {
+		val checker = CountingSpellChecker(correctWords = emptySet())
+
+		spellCheckUiTest(
+			spellChecker = checker,
+			initialText = words(60).joinToString(" "),
+		) {
+			assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+			val lookupsWhenSuspended = checker.lookups
+
+			typeText("hello world ")
+			letSpellCheckSettle()
+
+			assertIs<SpellCheckSuspension.LikelyWrongLanguage>(state.suspension)
+			assertEquals(lookupsWhenSuspended, checker.lookups, "No lookups while suspended")
+			assertEquals(0, spellCheckSpanCount)
+		}
+	}
+
+	@Test
+	fun `typing past the misspelling cap suspends checking`() {
+		val goodWords = List(5) { "goodword$it" }
+		val badWords = List(5) { "badword$it" }
+		val checker = CountingSpellChecker(correctWords = goodWords.toSet())
+
+		spellCheckUiTest(
+			spellChecker = checker,
+			initialText = (goodWords + badWords).joinToString(" "),
+			// Ratio can't trip here, only the absolute cap; 5 misspellings is exactly at
+			// the limit, so the initial full check passes and typing pushes it over.
+			guard = SpellCheckGuard(
+				maxMisspellings = 5,
+				minWordSample = Int.MAX_VALUE,
+				minSentenceSample = Int.MAX_VALUE,
+			),
+		) {
+			assertNull(state.suspension)
+			assertEquals(5, spellCheckSpanCount)
+
+			typeText("brokenwordone brokenwordtwo ")
+			letSpellCheckSettle()
+
+			val suspension = assertIs<SpellCheckSuspension.TooManyMisspellings>(state.suspension)
+			assertEquals(5, suspension.limit)
+			assertEquals(0, spellCheckSpanCount, "Tripping the cap must clear every squiggle")
+		}
+	}
+}

--- a/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/utils/SpellCheckUiTest.kt
+++ b/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/utils/SpellCheckUiTest.kt
@@ -1,0 +1,90 @@
+package utils
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.texteditor.richstyle.SpellCheckStyle
+import com.darkrockstudios.texteditor.spellcheck.SpellCheckGuard
+import com.darkrockstudios.texteditor.spellcheck.SpellCheckState
+import com.darkrockstudios.texteditor.spellcheck.SpellCheckingTextEditor
+import com.darkrockstudios.texteditor.spellcheck.api.EditorSpellChecker
+import com.darkrockstudios.texteditor.spellcheck.api.Suggestion
+import com.darkrockstudios.texteditor.spellcheck.rememberSpellCheckState
+
+/**
+ * Harness for end-to-end spell check tests: composes a real [SpellCheckingTextEditor]
+ * over a real [com.darkrockstudios.texteditor.BasicTextEditor], drives it with synthetic
+ * keyboard events, and exposes [SpellCheckUiTestScope.state] for data-level assertions.
+ * The debounced partial-check pipeline runs on the test's virtual clock; use
+ * [SpellCheckUiTestScope.letSpellCheckSettle] to advance past the quiescence window.
+ */
+@OptIn(ExperimentalTestApi::class)
+fun spellCheckUiTest(
+	spellChecker: EditorSpellChecker,
+	initialText: String = "",
+	guard: SpellCheckGuard = SpellCheckGuard.Default,
+	width: Dp = 400.dp,
+	height: Dp = 300.dp,
+	block: SpellCheckUiTestScope.() -> Unit,
+) = runSkikoComposeUiTest {
+	lateinit var state: SpellCheckState
+	setContent {
+		state = rememberSpellCheckState(
+			spellChecker = spellChecker,
+			initialText = AnnotatedString(initialText),
+			guard = guard,
+		)
+		SpellCheckingTextEditor(
+			spellChecker = spellChecker,
+			state = state,
+			modifier = Modifier.size(width, height),
+			autoFocus = true,
+		)
+	}
+	waitForIdle()
+	SpellCheckUiTestScope(this, state).block()
+}
+
+@OptIn(ExperimentalTestApi::class)
+class SpellCheckUiTestScope(
+	val test: SkikoComposeUiTest,
+	val state: SpellCheckState,
+) {
+	/** How many spell-check decoration spans are currently on the document. */
+	val spellCheckSpanCount: Int
+		get() = state.textState.richSpanManager.getAllRichSpans()
+			.count { it.style is SpellCheckStyle }
+
+	/** Types printable characters through real desktop key events; `\n` and `\t` become Enter/Tab. */
+	fun typeText(text: String) = test.typeText(text)
+
+	/** Advances the virtual clock past the 500ms edit-quiescence debounce so pending partial checks run. */
+	fun letSpellCheckSettle() {
+		test.mainClock.advanceTimeBy(600)
+		test.waitForIdle()
+	}
+}
+
+/** Flags every word not in [correctWords] and counts lookups, so tests can prove checking stopped. */
+class CountingSpellChecker(
+	var correctWords: Set<String> = emptySet(),
+) : EditorSpellChecker {
+	var lookups: Int = 0
+		private set
+
+	override suspend fun isCorrectWord(word: String): Boolean {
+		lookups++
+		return correctWords.contains(word)
+	}
+
+	override suspend fun suggestions(
+		input: String,
+		scope: EditorSpellChecker.Scope,
+		closestOnly: Boolean,
+	): List<Suggestion> = emptyList()
+}

--- a/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/utils/UiTestTyping.kt
+++ b/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/utils/UiTestTyping.kt
@@ -1,0 +1,43 @@
+package utils
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+
+/**
+ * Types [text] into the focused editor by replaying the event sequence a real
+ * desktop keystroke produces: KeyDown, then a KEY_TYPED-style Unknown event
+ * carrying the character, then KeyUp. `performKeyInput` cannot do this; it
+ * only synthesizes KeyDown/KeyUp, and on desktop printable characters are
+ * consumed exclusively from the KEY_TYPED event (see
+ * PlatformCharacterInput.desktop.kt).
+ *
+ * `\n` and `\t` are typed as Enter and Tab keystrokes, matching how those
+ * characters actually enter the editor (handled on KeyDown, with the KEY_TYPED
+ * control character filtered out).
+ */
+@OptIn(ExperimentalTestApi::class, InternalComposeUiApi::class)
+fun SkikoComposeUiTest.typeText(text: String) {
+	for (ch in text) {
+		val key = when (ch) {
+			'\n' -> Key.Enter
+			'\t' -> Key.Tab
+			else -> Key(java.awt.event.KeyEvent.getExtendedKeyCodeForChar(ch.code))
+		}
+		runOnUiThread {
+			scene.sendKeyEvent(
+				KeyEvent(key = key, type = KeyEventType.KeyDown, codePoint = ch.code)
+			)
+			scene.sendKeyEvent(
+				KeyEvent(key = Key.Unknown, type = KeyEventType.Unknown, codePoint = ch.code)
+			)
+			scene.sendKeyEvent(
+				KeyEvent(key = key, type = KeyEventType.KeyUp, codePoint = ch.code)
+			)
+		}
+	}
+	waitForIdle()
+}


### PR DESCRIPTION
## What

A checker loaded with the wrong language flags every word: the document becomes a wall of red squiggles and every lookup is wasted work. This adds `SpellCheckGuard`, which suspends spell checking when results stop looking plausible, instead of flagging the whole document.

- **Wrong-language detection**: when more than `maxFlaggedRatio` (default 70%) of the whole document comes back misspelled, checking suspends. The ratio is judged against the full document's word count, so a foreign passage inside an otherwise fine document never trips it, and full checks still bail early once the outcome is mathematically decided.
- **Absolute cap**: more than `maxMisspellings` (default 500) live squiggles also suspends. Both limits count actual spans, which the span manager keeps position-correct across edits.
- **Sample floors** (`minWordSample = 40`, `minSentenceSample = 8`) keep short documents from ever suspending by ratio.
- Tripping drops every squiggle and stops automatic checking. `state.suspension` is observable Compose state (`LikelyWrongLanguage` / `TooManyMisspellings`) for surfacing a "spell checking paused" banner.
- **Recovery**: a suspension is sticky, but a full re-check (replacing the checker, `resumeSpellChecking()`, `runFullSpellCheck()`, or `setSpellCheckingEnabled(true)`) re-tries the checker and lifts the suspension only when a scan completes with plausible results, so a still-bad checker never flickers the banner. `SpellCheckGuard.Disabled` opts out entirely.

## Testing

- 15 unit tests (`SpellCheckGuardTest`) covering ratio and cap trips, early bail, the foreign-passage false-positive case, partial-check trips, every recovery path, and on-demand `checkWordSegment` behavior while suspended.
- 5 headless e2e tests (`SpellCheckGuardE2eTest`) driving a real composed `SpellCheckingTextEditor` with synthetic key events through the debounced partial-check pipeline, including a recomposition test that swaps the guard mid-session.
- A high-effort multi-agent code review was run against the branch; all 10 verified findings were fixed here.
