### PR TITLE
Resolve line-block stacking through one shared function

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/DocumentBlocks.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/DocumentBlocks.kt
@@ -102,20 +102,19 @@ internal fun TextEditorState.applyDocumentBlocks(
 	var rebuiltAnyLine = false
 	for ((line, blocks) in requested) {
 		var text = lines.getOrNull(line) ?: continue
-		val present = ALL_BLOCK_STYLES.filter { hasLineBlock(line, it) }.toMutableList()
+		val present = lineBlocks(line).toMutableList()
 		// Spans staged for this line, so a block demoted after being applied in this
 		// same pass is withdrawn rather than published alongside the block that
 		// replaced it.
 		val staged = linkedMapOf<LineBlockStyle, RichSpan>()
 		for (block in blocks) {
-			if (block in present) continue
-			for (excluded in mutuallyExcluded(block)) {
-				if (!present.remove(excluded)) continue
+			val resolved = resolveLineBlock(present, block, text) ?: continue
+			for (excluded in resolved.demoted) {
+				present.remove(excluded)
 				if (staged.remove(excluded) == null) removed += lineBlockSpans(line, excluded)
-				text = rebuildWithoutBlock(text, excluded)
 			}
+			text = resolved.text
 			staged[block] = RichSpan(lineRange(line, text.length), block.spanStyle)
-			text = rebuildWithBlock(text, block)
 			present += block
 		}
 		if (staged.isEmpty()) continue

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
@@ -155,6 +155,40 @@ internal fun rebuildWithoutBlock(existing: AnnotatedString, block: LineBlockStyl
 	}
 
 /**
+ * What putting one line block on a line comes to: the blocks already there that
+ * have to give way, and the line's text with those stripped and the new block's
+ * wrapping added.
+ */
+internal class ResolvedLineBlock(
+	val demoted: List<LineBlockStyle>,
+	val text: AnnotatedString,
+)
+
+/**
+ * Resolves [block] against a line holding [present] with content [text], or
+ * returns null when [block] is already there and there is nothing to do.
+ *
+ * The one place [mutuallyExcluded] is turned into an actual demotion and rebuild:
+ * the per-line toggle and the batched importer both resolve through this, so a
+ * stack of blocks produces the same line whether the user typed it or an import
+ * placed it.
+ */
+internal fun resolveLineBlock(
+	present: Collection<LineBlockStyle>,
+	block: LineBlockStyle,
+	text: AnnotatedString,
+): ResolvedLineBlock? {
+	if (block in present) return null
+	// Demote any conflicting block before applying — otherwise the new
+	// paragraph-style indent would overlap the old one and Compose blanks the
+	// line on the next measure pass.
+	val demoted = mutuallyExcluded(block).filter { it in present }
+	var rebuilt = text
+	demoted.forEach { rebuilt = rebuildWithoutBlock(rebuilt, it) }
+	return ResolvedLineBlock(demoted, rebuildWithBlock(rebuilt, block))
+}
+
+/**
  * Idempotent — no-op if [line] already carries [block]. Otherwise demotes any
  * mutually-exclusive block on the same line, wraps the line's text in the
  * indent paragraph style (and the optional [LineBlockStyle.textStyle]), and
@@ -166,19 +200,15 @@ internal fun rebuildWithoutBlock(existing: AnnotatedString, block: LineBlockStyl
  * at column 0 while the end shifts forward, naturally tracking the line length.
  */
 internal fun TextEditorState.applyLineBlock(line: Int, block: LineBlockStyle) = withAtomicEdit {
-	if (hasLineBlock(line, block)) return@withAtomicEdit
-	// Demote any conflicting block before applying — otherwise the new
-	// paragraph-style indent would overlap the old one and Compose blanks the
-	// line on the next measure pass.
-	mutuallyExcluded(block)
-		.filter { hasLineBlock(line, it) }
-		.forEach { demoteLineBlock(line, it) }
 	val existing = textLines.getOrNull(line) ?: return@withAtomicEdit
+	val resolved = resolveLineBlock(lineBlocks(line), block, existing)
+		?: return@withAtomicEdit
+	resolved.demoted.forEach { removeLineBlockSpans(line, it) }
 	// Attach the span before rebuilding the line: updateLine triggers the relayout
 	// that resolves each line's gutter marker (bullet/numeral), so the span must be
 	// present first or the marker won't render until the next edit forces another pass.
-	addLineBlockSpan(line, existing.length, block)
-	updateLine(line, rebuildWithBlock(existing, block))
+	addLineBlockSpan(line, resolved.text.length, block)
+	updateLine(line, resolved.text)
 }
 
 /**
@@ -219,9 +249,13 @@ internal fun TextEditorState.demoteLineBlock(line: Int, block: LineBlockStyle) =
 internal fun TextEditorState.detectLineBlock(line: Int): LineBlockStyle? =
 	ALL_BLOCK_STYLES.firstOrNull { hasLineBlock(line, it) }
 
+/** The line blocks currently attached to [line], in [ALL_BLOCK_STYLES] order. */
+internal fun TextEditorState.lineBlocks(line: Int): List<LineBlockStyle> =
+	ALL_BLOCK_STYLES.filter { hasLineBlock(line, it) }
+
 /** The line-anchored block span styles currently attached to [line]. */
 internal fun TextEditorState.lineBlockSpanStyles(line: Int): List<RichSpanStyle> =
-	ALL_BLOCK_STYLES.filter { hasLineBlock(line, it) }.map { it.spanStyle }
+	lineBlocks(line).map { it.spanStyle }
 
 /**
  * Replaces every line-anchored block span on [line] so that exactly [spanStyles]

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
@@ -189,15 +189,9 @@ internal fun resolveLineBlock(
 }
 
 /**
- * Idempotent — no-op if [line] already carries [block]. Otherwise demotes any
- * mutually-exclusive block on the same line, wraps the line's text in the
- * indent paragraph style (and the optional [LineBlockStyle.textStyle]), and
- * attaches a fresh rich span.
- *
- * On an empty line the span is zero-width `[0, 0)` — `RichSpan.intersectsWith`
- * special-cases sticky-at-start spans so the gutter marker still renders.
- * As soon as the user types a character, sticky-at-start keeps the span anchored
- * at column 0 while the end shifts forward, naturally tracking the line length.
+ * Puts [block] on [line] and commits it in a single relayout. The demotions and
+ * the rebuilt line come from [resolveLineBlock], which also makes this a no-op
+ * when [line] already carries [block].
  */
 internal fun TextEditorState.applyLineBlock(line: Int, block: LineBlockStyle) = withAtomicEdit {
 	val existing = textLines.getOrNull(line) ?: return@withAtomicEdit
@@ -215,6 +209,11 @@ internal fun TextEditorState.applyLineBlock(line: Int, block: LineBlockStyle) = 
  * Attaches the line-anchored span for [block] to [line] via the direct, non-
  * recording manager path. Callers that want the toggle in undo history record a
  * [TextEditOperation.LineBlock] separately — recording here too would double-count.
+ *
+ * On an empty line the span is zero-width `[0, 0)`: `RichSpan.intersectsWith`
+ * special-cases sticky-at-start spans so the gutter marker still renders. As soon
+ * as the user types a character, sticky-at-start keeps the span anchored at column
+ * 0 while the end shifts forward, naturally tracking the line length.
  */
 internal fun TextEditorState.addLineBlockSpan(line: Int, length: Int, block: LineBlockStyle) {
 	richSpanManager.addRichSpan(

--- a/ComposeTextEditor/src/desktopTest/kotlin/blocks/LineBlockStackingParityTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/blocks/LineBlockStackingParityTest.kt
@@ -1,0 +1,126 @@
+package blocks
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import com.darkrockstudios.texteditor.richstyle.ALL_BLOCK_STYLES
+import com.darkrockstudios.texteditor.richstyle.Blockquote
+import com.darkrockstudios.texteditor.richstyle.BulletList
+import com.darkrockstudios.texteditor.richstyle.CodeFence
+import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
+import com.darkrockstudios.texteditor.richstyle.OrderedList
+import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.richstyle.applyDocumentBlocks
+import com.darkrockstudios.texteditor.richstyle.applyLineBlock
+import com.darkrockstudios.texteditor.richstyle.lineBlockSpanStyles
+import com.darkrockstudios.texteditor.state.TextEditorState
+import kotlinx.coroutines.test.TestScope
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The per-line path (toolbar toggle, undo/redo, Enter on a block line) and the
+ * batched path (markdown/HTML import, HTML paste) must resolve a stack of line
+ * blocks to the same line.
+ *
+ * They are split along how a block arrived, so a divergence means the same source
+ * produces different block structure depending on whether it was imported or typed.
+ * Both resolve through `resolveLineBlock`; this pins that they still do.
+ */
+class LineBlockStackingParityTest {
+	private val testScope = TestScope()
+	private val density = Density(1f, 1f)
+
+	private fun freshState(text: String): TextEditorState = TextEditorState(
+		scope = testScope,
+		measurer = TextMeasurer(
+			defaultFontFamilyResolver = createFontFamilyResolver(),
+			defaultDensity = density,
+			defaultLayoutDirection = LayoutDirection.Ltr,
+		),
+	).also {
+		it.density = density
+		it.onViewportSizeChange(Size(500f, 200f))
+		it.setText(text)
+	}
+
+	/** The document as the two paths have to agree on it: text, styles and block spans. */
+	private fun TextEditorState.blockStructure(): List<Pair<AnnotatedString, List<RichSpanStyle>>> =
+		textLines.mapIndexed { line, text -> text to lineBlockSpanStyles(line) }
+
+	/**
+	 * Applies [blocks] to line 0 of a one-line document down both paths and asserts
+	 * they land on the same structure. [existing] is applied to both first, so the
+	 * demotion rules are exercised against a line that already carries a block.
+	 */
+	private fun assertPathsAgree(
+		vararg blocks: LineBlockStyle,
+		existing: List<LineBlockStyle> = emptyList(),
+	) {
+		val perLine = freshState("line text")
+		existing.forEach { perLine.applyLineBlock(0, it) }
+		// The batched path visits a line's blocks in ALL_BLOCK_STYLES order whatever
+		// order they were requested in, so the per-line path has to be driven that way
+		// for the comparison to be about the rules rather than about the ordering.
+		ALL_BLOCK_STYLES.filter { it in blocks }.forEach { perLine.applyLineBlock(0, it) }
+
+		val batched = freshState("line text")
+		existing.forEach { batched.applyLineBlock(0, it) }
+		batched.applyDocumentBlocks(blockLines = blocks.associateWith { listOf(0) })
+
+		assertEquals(perLine.blockStructure(), batched.blockStructure())
+	}
+
+	@Test
+	fun `blockquote stacks with bullet the same way on both paths`() {
+		assertPathsAgree(Blockquote, BulletList)
+	}
+
+	@Test
+	fun `blockquote stacks with an ordered list the same way on both paths`() {
+		assertPathsAgree(Blockquote, OrderedList)
+	}
+
+	@Test
+	fun `mutually exclusive lists resolve the same way on both paths`() {
+		assertPathsAgree(BulletList, OrderedList)
+	}
+
+	@Test
+	fun `a fence beats every other block the same way on both paths`() {
+		assertPathsAgree(CodeFence, Blockquote, BulletList, OrderedList)
+	}
+
+	@Test
+	fun `a block already on the line is a no-op on both paths`() {
+		assertPathsAgree(BulletList, existing = listOf(BulletList))
+	}
+
+	@Test
+	fun `a fence demotes a quoted list the same way on both paths`() {
+		assertPathsAgree(CodeFence, existing = listOf(Blockquote, BulletList))
+	}
+
+	@Test
+	fun `a list demotes an existing fence the same way on both paths`() {
+		assertPathsAgree(OrderedList, existing = listOf(CodeFence))
+	}
+
+	@Test
+	fun `an empty line carries the same zero-width span on both paths`() {
+		val perLine = freshState("")
+		perLine.applyLineBlock(0, BulletList)
+
+		val batched = freshState("")
+		batched.applyDocumentBlocks(blockLines = mapOf(BulletList to listOf(0)))
+
+		assertEquals(perLine.blockStructure(), batched.blockStructure())
+		assertEquals(
+			perLine.richSpanManager.getAllRichSpans().mapTo(mutableSetOf()) { it.range },
+			batched.richSpanManager.getAllRichSpans().mapTo(mutableSetOf()) { it.range },
+		)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/blocks/LineBlockStackingParityTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/blocks/LineBlockStackingParityTest.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.font.createFontFamilyResolver
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.richstyle.ALL_BLOCK_STYLES
 import com.darkrockstudios.texteditor.richstyle.Blockquote
 import com.darkrockstudios.texteditor.richstyle.BulletList
@@ -53,11 +55,16 @@ class LineBlockStackingParityTest {
 
 	/**
 	 * Applies [blocks] to line 0 of a one-line document down both paths and asserts
-	 * they land on the same structure. [existing] is applied to both first, so the
-	 * demotion rules are exercised against a line that already carries a block.
+	 * they land on the same structure, and that the structure is [expected].
+	 *
+	 * Parity alone would also hold if both paths stopped placing blocks entirely, so
+	 * [expected] pins the outcome as well as the agreement. [existing] is applied to
+	 * both first, so the demotion rules are exercised against a line that already
+	 * carries a block.
 	 */
 	private fun assertPathsAgree(
 		vararg blocks: LineBlockStyle,
+		expected: List<LineBlockStyle>,
 		existing: List<LineBlockStyle> = emptyList(),
 	) {
 		val perLine = freshState("line text")
@@ -72,41 +79,58 @@ class LineBlockStackingParityTest {
 		batched.applyDocumentBlocks(blockLines = blocks.associateWith { listOf(0) })
 
 		assertEquals(perLine.blockStructure(), batched.blockStructure())
+		assertEquals(expected.map { it.spanStyle }, perLine.lineBlockSpanStyles(0))
 	}
 
 	@Test
 	fun `blockquote stacks with bullet the same way on both paths`() {
-		assertPathsAgree(Blockquote, BulletList)
+		assertPathsAgree(Blockquote, BulletList, expected = listOf(Blockquote, BulletList))
 	}
 
 	@Test
 	fun `blockquote stacks with an ordered list the same way on both paths`() {
-		assertPathsAgree(Blockquote, OrderedList)
+		assertPathsAgree(Blockquote, OrderedList, expected = listOf(Blockquote, OrderedList))
 	}
 
 	@Test
 	fun `mutually exclusive lists resolve the same way on both paths`() {
-		assertPathsAgree(BulletList, OrderedList)
+		// ALL_BLOCK_STYLES puts OrderedList first, so BulletList demotes it.
+		assertPathsAgree(BulletList, OrderedList, expected = listOf(BulletList))
 	}
 
 	@Test
 	fun `a fence beats every other block the same way on both paths`() {
-		assertPathsAgree(CodeFence, Blockquote, BulletList, OrderedList)
+		assertPathsAgree(
+			CodeFence, Blockquote, BulletList, OrderedList,
+			expected = listOf(CodeFence),
+		)
 	}
 
 	@Test
 	fun `a block already on the line is a no-op on both paths`() {
-		assertPathsAgree(BulletList, existing = listOf(BulletList))
+		assertPathsAgree(
+			BulletList,
+			expected = listOf(BulletList),
+			existing = listOf(BulletList),
+		)
 	}
 
 	@Test
 	fun `a fence demotes a quoted list the same way on both paths`() {
-		assertPathsAgree(CodeFence, existing = listOf(Blockquote, BulletList))
+		assertPathsAgree(
+			CodeFence,
+			expected = listOf(CodeFence),
+			existing = listOf(Blockquote, BulletList),
+		)
 	}
 
 	@Test
 	fun `a list demotes an existing fence the same way on both paths`() {
-		assertPathsAgree(OrderedList, existing = listOf(CodeFence))
+		assertPathsAgree(
+			OrderedList,
+			expected = listOf(OrderedList),
+			existing = listOf(CodeFence),
+		)
 	}
 
 	@Test
@@ -118,6 +142,12 @@ class LineBlockStackingParityTest {
 		batched.applyDocumentBlocks(blockLines = mapOf(BulletList to listOf(0)))
 
 		assertEquals(perLine.blockStructure(), batched.blockStructure())
+		assertEquals(listOf(BulletList.spanStyle), perLine.lineBlockSpanStyles(0))
+		val zeroWidth = TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 0))
+		assertEquals(
+			setOf(zeroWidth),
+			perLine.richSpanManager.getAllRichSpans().mapTo(mutableSetOf()) { it.range },
+		)
 		assertEquals(
 			perLine.richSpanManager.getAllRichSpans().mapTo(mutableSetOf()) { it.range },
 			batched.richSpanManager.getAllRichSpans().mapTo(mutableSetOf()) { it.range },


### PR DESCRIPTION
Closes #61.

`applyLineBlock` and `applyDocumentBlocks` each carried their own copy of the line-block stacking rules: which blocks a new one demotes, what the rebuilt line looks like, what span goes on and over what range. They agreed, but only by hand, and they are split along a user-visible seam (imported/pasted vs typed/undone), so a divergence would mean the same markdown produces different block structure depending on how it arrived.

## What changed

`resolveLineBlock(present, block, text)` in `LineBlockStyle.kt` is now the single implementation. It takes the blocks already on a line, the block being applied and the line's current text, and returns the blocks to demote plus the rebuilt text, or null when the block is already there. It owns the idempotence guard, the demotion selection and the rebuild; `mutuallyExcluded` stays where it was as the exclusion table.

`applyLineBlock` resolves, drops the demoted spans, attaches the new span, and does one `updateLine`. It used to call `demoteLineBlock` per conflict, each triggering its own relayout, before rebuilding the line again, so this is also a little cheaper. Behaviour is unchanged.

`applyDocumentBlocks` keeps its staging and withdrawal book-keeping, which is genuinely batch-specific, and takes the demotion list and rebuilt text from `resolveLineBlock`.

Also added `lineBlocks(line)`, the blocks attached to a line in `ALL_BLOCK_STYLES` order, which both call sites and `lineBlockSpanStyles` now use.

## Tests

New `blocks/LineBlockStackingParityTest.kt` runs the same block stacks down both paths and asserts identical text, paragraph and span styles, and block spans: quote+list stacking, list-vs-list exclusion, fences beating everything, fences being demoted by a list, idempotent reapplication, and the empty-line zero-width span.

Checked the test isn't vacuous by re-forking the batched demotion loop, which failed 4 of the 8 cases.

Full desktop suite: 742 tests, 0 failures (734 before).

## Not in scope

The alternative fix in the issue, wrapping the per-line loop in a relayout-suppression window and deleting the batched path, still needs `withDeferredBookKeeping` from #58 and is not touched here.
