### PR TITLE
Rich-text torture test suite: block styles, paste, deletion, undo storms, fuzzing

### DIFF
--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/HtmlPasteE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/HtmlPasteE2eTest.kt
@@ -1,20 +1,14 @@
 package e2e
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.text.AnnotatedString
 import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
 import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
 import com.darkrockstudios.texteditor.richstyle.CodeFenceSpanStyle
 import com.darkrockstudios.texteditor.richstyle.OrderedListSpanStyle
-import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
-import com.darkrockstudios.texteditor.state.TextEditorState
-import utils.EditorUiTestScope
 import utils.editorUiTest
-import java.awt.datatransfer.DataFlavor
-import java.awt.datatransfer.Transferable
-import java.awt.datatransfer.UnsupportedFlavorException
+import utils.linesWith
+import utils.pasteHtml
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -23,18 +17,6 @@ import kotlin.test.assertEquals
  * nothing this editor put there itself.
  */
 class HtmlPasteE2eTest {
-
-	private fun TextEditorState.linesWith(style: RichSpanStyle): List<Int> =
-		richSpanManager.getAllRichSpans()
-			.filter { it.style === style }
-			.map { it.range.start.line }
-			.sorted()
-
-	@OptIn(ExperimentalComposeUiApi::class)
-	private fun EditorUiTestScope.pasteHtml(html: String) {
-		clipboard.seed(ClipEntry(ForeignHtmlTransferable(html)))
-		press(Key.V, ctrl = true)
-	}
 
 	@Test
 	fun `pasting a bulleted list keeps the bullets`() = editorUiTest {
@@ -144,17 +126,4 @@ class HtmlPasteE2eTest {
 		assertEquals("one\ntwoone\ntwo", text)
 		assertEquals(listOf(0, 1, 2), state.linesWith(BulletListSpanStyle))
 	}
-}
-
-/** Offers markup the way a browser or word processor does: HTML, and nothing editor-specific. */
-private class ForeignHtmlTransferable(private val html: String) : Transferable {
-	private val htmlFlavor = DataFlavor("text/html;class=java.lang.String;charset=Unicode")
-
-	override fun getTransferDataFlavors(): Array<DataFlavor> = arrayOf(htmlFlavor)
-
-	override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
-		transferDataFlavors.any { it.match(flavor) }
-
-	override fun getTransferData(flavor: DataFlavor): Any =
-		if (flavor.match(htmlFlavor)) html else throw UnsupportedFlavorException(flavor)
 }

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockBoundaryDeletionE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockBoundaryDeletionE2eTest.kt
@@ -1,0 +1,189 @@
+package e2e.torture
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
+import utils.assertBlockState
+import utils.assertRichSpanInvariants
+import utils.blockFlags
+import utils.editorUiTest
+import utils.linesWith
+import utils.markdown
+import utils.selectChars
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Deletions that cross block boundaries: merging lists, joining styled lines into
+ * plain ones, and chewing through mixed-block documents one keystroke at a time.
+ */
+class BlockBoundaryDeletionE2eTest {
+
+	@Test
+	fun `deleting the separator line merges two bullet lists`() = editorUiTest {
+		markdown.importMarkdown("- a\n\n- b")
+		assertEquals(listOf("a", "", "b"), lines)
+
+		press(Key.MoveHome, ctrl = true)
+		press(Key.MoveEnd)
+		press(Key.Delete)
+
+		assertEquals(listOf("a", "b"), lines)
+		assertBlockState(0, bullet = true)
+		assertBlockState(1, bullet = true)
+		assertEquals("- a\n- b", markdown.exportAsMarkdown(), "one contiguous list")
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `forward deleting the newline before a bulleted line makes it plain`() = editorUiTest(
+		initialText = AnnotatedString("plain\nitem"),
+	) {
+		markdown.toggleBulletList(1..1)
+
+		press(Key.MoveHome, ctrl = true)
+		press(Key.MoveEnd)
+		press(Key.Delete)
+
+		assertEquals(listOf("plainitem"), lines)
+		// The backspace path deliberately demotes a block before merging it into a
+		// plain line; the forward-delete join of the same two lines must agree.
+		assertEquals(emptySet(), blockFlags(0), "the receiving plain line keeps its identity")
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `deleting across a quote to fence boundary leaves one block style`() = editorUiTest(
+		initialText = AnnotatedString("quoted\ncode"),
+	) {
+		markdown.toggleBlockquote(0..0)
+		markdown.toggleCodeFence(1..1)
+
+		selectChars(3, 9)
+		press(Key.Delete)
+
+		assertEquals(listOf("quode"), lines)
+		// Fence stacks with nothing (mutuallyExcluded), so whatever the join keeps,
+		// a quote+fence combination on one line is an invalid document.
+		assertEquals(setOf("quote"), blockFlags(0), "joined line must keep one valid block style")
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `select all delete in a fully styled doc leaves a clean empty state`() = editorUiTest(
+		initialText = AnnotatedString("one\ntwo\nthree"),
+	) {
+		markdown.toggleBulletList(0..2)
+		markdown.toggleBlockquote(0..2)
+
+		press(Key.A, ctrl = true)
+		press(Key.Delete)
+
+		assertEquals("", text)
+		assertTrue(
+			state.richSpanManager.getAllRichSpans().isEmpty(),
+			"an emptied document must carry no rich spans",
+		)
+	}
+
+	@Test
+	fun `deleting the last character of a one char item keeps the bullet`() = editorUiTest(
+		initialText = AnnotatedString("x"),
+	) {
+		markdown.toggleBulletList(0..0)
+		press(Key.MoveEnd)
+		press(Key.Backspace)
+
+		assertEquals("", text)
+		assertBlockState(0, bullet = true)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `deleting across a horizontal rule removes it cleanly`() = editorUiTest {
+		markdown.importMarkdown("aa\n---\nbb")
+		assertEquals(listOf(1), state.linesWith(HorizontalRuleSpanStyle))
+
+		selectChars(1, 6)
+		press(Key.Delete)
+
+		assertEquals("ab", text)
+		assertEquals(emptyList(), state.linesWith(HorizontalRuleSpanStyle))
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `undo of a cross block delete restores both block styles`() = editorUiTest(
+		initialText = AnnotatedString("quoted\ncode"),
+	) {
+		markdown.toggleBlockquote(0..0)
+		markdown.toggleCodeFence(1..1)
+
+		selectChars(3, 9)
+		press(Key.Delete)
+		press(Key.Z, ctrl = true)
+
+		assertEquals(listOf("quoted", "code"), lines)
+		assertEquals(setOf("quote"), blockFlags(0), "line 0 restored exactly")
+		assertEquals(setOf("fence"), blockFlags(1), "line 1 restored exactly")
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `word delete at the end of a bulleted word keeps the bullet`() = editorUiTest(
+		initialText = AnnotatedString("word"),
+	) {
+		markdown.toggleBulletList(0..0)
+		press(Key.MoveEnd)
+		press(Key.Backspace, ctrl = true)
+
+		assertEquals("", text)
+		assertBlockState(0, bullet = true)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `deleting the blank line between two fences merges them`() = editorUiTest(
+		initialText = AnnotatedString("code1\n\ncode2"),
+	) {
+		markdown.toggleCodeFence(0..0)
+		markdown.toggleCodeFence(2..2)
+
+		press(Key.MoveHome, ctrl = true)
+		press(Key.MoveEnd)
+		press(Key.Delete)
+
+		assertEquals(listOf("code1", "code2"), lines)
+		assertBlockState(0, fence = true)
+		assertBlockState(1, fence = true)
+		assertEquals(
+			"```\ncode1\ncode2\n```",
+			markdown.exportAsMarkdown(),
+			"contiguous fence lines export as one fence pair",
+		)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `backspacing through an entire mixed block document ends clean`() = editorUiTest(
+		initialText = AnnotatedString("qq\nbb\noo\ncc\npp"),
+	) {
+		markdown.toggleBlockquote(0..0)
+		markdown.toggleBulletList(1..1)
+		markdown.toggleOrderedList(2..2)
+		markdown.toggleCodeFence(3..3)
+
+		press(Key.MoveEnd, ctrl = true)
+		var presses = 0
+		while ((text.isNotEmpty() || state.richSpanManager.getAllRichSpans().isNotEmpty()) && presses < 40) {
+			press(Key.Backspace)
+			presses++
+			if (presses % 5 == 0) assertRichSpanInvariants()
+		}
+
+		assertEquals("", text, "the document must empty within $presses backspaces")
+		assertTrue(state.richSpanManager.getAllRichSpans().isEmpty())
+		assertRichSpanInvariants()
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockToggleTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockToggleTortureE2eTest.kt
@@ -1,0 +1,236 @@
+package e2e.torture
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import utils.assertBlockState
+import utils.assertRichSpanInvariants
+import utils.editorUiTest
+import utils.markdown
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Block styles (bullet, ordered, quote, fence) under hostile realistic editing:
+ * toggles interleaved with typing, splitting, demoting, and undo.
+ */
+class BlockToggleTortureE2eTest {
+
+	@Test
+	fun `typing at the end of a bulleted item extends it`() = editorUiTest(
+		initialText = AnnotatedString("item"),
+	) {
+		markdown.toggleBulletList(0..0)
+		press(Key.MoveEnd)
+		typeText(" grows")
+
+		assertEquals("item grows", text)
+		assertBlockState(0, bullet = true)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `enter mid item splits into two bulleted items`() = editorUiTest(
+		initialText = AnnotatedString("itemtail"),
+	) {
+		markdown.toggleBulletList(0..0)
+		press(Key.MoveHome)
+		repeat(4) { press(Key.DirectionRight) }
+		press(Key.Enter)
+
+		assertEquals(listOf("item", "tail"), lines)
+		assertBlockState(0, bullet = true)
+		assertBlockState(1, bullet = true)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `enter on an empty list item exits the list`() = editorUiTest {
+		markdown.toggleBulletList(0..0)
+		typeText("item")
+		press(Key.Enter)
+		assertBlockState(1, bullet = true)
+
+		press(Key.Enter)
+
+		assertEquals(listOf("item", ""), lines, "the exit keystroke is eaten, not inserted")
+		assertBlockState(0, bullet = true)
+		assertBlockState(1)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `backspace at column 0 demotes first then merges`() = editorUiTest(
+		initialText = AnnotatedString("plain\nitem"),
+	) {
+		markdown.toggleBulletList(1..1)
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.MoveHome)
+
+		press(Key.Backspace)
+		assertEquals(listOf("plain", "item"), lines, "first backspace only demotes")
+		assertBlockState(1)
+
+		press(Key.Backspace)
+		assertEquals(listOf("plainitem"), lines, "second backspace merges the lines")
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `backspace at column 0 merges adjacent same-block items directly`() = editorUiTest(
+		initialText = AnnotatedString("one\ntwo"),
+	) {
+		markdown.toggleBulletList(0..1)
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.MoveHome)
+
+		press(Key.Backspace)
+
+		assertEquals(listOf("onetwo"), lines, "same-block neighbours merge on the first backspace")
+		assertBlockState(0, bullet = true)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `bullet toggle over an ordered line swaps the list type`() = editorUiTest(
+		initialText = AnnotatedString("a\nb\nc"),
+	) {
+		markdown.toggleOrderedList(0..2)
+		markdown.toggleBulletList(1..1)
+
+		assertBlockState(0, ordered = true)
+		assertBlockState(1, bullet = true)
+		assertBlockState(2, ordered = true)
+		assertEquals(
+			"1. a\n- b\n1. c",
+			markdown.exportAsMarkdown(),
+			"the ordered run restarts numbering after the interruption",
+		)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `code fence toggle strips stacked quote and bullet`() = editorUiTest(
+		initialText = AnnotatedString("code"),
+	) {
+		markdown.toggleBulletList(0..0)
+		markdown.toggleBlockquote(0..0)
+		assertBlockState(0, bullet = true, quote = true)
+
+		markdown.toggleCodeFence(0..0)
+
+		assertBlockState(0, fence = true)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `quote stacks with bullet and both survive typing`() = editorUiTest(
+		initialText = AnnotatedString("item"),
+	) {
+		markdown.toggleBulletList(0..0)
+		markdown.toggleBlockquote(0..0)
+		press(Key.MoveEnd)
+		typeText(" and more")
+
+		assertEquals("item and more", text)
+		assertBlockState(0, bullet = true, quote = true)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `block toggle after select all does not inject literal markers`() = editorUiTest(
+		initialText = AnnotatedString("alpha\nbravo\ncharlie"),
+	) {
+		press(Key.A, ctrl = true)
+		markdown.toggleBulletList(0..2)
+
+		assertEquals(
+			listOf("alpha", "bravo", "charlie"),
+			lines,
+			"toggling must attach gutter spans, never literal '- ' text",
+		)
+		for (line in 0..2) assertBlockState(line, bullet = true)
+
+		val exported = markdown.exportAsMarkdown()
+		assertEquals("- alpha\n- bravo\n- charlie", exported)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `toggle undo redo cycle is lossless`() = editorUiTest(
+		initialText = AnnotatedString("one\ntwo"),
+	) {
+		markdown.toggleBlockquote(0..1)
+		markdown.toggleBulletList(0..1)
+		assertBlockState(0, quote = true, bullet = true)
+		assertBlockState(1, quote = true, bullet = true)
+
+		press(Key.Z, ctrl = true)
+		assertBlockState(0, quote = true)
+		assertBlockState(1, quote = true)
+
+		press(Key.Z, ctrl = true)
+		assertBlockState(0)
+		assertBlockState(1)
+
+		press(Key.Y, ctrl = true)
+		press(Key.Y, ctrl = true)
+		assertBlockState(0, quote = true, bullet = true)
+		assertBlockState(1, quote = true, bullet = true)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `deleting a whole bulleted line leaves no orphan span`() = editorUiTest(
+		initialText = AnnotatedString("aa\nbb\ncc"),
+	) {
+		markdown.toggleBulletList(0..2)
+
+		press(Key.MoveHome, ctrl = true)
+		press(Key.DirectionDown)
+		press(Key.MoveEnd, shift = true)
+		press(Key.DirectionRight, shift = true)
+		press(Key.Delete)
+
+		assertEquals(listOf("aa", "cc"), lines)
+		assertBlockState(0, bullet = true)
+		assertBlockState(1, bullet = true)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `inserting an item renumbers an ordered list on export`() = editorUiTest(
+		initialText = AnnotatedString("a\nb\nc"),
+	) {
+		markdown.toggleOrderedList(0..2)
+		press(Key.MoveHome, ctrl = true)
+		press(Key.MoveEnd)
+		press(Key.Enter)
+		typeText("new")
+
+		assertEquals(listOf("a", "new", "b", "c"), lines)
+		assertEquals("1. a\n2. new\n3. b\n4. c", markdown.exportAsMarkdown())
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `fencing 50 lines and unfencing is symmetric`() = editorUiTest(
+		initialText = AnnotatedString((0 until 50).joinToString("\n") { "line$it" }),
+	) {
+		markdown.toggleCodeFence(0..49)
+		for (line in 0 until 50) assertBlockState(line, fence = true)
+
+		markdown.toggleCodeFence(0..49)
+		assertTrue(
+			state.richSpanManager.getAllRichSpans().isEmpty(),
+			"unfencing must leave zero rich spans",
+		)
+
+		press(Key.Z, ctrl = true)
+		for (line in 0 until 50) assertBlockState(line, fence = true)
+
+		press(Key.Z, ctrl = true)
+		assertTrue(state.richSpanManager.getAllRichSpans().isEmpty())
+		assertRichSpanInvariants()
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockToggleTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockToggleTortureE2eTest.kt
@@ -214,6 +214,39 @@ class BlockToggleTortureE2eTest {
 	}
 
 	@Test
+	fun `a smart backspace demotion is undoable`() = editorUiTest(
+		initialText = AnnotatedString("plain\nitem"),
+	) {
+		markdown.toggleBulletList(1..1)
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.MoveHome)
+
+		press(Key.Backspace)
+		assertBlockState(1)
+
+		press(Key.Z, ctrl = true)
+
+		// demoteLineBlock mutates the line directly without recording a history
+		// entry, so the marker a user removed by accident cannot come back.
+		assertEquals(listOf("plain", "item"), lines, "undo must not fall through to an older edit")
+		assertBlockState(1, bullet = true)
+	}
+
+	@Test
+	fun `a smart enter exit from a list is undoable`() = editorUiTest {
+		markdown.toggleBulletList(0..0)
+		typeText("item")
+		press(Key.Enter)
+		press(Key.Enter)
+		assertBlockState(1)
+
+		press(Key.Z, ctrl = true)
+
+		assertEquals(listOf("item", ""), lines, "undo must not fall through to an older edit")
+		assertBlockState(1, bullet = true)
+	}
+
+	@Test
 	fun `fencing 50 lines and unfencing is symmetric`() = editorUiTest(
 		initialText = AnnotatedString((0 until 50).joinToString("\n") { "line$it" }),
 	) {

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorFuzzE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorFuzzE2eTest.kt
@@ -1,0 +1,80 @@
+package e2e.torture
+
+import androidx.compose.ui.text.AnnotatedString
+import utils.applyFuzzOpUi
+import utils.checkCheapInvariants
+import utils.editorUiTest
+import utils.fuzzSeed
+import utils.generateFuzzScript
+import utils.markdown
+import utils.runFuzzScript
+import utils.snapshotOf
+import utils.undoAll
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The seeded edit storms of EditorStateFuzzTest driven through the composed
+ * editor instead: real key events, the clipboard, and the same two invariants.
+ * Keyboard-only; a mouse gesture costs a real 350ms sleep, so none are used.
+ */
+class EditorFuzzE2eTest {
+
+	private fun undoToOrigin(seed: Long) = editorUiTest(
+		initialText = AnnotatedString("seed line\nsecond line"),
+	) {
+		val origin = snapshotOf(state)
+		val script = generateFuzzScript(
+			seed = fuzzSeed(seed),
+			count = 60,
+			mutatingBudget = 80,
+			includeBlocks = false,
+		)
+
+		runFuzzScript(fuzzSeed(seed), script) { op ->
+			applyFuzzOpUi(op, skipDemotions = true, replaceOverSelection = false)
+			checkCheapInvariants(state)
+		}
+
+		undoAll()
+		assertEquals(
+			origin,
+			snapshotOf(state),
+			"fuzz seed=${fuzzSeed(seed)}: undoing every edit must restore the origin exactly",
+		)
+	}
+
+	private fun markdownFixpoint(seed: Long) = editorUiTest {
+		markdown.importMarkdown("seed line\n- item\n> quoted")
+		val script = generateFuzzScript(seed = fuzzSeed(seed), count = 60, includeBold = false)
+
+		runFuzzScript(fuzzSeed(seed), script) { op ->
+			applyFuzzOpUi(op, skipDemotions = false)
+			checkCheapInvariants(state)
+		}
+
+		val first = markdown.exportAsMarkdown()
+		markdown.importMarkdown(first)
+		val second = markdown.exportAsMarkdown()
+		assertEquals(
+			first,
+			second,
+			"fuzz seed=${fuzzSeed(seed)}: export/import/export must be a fixpoint",
+		)
+	}
+
+	@Test
+	fun `ui undo to origin seed 1`() = undoToOrigin(1)
+
+	@Test
+	fun `ui undo to origin seed 42`() = undoToOrigin(42)
+
+	@Test
+	fun `ui undo to origin seed 20260801`() = undoToOrigin(20260801)
+
+	@Test
+	fun `ui markdown fixpoint seed 4243`() = markdownFixpoint(4243)
+
+	@Test
+	fun `ui markdown fixpoint seed 987654321`() = markdownFixpoint(987654321)
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorStateFuzzTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorStateFuzzTest.kt
@@ -1,0 +1,112 @@
+package e2e.torture
+
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import utils.StateFuzzInterpreter
+import utils.checkCheapInvariants
+import utils.fuzzSeed
+import utils.generateFuzzScript
+import utils.runFuzzScript
+import utils.snapshotOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Seeded random edit storms against the bare state, no UI. Two invariants:
+ * a script whose history fits the undo cap must undo back to its origin
+ * exactly, and any document the storm produces must export to a markdown
+ * fixpoint. Replay a failure with FUZZ_SEED=<seed>.
+ */
+class EditorStateFuzzTest {
+
+	private fun editor(initialMarkdown: String): Pair<TextEditorState, MarkdownExtension> {
+		val state = TextEditorState(scope = TestScope(), measurer = mockk(relaxed = true))
+		val markdown = MarkdownExtension(state)
+		markdown.importMarkdown(initialMarkdown)
+		return state to markdown
+	}
+
+	private fun undoToOrigin(seed: Long) {
+		val (state, markdown) = editor("seed line\nsecond line")
+		val origin = snapshotOf(state)
+		val script = generateFuzzScript(
+			seed = fuzzSeed(seed),
+			count = 250,
+			mutatingBudget = 80,
+			includeBlocks = false,
+		)
+		val interpreter = StateFuzzInterpreter(
+			state, markdown,
+			skipDemotions = true,
+			replaceOverSelection = false,
+		)
+
+		runFuzzScript(fuzzSeed(seed), script) { op ->
+			interpreter.apply(op)
+			checkCheapInvariants(state)
+		}
+
+		// canUndo never refreshes without layout bookkeeping; undo() no-ops when drained.
+		repeat(300) { state.undo() }
+		assertEquals(
+			origin,
+			snapshotOf(state),
+			"fuzz seed=${fuzzSeed(seed)}: undoing every edit must restore the origin exactly",
+		)
+	}
+
+	private fun markdownFixpoint(seed: Long) {
+		val (state, markdown) = editor("seed line\n- item\n> quoted")
+		val script = generateFuzzScript(seed = fuzzSeed(seed), count = 250, includeBold = false)
+		val interpreter = StateFuzzInterpreter(state, markdown, skipDemotions = false)
+
+		runFuzzScript(fuzzSeed(seed), script) { op ->
+			interpreter.apply(op)
+			checkCheapInvariants(state)
+		}
+
+		val first = markdown.exportAsMarkdown()
+		markdown.importMarkdown(first)
+		val second = markdown.exportAsMarkdown()
+		assertEquals(
+			first,
+			second,
+			"fuzz seed=${fuzzSeed(seed)}: export/import/export must be a fixpoint",
+		)
+		checkCheapInvariants(state)
+		assertTrue(state.textLines.isNotEmpty())
+	}
+
+	@Test
+	fun `undo to origin seed 1`() = undoToOrigin(1)
+
+	@Test
+	fun `undo to origin seed 42`() = undoToOrigin(42)
+
+	@Test
+	fun `undo to origin seed 4243`() = undoToOrigin(4243)
+
+	@Test
+	fun `undo to origin seed 987654321`() = undoToOrigin(987654321)
+
+	@Test
+	fun `undo to origin seed 20260801`() = undoToOrigin(20260801)
+
+	@Test
+	fun `markdown fixpoint seed 1`() = markdownFixpoint(1)
+
+	@Test
+	fun `markdown fixpoint seed 42`() = markdownFixpoint(42)
+
+	@Test
+	fun `markdown fixpoint seed 4243`() = markdownFixpoint(4243)
+
+	@Test
+	fun `markdown fixpoint seed 987654321`() = markdownFixpoint(987654321)
+
+	@Test
+	fun `markdown fixpoint seed 20260801`() = markdownFixpoint(20260801)
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/MarkdownRoundTripTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/MarkdownRoundTripTortureE2eTest.kt
@@ -145,6 +145,28 @@ class MarkdownRoundTripTortureE2eTest {
 	}
 
 	@Test
+	fun `a bold run ending in a space round trips`() = editorUiTest {
+		markdown.importMarkdown("word tail")
+		state.addStyleSpan(
+			com.darkrockstudios.texteditor.TextEditorRange(
+				state.getOffsetAtCharacter(0),
+				state.getOffsetAtCharacter(5),
+			),
+			SpanStyle(fontWeight = FontWeight.Bold),
+		)
+
+		// Found by EditorStateFuzzTest: emphasis wrapped around a range with an edge
+		// space ("**word **") is not valid markdown, so the next import keeps the
+		// asterisks as text and the following export escapes them.
+		val first = markdown.exportAsMarkdown()
+		markdown.importMarkdown(first)
+		val second = markdown.exportAsMarkdown()
+
+		assertEquals(first, second)
+		assertEquals("word tail", text, "no emphasis markers may leak into the text")
+	}
+
+	@Test
 	fun `empty list items round trip stably`() = editorUiTest {
 		markdown.importMarkdown("- a\n- \n- b")
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/MarkdownRoundTripTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/MarkdownRoundTripTortureE2eTest.kt
@@ -1,0 +1,171 @@
+package e2e.torture
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
+import utils.blockFlags
+import utils.editorUiTest
+import utils.linesWith
+import utils.markdown
+import utils.pasteHtml
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Export/import round trips of the shapes the line-blocks design doc marks as
+ * corrupting (D2, D3, D4), plus the fixpoint contracts that must hold: for any
+ * document, import(export(doc)) then export must reproduce the first export.
+ */
+class MarkdownRoundTripTortureE2eTest {
+
+	@Test
+	fun `a bulleted horizontal rule survives a round trip`() = editorUiTest {
+		markdown.importMarkdown("a\n---\nb")
+		assertEquals(listOf(1), state.linesWith(HorizontalRuleSpanStyle))
+
+		markdown.toggleBulletList(0..2)
+		markdown.importMarkdown(markdown.exportAsMarkdown())
+
+		assertEquals(
+			listOf(1),
+			state.linesWith(HorizontalRuleSpanStyle),
+			"the rule must still be a rule after a save/reload",
+		)
+	}
+
+	@Test
+	fun `the second generation export of a bulleted rule is a fixpoint`() = editorUiTest {
+		markdown.importMarkdown("a\n---\nb")
+		markdown.toggleBulletList(0..2)
+
+		val first = markdown.exportAsMarkdown()
+		markdown.importMarkdown(first)
+		val second = markdown.exportAsMarkdown()
+
+		assertEquals(first, second, "each save/reload cycle must not keep rewriting the document")
+	}
+
+	@Test
+	fun `a quote stacked on a bullet round trips`() = editorUiTest {
+		markdown.importMarkdown("item")
+		markdown.toggleBulletList(0..0)
+		markdown.toggleBlockquote(0..0)
+
+		val exported = markdown.exportAsMarkdown()
+		assertEquals("> - item", exported, "quote stacks with list on export")
+
+		markdown.importMarkdown(exported)
+
+		assertEquals("item", text, "no marker may leak into the text as literal characters")
+		assertEquals(setOf("quote", "bullet"), blockFlags(0))
+	}
+
+	@Test
+	fun `a stacked marker export import export is a fixpoint`() = editorUiTest {
+		markdown.importMarkdown("item")
+		markdown.toggleBulletList(0..0)
+		markdown.toggleBlockquote(0..0)
+
+		val first = markdown.exportAsMarkdown()
+		markdown.importMarkdown(first)
+		val second = markdown.exportAsMarkdown()
+
+		assertEquals(first, second)
+	}
+
+	@Test
+	fun `an html blockquote containing a rule survives a markdown save`() = editorUiTest {
+		pasteHtml("<blockquote>a<hr>b</blockquote>")
+		assertTrue(
+			state.linesWith(HorizontalRuleSpanStyle).isNotEmpty(),
+			"precondition: the html paste must produce a rule span",
+		)
+
+		markdown.importMarkdown(markdown.exportAsMarkdown())
+
+		assertTrue(
+			state.linesWith(HorizontalRuleSpanStyle).isNotEmpty(),
+			"the rule inside the quote must survive a save/reload",
+		)
+		assertTrue(
+			lines.none { it.contains("---") },
+			"the rule must not decay into literal dashes",
+		)
+	}
+
+	@Test
+	fun `a mixed document export import export is a fixpoint`() = editorUiTest {
+		markdown.importMarkdown(
+			"""
+			# Title
+
+			plain **bold** and *italic*
+
+			- one
+			- two
+
+			1. first
+			2. second
+
+			> quoted
+
+			```
+			code line
+			```
+
+			---
+
+			end
+			""".trimIndent()
+		)
+
+		val first = markdown.exportAsMarkdown()
+		markdown.importMarkdown(first)
+		val second = markdown.exportAsMarkdown()
+
+		assertEquals(first, second)
+	}
+
+	@Test
+	fun `switching header configuration must not silently demote headings`() = editorUiTest {
+		markdown.importMarkdown("# Title\n\nbody")
+
+		markdown.markdownConfiguration = MarkdownConfiguration(
+			header1Style = SpanStyle(fontSize = 40.sp, fontWeight = FontWeight.Bold),
+		)
+
+		val exported = markdown.exportAsMarkdown()
+		assertTrue(
+			exported.startsWith("# "),
+			"a heading is a semantic level, not a font size; got: ${exported.lineSequence().first()}",
+		)
+	}
+
+	@Test
+	fun `empty list items round trip stably`() = editorUiTest {
+		markdown.importMarkdown("- a\n- \n- b")
+
+		val first = markdown.exportAsMarkdown()
+		markdown.importMarkdown(first)
+		val second = markdown.exportAsMarkdown()
+
+		assertEquals(first, second)
+		assertEquals(listOf("a", "", "b"), lines)
+	}
+
+	@Test
+	fun `escaped special characters in list items survive two round trips`() = editorUiTest {
+		markdown.importMarkdown("- a\\*b\n- c\\_d\n- 1990\\. year")
+		assertEquals(listOf("a*b", "c_d", "1990. year"), lines)
+
+		val first = markdown.exportAsMarkdown()
+		markdown.importMarkdown(first)
+		val second = markdown.exportAsMarkdown()
+
+		assertEquals(first, second)
+		assertEquals(listOf("a*b", "c_d", "1990. year"), lines)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/ParagraphOverlapCrashTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/ParagraphOverlapCrashTest.kt
@@ -1,0 +1,48 @@
+package e2e.torture
+
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlin.test.Test
+
+/**
+ * Found by EditorStateFuzzTest seed 987654321, hand-shrunk: a delete that joins a
+ * code-fence line with another block-styled line bakes overlapping ParagraphStyles
+ * into the joined line, and the next insert crashes constructing the AnnotatedString
+ * ("Paragraph overlap not allowed") in mergeAnnotatedStrings. No sequence of
+ * ordinary edits may ever throw.
+ */
+class ParagraphOverlapCrashTest {
+
+	private fun editor(): Pair<TextEditorState, MarkdownExtension> {
+		val state = TextEditorState(scope = TestScope(), measurer = mockk(relaxed = true))
+		return state to MarkdownExtension(state)
+	}
+
+	@Test
+	fun `typing after a delete across a fence to bullet boundary must not crash`() {
+		val (state, markdown) = editor()
+		markdown.importMarkdown("aaa\nbbb\nccc")
+		markdown.toggleCodeFence(0..1)
+		markdown.toggleBulletList(2..2)
+
+		state.delete(TextEditorRange(CharLineOffset(1, 1), CharLineOffset(2, 1)))
+		state.cursor.updatePosition(CharLineOffset(1, 1))
+		state.insertStringAtCursor("x")
+	}
+
+	@Test
+	fun `typing after a delete across a bullet to fence boundary must not crash`() {
+		val (state, markdown) = editor()
+		markdown.importMarkdown("aaa\nbbb\nccc")
+		markdown.toggleBulletList(0..0)
+		markdown.toggleCodeFence(1..2)
+
+		state.delete(TextEditorRange(CharLineOffset(0, 1), CharLineOffset(1, 1)))
+		state.cursor.updatePosition(CharLineOffset(0, 1))
+		state.insertStringAtCursor("x")
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/PasteOverSelectionTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/PasteOverSelectionTortureE2eTest.kt
@@ -1,0 +1,209 @@
+package e2e.torture
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
+import utils.assertRichSpanInvariants
+import utils.blockFlags
+import utils.editorUiTest
+import utils.linesWith
+import utils.markdown
+import utils.pasteHtml
+import utils.selectChars
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Paste-over-selection is the replace path (RichSpanManager.handleReplace), the
+ * least defended span-adjustment route: spans wholly inside the replaced range,
+ * sticky line anchors, and the copy buffer all get abused here.
+ */
+class PasteOverSelectionTortureE2eTest {
+
+	@Test
+	fun `pasting plain text over a mid word selection keeps the bullet`() = editorUiTest {
+		markdown.importMarkdown("- item here")
+
+		selectChars(2, 4)
+		setPlainClipboardText("XX")
+		press(Key.V, ctrl = true)
+
+		assertEquals("itXX here", text)
+		assertEquals(setOf("bullet"), blockFlags(0))
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `pasting an html list over a selected plain line bullets only the pasted lines`() = editorUiTest(
+		initialText = AnnotatedString("intro\nmiddle\nend"),
+	) {
+		selectChars(6, 12)
+		pasteHtml("<ul><li>a</li><li>b</li></ul>")
+
+		assertEquals(listOf("intro", "a", "b", "end"), lines)
+		assertEquals(listOf(1, 2), state.linesWith(BulletListSpanStyle))
+		assertEquals(setOf<String>(), blockFlags(0))
+		assertEquals(setOf<String>(), blockFlags(3))
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `pasting an html ordered list into a bullet list keeps list types exclusive`() = editorUiTest {
+		markdown.importMarkdown("- one\n- two")
+
+		selectChars(2, 6)
+		pasteHtml("<ol><li>x</li><li>y</li></ol>")
+
+		for (line in lines.indices) {
+			val flags = blockFlags(line)
+			assertTrue(
+				!("bullet" in flags && "ordered" in flags),
+				"line $line carries both list types: $flags",
+			)
+		}
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `typing over a fully selected bulleted item keeps the bullet`() = editorUiTest {
+		markdown.importMarkdown("- item")
+
+		selectChars(0, 4)
+		typeText("X")
+
+		assertEquals("X", text)
+		assertEquals(setOf("bullet"), blockFlags(0), "replacing an item's text is not removing the item")
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `a partial copy of a list item pastes as plain text`() = editorUiTest {
+		markdown.importMarkdown("- item\n> quoted")
+
+		selectChars(1, 3)
+		press(Key.C, ctrl = true)
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.V, ctrl = true)
+
+		assertEquals(listOf("item", "quotedte"), lines)
+		assertEquals(
+			setOf("quote"),
+			blockFlags(1),
+			"a fragment of an item's text must not drag its list marker along",
+		)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `copy then an intervening edit then paste applies no stale spans`() = editorUiTest {
+		markdown.importMarkdown("- item\nplain")
+
+		selectChars(0, 4)
+		press(Key.C, ctrl = true)
+		press(Key.MoveEnd, ctrl = true)
+		typeText("z")
+		press(Key.V, ctrl = true)
+
+		assertEquals(listOf("item", "plainzitem"), lines)
+		assertEquals(setOf<String>(), blockFlags(1), "the intervening edit must invalidate the span buffer")
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `undo restores a highlight the paste replaced`() = editorUiTest(
+		initialText = AnnotatedString("hello world"),
+	) {
+		val highlight = HighlightSpanStyle(Color.Yellow)
+		state.addRichSpan(5, 8, highlight)
+
+		selectChars(3, 10)
+		setPlainClipboardText("REPL")
+		press(Key.V, ctrl = true)
+		assertEquals("helREPLd", text)
+
+		press(Key.Z, ctrl = true)
+
+		assertEquals("hello world", text)
+		val spans = state.richSpanManager.getAllRichSpans().filter { it.style === highlight }
+		assertEquals(1, spans.size, "undo of a replace must restore the span the replace swallowed")
+		assertEquals(5, spans.single().range.start.char)
+		assertEquals(8, spans.single().range.end.char)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `paste over a selection anchored at the item start keeps the bullet anchored`() = editorUiTest {
+		markdown.importMarkdown("- item")
+
+		selectChars(0, 2)
+		setPlainClipboardText("XY")
+		press(Key.V, ctrl = true)
+
+		assertEquals("XYem", text)
+		val bullets = state.richSpanManager.getAllRichSpans().filter { it.style === BulletListSpanStyle }
+		assertEquals(1, bullets.size, "the line must still be a bullet item")
+		assertEquals(
+			0,
+			bullets.single().range.start.char,
+			"the line-anchored marker must stay stuck to column 0",
+		)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `multi line paste over a multi line selection rebases the surviving halves`() = editorUiTest {
+		markdown.importMarkdown("> alpha\nbeta\n- gamma")
+
+		selectChars(2, 13)
+		setPlainClipboardText("XX\nYY")
+		press(Key.V, ctrl = true)
+
+		assertEquals(listOf("alXX", "YYmma"), lines)
+		assertEquals(setOf("quote"), blockFlags(0), "the quote's surviving half keeps its style")
+		assertEquals(setOf("bullet"), blockFlags(1), "the bullet's surviving half keeps its style")
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `undo then redo of a multi line paste is idempotent`() = editorUiTest {
+		markdown.importMarkdown("> alpha\nbeta\n- gamma")
+
+		selectChars(2, 13)
+		setPlainClipboardText("XX\nYY")
+		press(Key.V, ctrl = true)
+
+		val textAfter = text
+		val flagsAfter = lines.indices.map { blockFlags(it) }
+
+		press(Key.Z, ctrl = true)
+		press(Key.Y, ctrl = true)
+
+		assertEquals(textAfter, text)
+		assertEquals(flagsAfter, lines.indices.map { blockFlags(it) })
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `a foreign paste matching the copy buffer must not resurrect spans`() = editorUiTest {
+		markdown.importMarkdown("- item\nplain")
+
+		selectChars(0, 4)
+		press(Key.C, ctrl = true)
+		press(Key.MoveEnd, ctrl = true)
+		setPlainClipboardText("item")
+		press(Key.V, ctrl = true)
+
+		assertEquals(listOf("item", "plainitem"), lines)
+		// Documented residual limitation: identical text from a foreign source with no
+		// intervening edit still matches the in-editor buffer and re-applies its spans.
+		assertEquals(
+			setOf<String>(),
+			blockFlags(1),
+			"plain text from another application must never arrive styled",
+		)
+		assertRichSpanInvariants()
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/SpanConsistencyTortureTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/SpanConsistencyTortureTest.kt
@@ -138,6 +138,23 @@ class SpanConsistencyTortureTest {
 	}
 
 	@Test
+	fun `replacing across a quoted line keeps spans inside the document`() {
+		val state = editor()
+		val markdown = com.darkrockstudios.texteditor.markdown.MarkdownExtension(state)
+		markdown.importMarkdown("first\n> quoted line here")
+
+		// Found by EditorStateFuzzTest seed 987654321: a multi-line selection replaced
+		// with shorter single-line text leaves the quote span ending past its line.
+		state.replace(
+			TextEditorRange(CharLineOffset(0, 3), CharLineOffset(1, 4)),
+			AnnotatedString("XX"),
+			inheritStyle = false,
+		)
+
+		state.assertRichSpanInvariants()
+	}
+
+	@Test
 	fun `rich spans stay inside the document as it shrinks`() {
 		val state = editor(AnnotatedString("hello world"))
 		state.addRichSpan(6, 11, HighlightSpanStyle(Color.Yellow))

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/SpanConsistencyTortureTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/SpanConsistencyTortureTest.kt
@@ -1,0 +1,151 @@
+package e2e.torture
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import utils.assertRichSpanInvariants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Span arithmetic contracts checked without the UI: what the two styling layers
+ * promise about merging, deduplication, inheritance, and staying inside the document.
+ */
+class SpanConsistencyTortureTest {
+
+	private fun editor(initial: AnnotatedString = AnnotatedString("")): TextEditorState =
+		TextEditorState(scope = TestScope(), measurer = mockk(relaxed = true), initialText = initial)
+
+	private val bold = SpanStyle(fontWeight = FontWeight.Bold)
+
+	private fun boldRangesIn(state: TextEditorState): List<Pair<Int, Int>> =
+		state.getAllText().spanStyles
+			.filter { it.item.fontWeight == FontWeight.Bold }
+			.map { it.start to it.end }
+			.sortedBy { it.first }
+
+	@Test
+	fun `an edit does not bridge two bold runs across a one char gap`() {
+		val state = editor(
+			AnnotatedString(
+				"abcdefgh",
+				spanStyles = listOf(
+					AnnotatedString.Range(bold, 0, 3),
+					AnnotatedString.Range(bold, 4, 7),
+				),
+			)
+		)
+
+		state.cursor.updatePosition(CharLineOffset(0, 8))
+		state.insertStringAtCursor("x")
+
+		val bridged = state.getAllText().spanStyles.any {
+			it.item.fontWeight == FontWeight.Bold && it.start <= 3 && it.end > 3
+		}
+		assertTrue(!bridged, "the unstyled character at index 3 must never become bold: ${boldRangesIn(state)}")
+	}
+
+	@Test
+	fun `addStyleSpan does not bridge unrelated same style runs across a one char gap`() {
+		val state = editor(
+			AnnotatedString(
+				"abcdefgh",
+				spanStyles = listOf(
+					AnnotatedString.Range(bold, 0, 3),
+					AnnotatedString.Range(bold, 4, 7),
+				),
+			)
+		)
+
+		state.addStyleSpan(TextEditorRange(CharLineOffset(0, 7), CharLineOffset(0, 8)), bold)
+
+		// The edit path merges only exactly-adjacent same-style runs (SpanInfo.isAdjacent);
+		// the addStyleSpan path must not be looser and swallow the unstyled gap character.
+		val bridged = state.getAllText().spanStyles.any {
+			it.item.fontWeight == FontWeight.Bold && it.start <= 3 && it.end > 3
+		}
+		assertTrue(!bridged, "the unstyled character at index 3 must never become bold: ${boldRangesIn(state)}")
+	}
+
+	@Test
+	fun `setText drops rich spans by contract`() {
+		val state = editor(AnnotatedString("hello world"))
+		state.addRichSpan(0, 5, HighlightSpanStyle(Color.Yellow))
+		assertEquals(1, state.richSpanManager.getAllRichSpans().size)
+
+		state.setText("replaced")
+
+		assertTrue(state.richSpanManager.getAllRichSpans().isEmpty())
+	}
+
+	@Test
+	fun `replace with inheritStyle takes the style at the replacement`() {
+		val state = editor(
+			AnnotatedString(
+				"bold plain",
+				spanStyles = listOf(AnnotatedString.Range(bold, 0, 4)),
+			)
+		)
+
+		state.replace(
+			TextEditorRange(CharLineOffset(0, 1), CharLineOffset(0, 3)),
+			AnnotatedString("XX"),
+			inheritStyle = true,
+		)
+
+		assertEquals("bXXd plain", state.getAllText().text)
+		val styledAt2 = state.getAllText().spanStyles
+			.any { it.item.fontWeight == FontWeight.Bold && it.start <= 2 && it.end > 2 }
+		assertTrue(styledAt2, "replacement text inside a bold run must inherit bold")
+	}
+
+	@Test
+	fun `adding the same rich span twice does not accumulate`() {
+		val state = editor(AnnotatedString("hello world"))
+		val highlight = HighlightSpanStyle(Color.Yellow)
+
+		state.addRichSpan(0, 5, highlight)
+		state.addRichSpan(0, 5, highlight)
+
+		assertEquals(
+			1,
+			state.richSpanManager.getAllRichSpans().count { it.style === highlight },
+			"identical range and style must collapse to one span",
+		)
+		state.assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `overlapping same style spans normalize to one range`() {
+		val state = editor(AnnotatedString("hello world"))
+
+		state.addStyleSpan(TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 6)), bold)
+		state.addStyleSpan(TextEditorRange(CharLineOffset(0, 3), CharLineOffset(0, 9)), bold)
+
+		assertEquals(
+			listOf(0 to 9),
+			boldRangesIn(state),
+			"two overlapping bold spans must merge into one",
+		)
+	}
+
+	@Test
+	fun `rich spans stay inside the document as it shrinks`() {
+		val state = editor(AnnotatedString("hello world"))
+		state.addRichSpan(6, 11, HighlightSpanStyle(Color.Yellow))
+
+		while (state.getAllText().text.length > 2) {
+			val len = state.getAllText().text.length
+			state.delete(TextEditorRange(CharLineOffset(0, len - 2), CharLineOffset(0, len)))
+			state.assertRichSpanInvariants()
+		}
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoReplayCrashTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoReplayCrashTest.kt
@@ -1,0 +1,51 @@
+package e2e.torture
+
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import utils.FuzzOp
+import utils.StateFuzzInterpreter
+import kotlin.test.Test
+
+/**
+ * Replays a minimized fuzz script (EditorStateFuzzTest seed 42, greedily shrunk
+ * to 19 ops) that crashes the editor with a StringIndexOutOfBoundsException from
+ * captureMetadata while undoing a Replace: the undo recomputes the replaced
+ * range against a document that has since moved. No document produced by
+ * ordinary typing, selecting, and undoing may ever throw.
+ */
+class UndoReplayCrashTest {
+
+	@Test
+	fun `an undo storm over select all replacements must not crash`() {
+		val state = TextEditorState(scope = TestScope(), measurer = mockk(relaxed = true))
+		val markdown = MarkdownExtension(state)
+		markdown.importMarkdown("seed line\nsecond line")
+		val interpreter = StateFuzzInterpreter(state, markdown, skipDemotions = true)
+
+		val script = listOf(
+			FuzzOp.SelectAllType("日本"),
+			FuzzOp.TypeText("beta"),
+			FuzzOp.TypeText("editor"),
+			FuzzOp.TypeText("beta"),
+			FuzzOp.TypeText("beta"),
+			FuzzOp.TypeText("words"),
+			FuzzOp.TypeText("words"),
+			FuzzOp.Enter,
+			FuzzOp.TypeText("delta"),
+			FuzzOp.TypeText("a b"),
+			FuzzOp.SelectAllType("x"),
+			FuzzOp.TypeText("café"),
+			FuzzOp.TypeText("café"),
+			FuzzOp.TypeText("café"),
+			FuzzOp.UndoBurst(5),
+			FuzzOp.PastePlain("café"),
+			FuzzOp.SelectRange(107, 599),
+			FuzzOp.TypeText("gamma"),
+			FuzzOp.UndoBurst(5),
+		)
+
+		script.forEach { interpreter.apply(it) }
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoStormE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoStormE2eTest.kt
@@ -1,0 +1,210 @@
+package e2e.torture
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpan
+import utils.assertBlockState
+import utils.assertRichSpanInvariants
+import utils.editorUiTest
+import utils.markdown
+import utils.selectChars
+import utils.undoAll
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Undo/redo under sustained abuse: long streaks, interleaved bursts, the history
+ * cap, and spans that must survive the round trips.
+ */
+class UndoStormE2eTest {
+
+	@Test
+	fun `type 50 undo 50 redo 50 is exact at both endpoints`() = editorUiTest {
+		val typed = "x".repeat(50)
+		typeText(typed)
+		assertEquals(typed, text)
+
+		repeat(50) { press(Key.Z, ctrl = true) }
+		assertEquals("", text)
+		assertFalse(state.canUndo)
+
+		repeat(50) { press(Key.Y, ctrl = true) }
+		assertEquals(typed, text)
+		assertEquals(50, cursorIndex)
+		assertFalse(state.canRedo)
+	}
+
+	@Test
+	fun `exactly 100 edits then undoAll restores the initial document`() = editorUiTest(
+		initialText = AnnotatedString("seed"),
+	) {
+		press(Key.MoveEnd)
+		typeText("y".repeat(100))
+
+		undoAll()
+
+		assertEquals("seed", text)
+	}
+
+	@Test
+	fun `101 edits then undoAll restores the initial document`() = editorUiTest(
+		initialText = AnnotatedString("seed"),
+	) {
+		press(Key.MoveEnd)
+		typeText("y".repeat(101))
+
+		undoAll()
+
+		// The history silently caps at 100 entries; the 101st keystroke pushes the
+		// first edit off the stack and this document can never be fully restored.
+		assertEquals("seed", text)
+	}
+
+	@Test
+	fun `alternating type and undo leaves a bold span untouched`() = editorUiTest(
+		initialText = AnnotatedString("bold word"),
+	) {
+		val bold = SpanStyle(fontWeight = FontWeight.Bold)
+		state.addStyleSpan(
+			TextEditorRange(state.getOffsetAtCharacter(0), state.getOffsetAtCharacter(4)),
+			bold,
+		)
+		press(Key.MoveEnd)
+
+		repeat(20) {
+			typeText("z")
+			press(Key.Z, ctrl = true)
+		}
+
+		assertEquals("bold word", text)
+		assertTrue(
+			stylesAt(2).any { it.fontWeight == FontWeight.Bold },
+			"the bold run must survive 20 type/undo cycles",
+		)
+		assertTrue(
+			stylesAt(6).none { it.fontWeight == FontWeight.Bold },
+			"the bold run must not grow",
+		)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `undo storm across block toggles lands on the initial document`() = editorUiTest {
+		typeText("abc\ndef")
+		markdown.toggleBulletList(0..1)
+		press(Key.MoveEnd, ctrl = true)
+		typeText("x")
+		markdown.toggleBlockquote(0..1)
+
+		undoAll()
+
+		assertEquals("", text)
+		assertTrue(state.richSpanManager.getAllRichSpans().isEmpty())
+	}
+
+	@Test
+	fun `a divergent edit clears the redo stack`() = editorUiTest {
+		typeText("a")
+		press(Key.Z, ctrl = true)
+		typeText("b")
+
+		assertFalse(state.canRedo)
+		press(Key.Y, ctrl = true)
+		assertEquals("b", text)
+	}
+
+	@Test
+	fun `undo of a paste insert keeps every rich span`() = editorUiTest {
+		markdown.importMarkdown("- alpha\n- bravo")
+
+		press(Key.MoveHome, ctrl = true)
+		repeat(2) { press(Key.DirectionRight) }
+		setPlainClipboardText("XX")
+		press(Key.V, ctrl = true)
+		assertEquals(listOf("alXXpha", "bravo"), lines)
+
+		press(Key.Z, ctrl = true)
+
+		assertEquals(listOf("alpha", "bravo"), lines)
+		assertBlockState(0, bullet = true)
+		assertBlockState(1, bullet = true)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `a decoration added outside history survives undo of a real edit`() = editorUiTest(
+		initialText = AnnotatedString("hello world"),
+	) {
+		val highlight = HighlightSpanStyle(Color.Yellow)
+		state.updateRichSpans(
+			remove = emptySet(),
+			add = setOf(
+				RichSpan(
+					TextEditorRange(state.getOffsetAtCharacter(6), state.getOffsetAtCharacter(11)),
+					highlight,
+				)
+			),
+		)
+
+		press(Key.MoveHome, ctrl = true)
+		typeText("A")
+		press(Key.Z, ctrl = true)
+
+		val spans = state.richSpanManager.getAllRichSpans().filter { it.style === highlight }
+		assertEquals(1, spans.size, "the highlight must survive the type/undo cycle")
+		val range = spans.single().range
+		assertEquals(6, range.start.char, "the highlight must rebase back to its original start")
+		assertEquals(11, range.end.char)
+		assertRichSpanInvariants()
+	}
+
+	@Test
+	fun `interleaved undo redo bursts land where the ledger says`() = editorUiTest {
+		typeText("one two three")
+		val full = "one two three"
+
+		repeat(3) {
+			press(Key.Z, ctrl = true)
+			press(Key.Z, ctrl = true)
+			press(Key.Y, ctrl = true)
+			press(Key.Z, ctrl = true)
+			press(Key.Y, ctrl = true)
+			press(Key.Y, ctrl = true)
+
+			assertEquals(full, text, "a net-zero undo/redo burst must be a no-op")
+		}
+	}
+
+	@Test
+	fun `five selection replacements then undoAll restores text and spans`() = editorUiTest(
+		initialText = AnnotatedString(
+			"aaa bbb ccc ddd eee",
+			spanStyles = listOf(
+				AnnotatedString.Range(SpanStyle(fontWeight = FontWeight.Bold), 8, 11),
+			),
+		),
+	) {
+		for (word in listOf("aaa", "bbb", "ddd", "eee")) {
+			val from = text.indexOf(word)
+			selectChars(from, from + word.length)
+			typeText("X")
+		}
+		assertEquals("X X ccc X X", text)
+		undoAll()
+
+		assertEquals("aaa bbb ccc ddd eee", text)
+		assertTrue(
+			stylesAt(9).any { it.fontWeight == FontWeight.Bold },
+			"the bold run on 'ccc' must survive the replacement storm",
+		)
+		assertTrue(stylesAt(4).none { it.fontWeight == FontWeight.Bold })
+		assertRichSpanInvariants()
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/ForeignHtmlTransferable.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/ForeignHtmlTransferable.kt
@@ -1,0 +1,18 @@
+package utils
+
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
+
+/** Offers markup the way a browser or word processor does: HTML, and nothing editor-specific. */
+internal class ForeignHtmlTransferable(private val html: String) : Transferable {
+	private val htmlFlavor = DataFlavor("text/html;class=java.lang.String;charset=Unicode")
+
+	override fun getTransferDataFlavors(): Array<DataFlavor> = arrayOf(htmlFlavor)
+
+	override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
+		transferDataFlavors.any { it.match(flavor) }
+
+	override fun getTransferData(flavor: DataFlavor): Any =
+		if (flavor.match(htmlFlavor)) html else throw UnsupportedFlavorException(flavor)
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
@@ -1,0 +1,501 @@
+package utils
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.state.TextEditorState
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A deterministic, seed-driven edit script that replays identically through the
+ * pure-state interpreter and the UI harness, so a seed that finds a bug in one
+ * reproduces in the other. Override the committed seeds with the FUZZ_SEED
+ * environment variable to replay a specific failure.
+ */
+sealed class FuzzOp {
+	data class TypeText(val text: String) : FuzzOp()
+	data object Enter : FuzzOp()
+	data object Backspace : FuzzOp()
+	data object DeleteForward : FuzzOp()
+	data class MoveCursor(val slot: Int) : FuzzOp()
+	data class SelectRange(val a: Int, val b: Int) : FuzzOp()
+	data class ToggleBlock(val styleIndex: Int, val lineSeed: Int, val extent: Int) : FuzzOp()
+	data class ToggleBold(val a: Int, val b: Int) : FuzzOp()
+	data class PastePlain(val text: String) : FuzzOp()
+	data class UndoBurst(val count: Int) : FuzzOp()
+	data class RedoBurst(val count: Int) : FuzzOp()
+	data class SelectAllType(val text: String) : FuzzOp()
+}
+
+fun fuzzSeed(default: Long): Long =
+	System.getenv("FUZZ_SEED")?.toLongOrNull() ?: default
+
+private val WORDS = listOf(
+	"alpha", "beta", "gamma", "delta", "words", "editor",
+	"café", "日本", "a b", "x",
+)
+
+private fun FuzzOp.isMutating(): Boolean = when (this) {
+	is FuzzOp.MoveCursor, is FuzzOp.SelectRange,
+	is FuzzOp.UndoBurst, is FuzzOp.RedoBurst -> false
+	else -> true
+}
+
+// Worst-case history entries an op can record. The UI harness types character by
+// character, so a word costs one entry per keystroke, not one per op.
+private fun FuzzOp.historyCost(): Int = when (this) {
+	is FuzzOp.TypeText -> text.length
+	is FuzzOp.SelectAllType -> text.length + 1
+	is FuzzOp.MoveCursor, is FuzzOp.SelectRange,
+	is FuzzOp.UndoBurst, is FuzzOp.RedoBurst -> 0
+	else -> 1
+}
+
+/**
+ * Generates [count] ops. Mutating ops stop once their worst-case history entries
+ * (per keystroke, see [historyCost]) reach [mutatingBudget], which keeps a whole
+ * script inside the 100-entry undo cap so the undo-to-origin invariant is honest;
+ * the rest are navigation and undo/redo.
+ *
+ * [includeBlocks] excludes block toggles from the vocabulary. The undo-to-origin
+ * scripts need this because block undo has known red-test defects (cross-block
+ * restore, unrecorded demotions); those stay covered by the hand-written tests.
+ *
+ * [includeBold] excludes character styling. The fixpoint scripts need this
+ * because any typing near a bold edge can grow the span onto a space, and
+ * emphasis with edge spaces exports as invalid markdown (a known red-test
+ * defect, see MarkdownRoundTripTortureE2eTest `a bold run ending in a space
+ * round trips`). Lift both when the underlying defects are fixed.
+ */
+fun generateFuzzScript(
+	seed: Long,
+	count: Int,
+	mutatingBudget: Int = Int.MAX_VALUE,
+	includeBlocks: Boolean = true,
+	includeBold: Boolean = true,
+): List<FuzzOp> {
+	val random = Random(seed)
+	var budget = mutatingBudget
+	val script = mutableListOf<FuzzOp>()
+	while (script.size < count) {
+		var op = randomOp(random)
+		if (!includeBlocks && op is FuzzOp.ToggleBlock) {
+			op = FuzzOp.TypeText(WORDS.random(random))
+		}
+		if (!includeBold && op is FuzzOp.ToggleBold) {
+			op = FuzzOp.TypeText(WORDS.random(random))
+		}
+		if (op.isMutating()) {
+			val cost = op.historyCost()
+			if (cost > budget) {
+				script.add(randomNonMutatingOp(random))
+				continue
+			}
+			budget -= cost
+		}
+		script.add(op)
+	}
+	return script
+}
+
+private fun randomOp(random: Random): FuzzOp = when (random.nextInt(100)) {
+	in 0 until 30 -> FuzzOp.TypeText(WORDS.random(random))
+	in 30 until 38 -> FuzzOp.Enter
+	in 38 until 48 -> FuzzOp.Backspace
+	in 48 until 52 -> FuzzOp.DeleteForward
+	in 52 until 62 -> FuzzOp.MoveCursor(random.nextInt(1024))
+	in 62 until 68 -> FuzzOp.SelectRange(random.nextInt(1024), random.nextInt(1024))
+	in 68 until 74 -> FuzzOp.ToggleBlock(random.nextInt(4), random.nextInt(1024), random.nextInt(3))
+	in 74 until 79 -> FuzzOp.ToggleBold(random.nextInt(1024), random.nextInt(1024))
+	in 79 until 82 -> FuzzOp.PastePlain(WORDS.random(random))
+	in 82 until 86 -> FuzzOp.UndoBurst(1 + random.nextInt(5))
+	in 86 until 88 -> FuzzOp.RedoBurst(1 + random.nextInt(3))
+	in 88 until 89 -> FuzzOp.SelectAllType(WORDS.random(random))
+	else -> FuzzOp.TypeText(WORDS.random(random))
+}
+
+private fun randomNonMutatingOp(random: Random): FuzzOp = when (random.nextInt(4)) {
+	0 -> FuzzOp.MoveCursor(random.nextInt(1024))
+	1 -> FuzzOp.SelectRange(random.nextInt(1024), random.nextInt(1024))
+	2 -> FuzzOp.UndoBurst(1 + random.nextInt(5))
+	else -> FuzzOp.RedoBurst(1 + random.nextInt(3))
+}
+
+/** Immutable capture of everything the undo-to-origin invariant compares. */
+data class FuzzSnapshot(
+	val text: String,
+	val spanStyles: List<Triple<Int, Int, SpanStyle>>,
+	val richSpans: Set<Pair<TextEditorRange, String>>,
+)
+
+fun snapshotOf(state: TextEditorState): FuzzSnapshot = FuzzSnapshot(
+	text = state.getAllText().text,
+	spanStyles = state.getAllText().spanStyles
+		.map { Triple(it.start, it.end, it.item) }
+		.sortedWith(compareBy({ it.first }, { it.second })),
+	richSpans = state.richSpanManager.getAllRichSpans()
+		.map { it.range to it.style::class.simpleName.orEmpty() }
+		.toSet(),
+)
+
+fun checkCheapInvariants(state: TextEditorState) {
+	state.assertRichSpanInvariants()
+	assertEquals(
+		state.textLines.joinToString("\n") { it.text },
+		state.getAllText().text,
+		"the flat text and the line list must agree",
+	)
+	val cursor = state.cursorPosition
+	assertTrue(cursor.line in state.textLines.indices, "cursor line out of bounds: $cursor")
+	assertTrue(
+		cursor.char in 0..state.textLines[cursor.line].length,
+		"cursor char out of bounds: $cursor",
+	)
+}
+
+/** Runs [applyOp] over [script], decorating any failure with a replayable transcript. */
+fun runFuzzScript(
+	seed: Long,
+	script: List<FuzzOp>,
+	applyOp: (FuzzOp) -> Unit,
+) {
+	script.forEachIndexed { index, op ->
+		try {
+			applyOp(op)
+		} catch (failure: Throwable) {
+			throw AssertionError(
+				"fuzz seed=$seed failed at op[$index]=$op\nhistory=${script.take(index + 1)}",
+				failure,
+			)
+		}
+	}
+}
+
+private val FUZZ_BOLD = SpanStyle(fontWeight = FontWeight.Bold)
+
+private val BLOCK_TOGGLES: List<Pair<String, MarkdownExtension.(IntRange) -> Unit>> = listOf(
+	"bullet" to { lines -> toggleBulletList(lines) },
+	"ordered" to { lines -> toggleOrderedList(lines) },
+	"quote" to { lines -> toggleBlockquote(lines) },
+	"fence" to { lines -> toggleCodeFence(lines) },
+)
+
+private fun blockToggleTarget(
+	op: FuzzOp.ToggleBlock,
+	state: TextEditorState,
+	markdown: MarkdownExtension,
+): Pair<IntRange, MarkdownExtension.(IntRange) -> Unit>? {
+	val lineCount = state.textLines.size
+	val start = op.lineSeed % lineCount
+	val range = start..minOf(start + op.extent, lineCount - 1)
+	val (name, toggle) = BLOCK_TOGGLES[op.styleIndex % BLOCK_TOGGLES.size]
+	// D3-shaped documents (quote stacked on a list) corrupt on round trip today, so
+	// the fuzzers refuse to create them. Lift this guard when D2-D4 are fixed.
+	val wouldStack = when (name) {
+		"quote" -> range.any { markdown.isBulletList(it) || markdown.isOrderedList(it) }
+		"bullet", "ordered" -> range.any { markdown.isBlockquote(it) }
+		else -> false
+	}
+	return if (wouldStack) null else range to toggle
+}
+
+/**
+ * True when the live selection touches any block-styled line. Replacing across a
+ * block line leaves spans out of bounds today (a known red-test defect, see
+ * SpanConsistencyTortureTest `replacing across a quoted line keeps spans inside
+ * the document`), so the fuzz interpreters collapse such selections before
+ * typing instead of replacing through them. Lift when the rebase is fixed.
+ */
+private fun selectionTouchesBlockLine(state: TextEditorState, markdown: MarkdownExtension): Boolean {
+	val selection = state.selector.selection ?: return false
+	return selection.affectedLines().any { line ->
+		markdown.isBlockquote(line) || markdown.isBulletList(line) ||
+			markdown.isOrderedList(line) || markdown.isCodeFence(line)
+	}
+}
+
+/**
+ * True when deleting the live selection would join lines across a block boundary.
+ * That join can bake overlapping ParagraphStyles and crash the next insert (a
+ * known red-test defect, see ParagraphOverlapCrashTest), so the fuzz interpreters
+ * collapse such selections instead of deleting through them.
+ */
+private fun selectionDeleteIsGuarded(state: TextEditorState, markdown: MarkdownExtension): Boolean {
+	val selection = state.selector.selection ?: return false
+	if (selection.start.line == selection.end.line) return false
+	return selectionTouchesBlockLine(state, markdown)
+}
+
+private fun blockSetOf(markdown: MarkdownExtension, line: Int): Set<String> = buildSet {
+	if (markdown.isBlockquote(line)) add("quote")
+	if (markdown.isBulletList(line)) add("bullet")
+	if (markdown.isOrderedList(line)) add("ordered")
+	if (markdown.isCodeFence(line)) add("fence")
+}
+
+/**
+ * True when a forward delete at the cursor would join two lines with different
+ * block styles. Unlike backspace, forward delete has no demote-first step, so the
+ * join stacks both blocks onto one line (a known red-test defect, see
+ * BlockBoundaryDeletionE2eTest); the fuzz interpreters skip those deletes.
+ */
+private fun forwardJoinIsGuarded(state: TextEditorState, markdown: MarkdownExtension): Boolean {
+	val pos = state.cursorPosition
+	if (pos.char != state.textLines[pos.line].length) return false
+	val next = pos.line + 1
+	if (next >= state.textLines.size) return false
+	val current = blockSetOf(markdown, pos.line)
+	val below = blockSetOf(markdown, next)
+	return current != below && (current.isNotEmpty() || below.isNotEmpty())
+}
+
+/**
+ * True when a Backspace at the current cursor, or an Enter on the current line,
+ * would trigger the smart block demotion. Demotions bypass undo history (a known
+ * red-test defect), so the undo-to-origin fuzz scripts step around them.
+ */
+private fun wouldDemote(state: TextEditorState, markdown: MarkdownExtension, enter: Boolean): Boolean {
+	val line = state.cursorPosition.line
+	val hasBlock = markdown.isBlockquote(line) || markdown.isBulletList(line) ||
+		markdown.isOrderedList(line) || markdown.isCodeFence(line)
+	if (!hasBlock) return false
+	return if (enter) {
+		state.textLines[line].text.isEmpty()
+	} else {
+		state.cursorPosition.char == 0
+	}
+}
+
+/**
+ * Trims edge spaces off a candidate style range and rejects multi-line or empty
+ * results. Emphasis wrapped around an edge space exports as invalid markdown (a
+ * known red-test defect, see MarkdownRoundTripTortureE2eTest `a bold run ending
+ * in a space round trips`), so the fuzzers only bold clean single-line ranges.
+ */
+private fun trimmedStyleRange(text: String, rawA: Int, rawB: Int): Pair<Int, Int>? {
+	val clampedA = rawA % (text.length + 1)
+	val clampedB = rawB % (text.length + 1)
+	var start = minOf(clampedA, clampedB)
+	var end = maxOf(clampedA, clampedB)
+	while (start < end && (text[start] == ' ' || text[start] == '\n')) start++
+	while (end > start && (text[end - 1] == ' ' || text[end - 1] == '\n')) end--
+	if (start >= end) return null
+	if (text.substring(start, end).contains('\n')) return null
+	return start to end
+}
+
+/**
+ * Applies [op] directly to the state, the pure-state twin of [applyFuzzOpUi].
+ *
+ * With [replaceOverSelection] off, typing and pasting collapse any selection
+ * instead of replacing through it: undoing a Replace can crash in
+ * captureMetadata (see UndoReplayCrashTest), so the undo-to-origin scripts
+ * avoid creating Replace history entries. Lift when that crash is fixed.
+ */
+class StateFuzzInterpreter(
+	private val state: TextEditorState,
+	private val markdown: MarkdownExtension,
+	private val skipDemotions: Boolean,
+	private val replaceOverSelection: Boolean = true,
+) {
+	private fun clampIndex(raw: Int): Int = raw % (state.getAllText().text.length + 1)
+
+	private fun offset(raw: Int): CharLineOffset = state.getOffsetAtCharacter(clampIndex(raw))
+
+	private fun collapseSelection() {
+		val start = state.selector.selection?.start
+		state.selector.clearSelection()
+		start?.let { state.cursor.updatePosition(it) }
+	}
+
+	private fun typeOrReplace(text: String) {
+		if (!replaceOverSelection || selectionTouchesBlockLine(state, markdown)) {
+			collapseSelection()
+		}
+		val selection = state.selector.selection
+		if (selection != null) {
+			state.replace(selection, AnnotatedString(text), inheritStyle = true)
+			state.selector.clearSelection()
+		} else {
+			state.insertStringAtCursor(text)
+		}
+	}
+
+	fun apply(op: FuzzOp) {
+		when (op) {
+			is FuzzOp.TypeText -> typeOrReplace(op.text)
+
+			is FuzzOp.Enter -> {
+				if (skipDemotions && wouldDemote(state, markdown, enter = true)) return
+				state.selector.clearSelection()
+				state.insertNewlineAtCursor()
+			}
+
+			is FuzzOp.Backspace -> {
+				if (selectionDeleteIsGuarded(state, markdown)) collapseSelection()
+				if (skipDemotions && state.selector.selection == null &&
+					wouldDemote(state, markdown, enter = false)
+				) return
+				val selection = state.selector.selection
+				if (selection != null) {
+					state.delete(selection)
+					state.selector.clearSelection()
+				} else {
+					state.backspaceAtCursor()
+				}
+			}
+
+			is FuzzOp.DeleteForward -> {
+				if (selectionDeleteIsGuarded(state, markdown)) collapseSelection()
+				val selection = state.selector.selection
+				if (selection != null) {
+					state.delete(selection)
+					state.selector.clearSelection()
+				} else {
+					if (forwardJoinIsGuarded(state, markdown)) return
+					state.deleteAtCursor()
+				}
+			}
+
+			is FuzzOp.MoveCursor -> {
+				state.selector.clearSelection()
+				state.cursor.updatePosition(offset(op.slot))
+			}
+
+			is FuzzOp.SelectRange -> {
+				val a = clampIndex(op.a)
+				val b = clampIndex(op.b)
+				if (a != b) {
+					state.selector.updateSelection(offset(minOf(a, b)), offset(maxOf(a, b)))
+				}
+			}
+
+			is FuzzOp.ToggleBlock -> {
+				val target = blockToggleTarget(op, state, markdown) ?: return
+				target.second(markdown, target.first)
+			}
+
+			is FuzzOp.ToggleBold -> {
+				trimmedStyleRange(state.getAllText().text, op.a, op.b)?.let { (start, end) ->
+					state.addStyleSpan(
+						TextEditorRange(state.getOffsetAtCharacter(start), state.getOffsetAtCharacter(end)),
+						FUZZ_BOLD,
+					)
+				}
+			}
+
+			is FuzzOp.PastePlain -> typeOrReplace(op.text)
+
+			// canUndo/canRedo only refresh during layout bookkeeping, which never runs
+			// against the 1x1 mock viewport; undo()/redo() no-op safely on empty stacks.
+			is FuzzOp.UndoBurst -> repeat(op.count) { state.undo() }
+
+			is FuzzOp.RedoBurst -> repeat(op.count) { state.redo() }
+
+			is FuzzOp.SelectAllType -> {
+				state.selector.selectAll()
+				typeOrReplace(op.text)
+			}
+		}
+	}
+}
+
+/** Applies [op] through real key events and the clipboard, the UI twin of [StateFuzzInterpreter]. */
+fun EditorUiTestScope.applyFuzzOpUi(
+	op: FuzzOp,
+	skipDemotions: Boolean,
+	replaceOverSelection: Boolean = true,
+) {
+	fun clampIndex(raw: Int): Int = raw % (text.length + 1)
+
+	// An unshifted arrow collapses the selection, sidestepping the replace-over-block
+	// rebase defect and the Replace-undo crash the same way the state interpreter does.
+	fun collapseSelectionIfGuarded() {
+		val guarded = !replaceOverSelection || selectionTouchesBlockLine(state, markdown)
+		if (guarded && state.selector.selection != null) press(Key.DirectionLeft)
+	}
+
+	when (op) {
+		is FuzzOp.TypeText -> {
+			collapseSelectionIfGuarded()
+			typeText(op.text)
+		}
+
+		is FuzzOp.Enter -> {
+			if (skipDemotions && wouldDemote(state, markdown, enter = true)) return
+			press(Key.Enter)
+		}
+
+		is FuzzOp.Backspace -> {
+			if (selectionDeleteIsGuarded(state, markdown)) press(Key.DirectionLeft)
+			if (skipDemotions && state.selector.selection == null &&
+				wouldDemote(state, markdown, enter = false)
+			) return
+			press(Key.Backspace)
+		}
+
+		is FuzzOp.DeleteForward -> {
+			if (selectionDeleteIsGuarded(state, markdown)) press(Key.DirectionLeft)
+			if (state.selector.selection == null && forwardJoinIsGuarded(state, markdown)) return
+			press(Key.Delete)
+		}
+
+		is FuzzOp.MoveCursor -> when (op.slot % 8) {
+			0 -> press(Key.MoveHome, ctrl = true)
+			1 -> press(Key.MoveEnd, ctrl = true)
+			2 -> press(Key.MoveHome)
+			3 -> press(Key.MoveEnd)
+			4 -> press(Key.DirectionLeft)
+			5 -> press(Key.DirectionRight)
+			6 -> press(Key.DirectionUp)
+			else -> press(Key.DirectionDown)
+		}
+
+		is FuzzOp.SelectRange -> {
+			val a = clampIndex(op.a)
+			val b = clampIndex(op.b)
+			if (a != b) selectChars(minOf(a, b), maxOf(a, b))
+		}
+
+		is FuzzOp.ToggleBlock -> {
+			val target = blockToggleTarget(op, state, markdown) ?: return
+			target.second(markdown, target.first)
+			waitForIdle()
+		}
+
+		is FuzzOp.ToggleBold -> {
+			trimmedStyleRange(text, op.a, op.b)?.let { (start, end) ->
+				state.addStyleSpan(
+					TextEditorRange(
+						state.getOffsetAtCharacter(start),
+						state.getOffsetAtCharacter(end),
+					),
+					FUZZ_BOLD,
+				)
+				waitForIdle()
+			}
+		}
+
+		is FuzzOp.PastePlain -> {
+			collapseSelectionIfGuarded()
+			setPlainClipboardText(op.text)
+			press(Key.V, ctrl = true)
+		}
+
+		is FuzzOp.UndoBurst -> repeat(op.count) { press(Key.Z, ctrl = true) }
+
+		is FuzzOp.RedoBurst -> repeat(op.count) { press(Key.Y, ctrl = true) }
+
+		is FuzzOp.SelectAllType -> {
+			press(Key.A, ctrl = true)
+			collapseSelectionIfGuarded()
+			typeText(op.text)
+		}
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/TortureHelpers.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/TortureHelpers.kt
@@ -1,0 +1,119 @@
+package utils
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.ClipEntry
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.markdown.withMarkdown
+import com.darkrockstudios.texteditor.richstyle.RichSpan
+import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.state.getRichSpansInRange
+import java.util.WeakHashMap
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private val markdownExtensions = WeakHashMap<TextEditorState, MarkdownExtension>()
+
+/** Markdown extension for this editor's state, created once per test. */
+val EditorUiTestScope.markdown: MarkdownExtension
+	get() = markdownExtensions.getOrPut(state) { state.withMarkdown() }
+
+/** Pastes [html] the way a foreign application would: a text/html clipboard flavor, then Ctrl+V. */
+@OptIn(ExperimentalComposeUiApi::class)
+fun EditorUiTestScope.pasteHtml(html: String) {
+	clipboard.seed(ClipEntry(ForeignHtmlTransferable(html)))
+	press(Key.V, ctrl = true)
+}
+
+/** Line indices carrying a rich span of exactly [style], sorted. */
+fun TextEditorState.linesWith(style: RichSpanStyle): List<Int> =
+	richSpanManager.getAllRichSpans()
+		.filter { it.style === style }
+		.map { it.range.start.line }
+		.sorted()
+
+/** Rich spans overlapping the flat character range [startChar, endChar). */
+fun EditorUiTestScope.richSpansIn(startChar: Int, endChar: Int): Set<RichSpan> =
+	state.getRichSpansInRange(
+		TextEditorRange(
+			state.getOffsetAtCharacter(startChar),
+			state.getOffsetAtCharacter(endChar),
+		)
+	)
+
+/**
+ * Selects the flat character range [fromChar, toChar) directly through the selection
+ * manager. Use [EditorUiTestScope.dragSelect] only when the mouse gesture itself is
+ * under test; it costs a real 350ms sleep per call.
+ */
+fun EditorUiTestScope.selectChars(fromChar: Int, toChar: Int) {
+	state.selector.updateSelection(
+		state.getOffsetAtCharacter(fromChar),
+		state.getOffsetAtCharacter(toChar),
+	)
+	waitForIdle()
+}
+
+/** Presses Ctrl+Z until the undo stack is empty; returns how many undos ran. */
+fun EditorUiTestScope.undoAll(max: Int = 250): Int {
+	var count = 0
+	while (state.canUndo) {
+		check(count < max) { "undoAll exceeded $max undos without exhausting the undo stack" }
+		press(Key.Z, ctrl = true)
+		count++
+	}
+	return count
+}
+
+/** Asserts [line]'s exact block-style membership; every style not passed as true must be absent. */
+fun EditorUiTestScope.assertBlockState(
+	line: Int,
+	quote: Boolean = false,
+	bullet: Boolean = false,
+	ordered: Boolean = false,
+	fence: Boolean = false,
+) {
+	assertEquals(quote, markdown.isBlockquote(line), "line $line blockquote state")
+	assertEquals(bullet, markdown.isBulletList(line), "line $line bullet-list state")
+	assertEquals(ordered, markdown.isOrderedList(line), "line $line ordered-list state")
+	assertEquals(fence, markdown.isCodeFence(line), "line $line code-fence state")
+}
+
+/** Structural sanity of every rich span: ordered, in bounds, no duplicate (range, style) pairs. */
+fun EditorUiTestScope.assertRichSpanInvariants() = state.assertRichSpanInvariants()
+
+fun TextEditorState.assertRichSpanInvariants() {
+	val spans = richSpanManager.getAllRichSpans()
+	val lineCount = textLines.size
+	for (span in spans) {
+		val start = span.range.start
+		val end = span.range.end
+		assertTrue(
+			start.line < end.line || (start.line == end.line && start.char <= end.char),
+			"span $span has an inverted range",
+		)
+		assertTrue(
+			start.line in 0 until lineCount && end.line in 0 until lineCount,
+			"span $span references lines outside the $lineCount-line document",
+		)
+		assertTrue(
+			start.char in 0..textLines[start.line].length,
+			"span $span starts past the end of line ${start.line} " +
+				"(char ${start.char}, line length ${textLines[start.line].length})",
+		)
+		assertTrue(
+			end.char in 0..textLines[end.line].length,
+			"span $span ends past the end of line ${end.line} " +
+				"(char ${end.char}, line length ${textLines[end.line].length})",
+		)
+	}
+	val duplicates = spans
+		.groupBy { it.range to it.style::class }
+		.filterValues { it.size > 1 }
+	assertTrue(
+		duplicates.isEmpty(),
+		"duplicate rich spans with identical range and style class: ${duplicates.values}",
+	)
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/TortureHelpers.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/TortureHelpers.kt
@@ -81,6 +81,14 @@ fun EditorUiTestScope.assertBlockState(
 	assertEquals(fence, markdown.isCodeFence(line), "line $line code-fence state")
 }
 
+/** The block styles present on [line], as readable names; empty set means a plain line. */
+fun EditorUiTestScope.blockFlags(line: Int): Set<String> = buildSet {
+	if (markdown.isBlockquote(line)) add("quote")
+	if (markdown.isBulletList(line)) add("bullet")
+	if (markdown.isOrderedList(line)) add("ordered")
+	if (markdown.isCodeFence(line)) add("fence")
+}
+
 /** Structural sanity of every rich span: ordered, in bounds, no duplicate (range, style) pairs. */
 fun EditorUiTestScope.assertRichSpanInvariants() = state.assertRichSpanInvariants()
 


### PR DESCRIPTION
Expands the e2e/integration suite with a `e2e.torture` package: hand-written abuse scenarios for the rich-text machinery plus seeded, reproducible fuzz tests. ~120 new tests (807 total). **22 tests are intentionally committed RED**: each asserts correct behavior against a known or newly discovered defect, so CI on this branch stays red until the defects are fixed.

## New coverage

- `BlockToggleTortureE2eTest` (15): block toggles under realistic editing: splits, smart Enter/Backspace demotion, mutual exclusion, undo/redo, select-all toggles (regression guard for #43's benign shape).
- `BlockBoundaryDeletionE2eTest` (10): deletions crossing block boundaries: list merges, HR deletion, cross-block joins.
- `PasteOverSelectionTortureE2eTest` (11): the replace path (`RichSpanManager.handleReplace`) plus the `CopiedRichSpans` buffer.
- `MarkdownRoundTripTortureE2eTest` (10): the D2/D3/D4 corruption family from `docs/design/line-blocks.md`, header demotion, fixpoint contracts.
- `UndoStormE2eTest` (10): long undo/redo streaks, history cap, span survival.
- `SpanConsistencyTortureTest` (8, pure-state): span arithmetic contracts.
- `UndoReplayCrashTest`, `ParagraphOverlapCrashTest`: minimized fuzz-found crash repros.
- `EditorStateFuzzTest` (10) + `EditorFuzzE2eTest` (5): seeded random edit storms via a shared `FuzzScript` vocabulary that replays identically in the pure-state and UI harnesses. Invariants: per-op span sanity, undo-to-origin, markdown export/import fixpoint. Committed seeds are green; reproduce any failure with `FUZZ_SEED=<seed>`. Known-red mechanisms are excluded from the vocabulary with `Lift when ... fixed` markers pointing at the pinning red test.

Harness additions in `utils/`: `TortureHelpers.kt` (markdown accessor, `pasteHtml`, `selectChars`, `undoAll`, `blockFlags`, `assertRichSpanInvariants`), `ForeignHtmlTransferable` promoted from `HtmlPasteE2eTest`, `FuzzScript.kt`.

## Red-test ledger

| Test(s) | Defect |
|---|---|
| MarkdownRoundTrip: bulleted HR round trip, 2nd-gen fixpoint | **D2**: marker on a rule line destroys the rule, escalates to `- \-\-\-` |
| MarkdownRoundTrip: quote-on-bullet round trip, stacked fixpoint | **D3**: import peels only the outermost stacked marker; `- ` leaks into prose |
| MarkdownRoundTrip: HTML blockquote+hr | **D4**: rule inside a quote decays to literal `---` on save |
| MarkdownRoundTrip: header config switch | headers stored as font sizes; config change silently demotes `# Title` to plain text |
| MarkdownRoundTrip: bold ending in a space | **new (fuzz-found)**: export writes `**word **`, invalid markdown, escalates to escaped asterisks |
| UndoReplayCrashTest | **new (fuzz-found, minimized)**: undoing a Replace after other undos crashes in `captureMetadata` (`StringIndexOutOfBoundsException`) |
| ParagraphOverlapCrashTest (2) | **new (fuzz-found, minimized)**: delete joining a code-fence line with another block line bakes overlapping ParagraphStyles; the next insert crashes (`Paragraph overlap not allowed`) |
| BlockBoundaryDeletion: quote-to-fence join, cross-block undo restore | **new**: cross-block join stacks mutually-exclusive blocks (`[quote, fence]` on one line); undo restores the stacked state |
| BlockBoundaryDeletion: forward-delete join | **new**: forward delete drags the incoming line's bullet onto a plain line, asymmetric with backspace's demote-first; behavior is **nondeterministic across runs** (flaps green/red, span-set ordering suspected) |
| BlockBoundaryDeletion: one-char item, word delete | **new**: deleting an item's last character drops the bullet, though empty items render markers by design (`RichSpan.intersectsWith`) |
| BlockToggle: smart backspace/enter demotion undo (2) | **new**: `demoteLineBlock` mutates without a history entry; smart demotions cannot be undone |
| BlockToggle: enter on empty item exits | asserts intended behavior; **flaps green/red** in full-suite runs (same nondeterminism family as above) |
| PasteOverSelection: fully-selected item, sticky anchor | `handleReplace` drops spans wholly inside the replacement and has no `stickyAtStart` handling |
| PasteOverSelection: partial copy leaks marker | **new**: `copyRichSpans` clamps a partial-line list span and re-applies it mid-line on paste |
| PasteOverSelection: foreign paste resurrects spans | documented `CopiedRichSpans` residual limitation (`TextEditorState.kt` ~1250) |
| UndoStorm: 101 edits | history cap 100 silently loses the oldest edit |
| SpanConsistency: one-char-gap bridge | `mergeOverlaps` (`addStyleSpan` path) bridges a 1-char unstyled gap; the edit path (`SpanInfo.isAdjacent`) is exact |

Notes:
- The #43 select-all literal-marker symptom did not reproduce on plain non-empty lines (that shape is now a green guard); the corrupting variants are the D2 cases above.
- `canUndo`/`canRedo` only refresh inside layout bookkeeping; headless/state-only consumers always read `false` (worked around in the fuzz harness, worth a look).
- Suite adds roughly 70s to `desktopTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)