### PR TITLE
Cut the per-frame cost of drawing spell-check squiggles

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/DrawRichSpanUi.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/DrawRichSpanUi.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.texteditor
 
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.util.fastForEach
 import com.darkrockstudios.texteditor.state.TextEditorState
 
 /**
@@ -17,30 +18,32 @@ internal fun DrawScope.drawRichSpans(
 	state: TextEditorState,
 	phase: RichSpanDrawPhase = RichSpanDrawPhase.Foreground,
 ) {
+	val spans = lineWrap.richSpans
+	if (spans.isEmpty()) return
+
 	val textLayoutResult = lineWrap.textLayoutResult
 
-	lineWrap.richSpans.forEach { richSpan ->
-		// Get the range of text visible in this wrap
-		val wrapVisibleStart = textLayoutResult.getLineStart(lineWrap.virtualLineIndex)
-		val wrapVisibleEnd =
-			textLayoutResult.getLineEnd(lineWrap.virtualLineIndex, visibleEnd = true)
+	// Every value below describes the wrap, not the span, so it is computed once
+	// per line instead of once per span. Draw runs these on each visible line each
+	// frame, and the character-index conversions are the expensive part.
+	val wrapVisibleStart = textLayoutResult.getLineStart(lineWrap.virtualLineIndex)
+	val wrapVisibleEnd = textLayoutResult.getLineEnd(lineWrap.virtualLineIndex, visibleEnd = true)
 
-		// Calculate where in the original line this wrapped segment starts and ends
-		val lineStart = CharLineOffset(line = lineWrap.line, char = lineWrap.wrapStartsAtIndex)
-		val lineEnd = CharLineOffset(
-			line = lineWrap.line,
-			char = lineWrap.wrapStartsAtIndex + (wrapVisibleEnd - wrapVisibleStart)
-		)
+	val lineStart = CharLineOffset(line = lineWrap.line, char = lineWrap.wrapStartsAtIndex)
+	val lineEnd = CharLineOffset(
+		line = lineWrap.line,
+		char = lineWrap.wrapStartsAtIndex + (wrapVisibleEnd - wrapVisibleStart)
+	)
+	val lineStartAbsChar = lineStart.toCharacterIndex(state)
+	val lineEndAbsChar = lineEnd.toCharacterIndex(state)
+	val translateY = lineWrap.offset.y - state.scrollState.value
 
-		// Convert to absolute character indices
+	spans.fastForEach { richSpan ->
 		val spanStartAbsChar = richSpan.range.start.toCharacterIndex(state)
 		val spanEndAbsChar = richSpan.range.end.toCharacterIndex(state)
-		val lineStartAbsChar = lineStart.toCharacterIndex(state)
 
 		// If this wrapped segment intersects with our span
-		if (spanStartAbsChar <= lineEnd.toCharacterIndex(state) &&
-			spanEndAbsChar >= lineStart.toCharacterIndex(state)
-		) {
+		if (spanStartAbsChar <= lineEndAbsChar && spanEndAbsChar >= lineStartAbsChar) {
 			// Calculate position adjustment based on whether this is a wrapped line
 			// Calculate the local range within this wrapped segment
 			val localStart = if (spanStartAbsChar <= lineStartAbsChar) {
@@ -49,7 +52,7 @@ internal fun DrawScope.drawRichSpans(
 				(spanStartAbsChar - lineStartAbsChar) + wrapVisibleStart
 			}
 
-			val localEnd = if (spanEndAbsChar >= lineEnd.toCharacterIndex(state)) {
+			val localEnd = if (spanEndAbsChar >= lineEndAbsChar) {
 				wrapVisibleEnd
 			} else {
 				((spanEndAbsChar - lineStartAbsChar) + wrapVisibleStart)
@@ -62,7 +65,7 @@ internal fun DrawScope.drawRichSpans(
 			)
 
 			with(richSpan.style) {
-				translate(top = lineWrap.offset.y - state.scrollState.value) {
+				translate(top = translateY) {
 					when (phase) {
 						RichSpanDrawPhase.Background -> drawBackground(
 							layoutResult = textLayoutResult,

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/SpellCheckStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/SpellCheckStyle.kt
@@ -8,12 +8,9 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.texteditor.LineWrap
 import com.darkrockstudios.texteditor.state.TextEditorState
-import kotlin.math.PI
-import kotlin.math.sin
 
 /**
  * A [RichSpanStyle] that draws a red wavy underline beneath misspelled text.
@@ -26,7 +23,6 @@ object SpellCheckStyle : RichSpanStyle {
 	private val waveLengthDp = 15.dp
 	private val amplitudeDp = 2.dp
 	private val strokeWidthDp = 1.5.dp
-	private const val pointsPerWave: Int = 6
 
 	override fun DrawScope.drawCustomStyle(
 		layoutResult: TextLayoutResult,
@@ -34,9 +30,9 @@ object SpellCheckStyle : RichSpanStyle {
 		textRange: TextRange,
 		state: TextEditorState,
 	) {
-		val waveLength = with(Density(density)) { waveLengthDp.toPx() }
-		val amplitude = with(Density(density)) { amplitudeDp.toPx() }
-		val strokeWidth = with(Density(density)) { strokeWidthDp.toPx() }
+		val waveLength = waveLengthDp.toPx()
+		val amplitude = amplitudeDp.toPx()
+		val strokeWidth = strokeWidthDp.toPx()
 
 		val lineHeight = layoutResult.multiParagraph.getLineHeight(lineWrap.virtualLineIndex)
 		val baselineY = lineHeight - 2f // Slightly above the bottom
@@ -60,23 +56,23 @@ object SpellCheckStyle : RichSpanStyle {
 		}
 
 		if (endX > startX) {
+			// One quadratic per half wave rather than a polyline sampled across it:
+			// a third of the segments to stroke for a smoother curve, and stroking
+			// cost tracks segment count closely enough to show up in frame time.
+			val halfWave = waveLength / 2f
 			val path = Path().apply {
 				moveTo(startX, baselineY)
 
-				val width = endX - startX
-				val numPoints = ((width / waveLength) * pointsPerWave).toInt().coerceAtLeast(2)
-				val dx = width / (numPoints - 1)
-
-				for (i in 0 until numPoints) {
-					val x = startX + (i * dx)
-					val phase = (x - startX) * (2 * PI / waveLength)
-					val y = baselineY + (amplitude * sin(phase)).toFloat()
-
-					if (i == 0) {
-						moveTo(x, y)
-					} else {
-						lineTo(x, y)
-					}
+				var x = startX
+				var crestBelow = true
+				while (x < endX) {
+					val next = (x + halfWave).coerceAtMost(endX)
+					// A quadratic reaches half its control offset, so double the
+					// amplitude to put the crest on the sine's peak.
+					val control = if (crestBelow) amplitude * 2f else -amplitude * 2f
+					quadraticTo((x + next) / 2f, baselineY + control, next, baselineY)
+					x = next
+					crestBelow = !crestBelow
 				}
 			}
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/DocumentSnapshot.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/DocumentSnapshot.kt
@@ -25,6 +25,12 @@ class DocumentSnapshot private constructor(
 	 * `PUBLICATION` safety over, where a plain field would publish the map unsafely.
 	 */
 	private val spansByStartLine: Lazy<Map<Int, List<RichSpan>>>,
+	/**
+	 * Backs [lineStartOffsets]. Held as the [Lazy] for the same reasons as
+	 * [spansByStartLine], and shared with the revision [withRichSpans] produces
+	 * because a span-only edit leaves every line length untouched.
+	 */
+	private val lineStarts: Lazy<IntArray>,
 ) {
 	internal constructor(lines: List<AnnotatedString>, richSpans: Set<RichSpan>) : this(
 		lines = lines,
@@ -32,6 +38,7 @@ class DocumentSnapshot private constructor(
 		spansByStartLine = lazy(LazyThreadSafetyMode.PUBLICATION) {
 			richSpans.groupBy { it.range.start.line }
 		},
+		lineStarts = lineStartsOf(lines),
 	)
 
 	/**
@@ -40,6 +47,19 @@ class DocumentSnapshot private constructor(
 	 * cost a map lookup instead of a scan of every span in the document.
 	 */
 	internal val richSpansByStartLine: Map<Int, List<RichSpan>> get() = spansByStartLine.value
+
+	/**
+	 * Flat character index at which each line starts, counting one newline between
+	 * lines. Has one entry per line plus a trailing entry for the position just past
+	 * the document's final newline slot, so `lineStartOffsets[n + 1] - 1` is the end
+	 * of line `n`.
+	 *
+	 * Built on first read and reused until a revision changes the text, which turns
+	 * offset/index conversion from a walk over every preceding line into an array
+	 * read. Draw does that conversion several times per rich span per frame, so the
+	 * walk showed up directly in frame time on long documents.
+	 */
+	internal val lineStartOffsets: IntArray get() = lineStarts.value
 
 	/** The whole document as a single [AnnotatedString], lines joined with newlines. */
 	fun getAllText(): AnnotatedString = buildAnnotatedString {
@@ -54,7 +74,26 @@ class DocumentSnapshot private constructor(
 	 * start on are the same ones they started on before.
 	 */
 	internal fun withLines(lines: List<AnnotatedString>) =
-		DocumentSnapshot(lines, richSpans, spansByStartLine)
+		DocumentSnapshot(lines, richSpans, spansByStartLine, lineStartsOf(lines))
 
-	internal fun withRichSpans(richSpans: Set<RichSpan>) = DocumentSnapshot(lines, richSpans)
+	internal fun withRichSpans(richSpans: Set<RichSpan>) = DocumentSnapshot(
+		lines = lines,
+		richSpans = richSpans,
+		spansByStartLine = lazy(LazyThreadSafetyMode.PUBLICATION) {
+			richSpans.groupBy { it.range.start.line }
+		},
+		lineStarts = lineStarts,
+	)
 }
+
+private fun lineStartsOf(lines: List<AnnotatedString>): Lazy<IntArray> =
+	lazy(LazyThreadSafetyMode.PUBLICATION) {
+		val starts = IntArray(lines.size + 1)
+		var offset = 0
+		for (index in lines.indices) {
+			starts[index] = offset
+			offset += lines[index].length + 1
+		}
+		starts[lines.size] = offset
+		starts
+	}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -831,20 +831,29 @@ class TextEditorState(
 	 * The inverse of [getCharacterIndex]; clamps to the document end when out of range.
 	 */
 	fun getOffsetAtCharacter(index: Int): CharLineOffset {
-		var remainingChars = index
-
-		for (lineIndex in textLines.indices) {
-			val lineLength = textLines[lineIndex].length + 1  // +1 for newline
-			if (remainingChars < lineLength) {
-				return CharLineOffset(lineIndex, remainingChars)
-			}
-			remainingChars -= lineLength
+		val starts = workingContent.lineStartOffsets
+		val lineCount = textLines.size
+		if (index < 0) return CharLineOffset(0, index)
+		if (index >= starts[lineCount]) {
+			return CharLineOffset(textLines.lastIndex, textLines.last().length)
 		}
 
-		return CharLineOffset(
-			textLines.lastIndex,
-			textLines.last().length
-		)
+		val line = lineOfCharacter(starts, lineCount, index)
+		return CharLineOffset(line, index - starts[line])
+	}
+
+	/**
+	 * Index of the line containing flat character [index], by binary search over the
+	 * snapshot's line starts. [index] must be within the document.
+	 */
+	private fun lineOfCharacter(starts: IntArray, lineCount: Int, index: Int): Int {
+		var low = 0
+		var high = lineCount - 1
+		while (low < high) {
+			val mid = (low + high + 1) ushr 1
+			if (starts[mid] <= index) low = mid else high = mid - 1
+		}
+		return low
 	}
 
 	/**
@@ -861,36 +870,14 @@ class TextEditorState(
 			println("TextEditor warning: getCharacterIndex clamped $offset to $safe (textLines.size=${textLines.size})")
 		}
 
-		var totalChars = 0
-		for (lineIndex in 0 until safe.line) {
-			totalChars += textLines[lineIndex].length + 1
-		}
-		return totalChars + safe.char
+		return workingContent.lineStartOffsets[safe.line] + safe.char
 	}
 
-	fun CharLineOffset.toCharacterIndex(): Int {
-		var totalChars = 0
-		for (lineIndex in 0 until line) {
-			totalChars += textLines[lineIndex].length + 1  // +1 for newline
-		}
-		return totalChars + char
-	}
+	fun CharLineOffset.toCharacterIndex(): Int =
+		workingContent.lineStartOffsets[line] + char
 
 	// Convert character index to CharLineOffset
-	fun Int.toCharLineOffset(): CharLineOffset {
-		var remainingChars = this
-		for (lineIndex in textLines.indices) {
-			val lineLength = textLines[lineIndex].length + 1  // +1 for newline
-			if (remainingChars < lineLength) {
-				return CharLineOffset(lineIndex, remainingChars)
-			}
-			remainingChars -= lineLength
-		}
-		return CharLineOffset(
-			textLines.lastIndex,
-			textLines.last().length
-		)
-	}
+	fun Int.toCharLineOffset(): CharLineOffset = getOffsetAtCharacter(this)
 
 	fun wrapStartToCharacterIndex(lineWrap: LineWrap): Int {
 		// First get the physical line start offset
@@ -903,15 +890,7 @@ class TextEditorState(
 		require(lineIndex >= 0) { "Line index must be non-negative" }
 		require(lineIndex < textLines.size) { "Line index $lineIndex out of bounds for ${textLines.size} lines" }
 
-		var offset = 0
-		// Sum up lengths of all previous lines
-		for (i in 0 until lineIndex) {
-			offset += textLines[i].length
-			// Add 1 for the newline character at the end of each line
-			// except for the last line if it doesn't end with a newline
-			offset += 1
-		}
-		return offset
+		return workingContent.lineStartOffsets[lineIndex]
 	}
 
 	internal fun updateBookKeeping(affectedLines: IntRange? = null) {
@@ -1360,10 +1339,8 @@ class TextEditorState(
 
 	/** Returns the total character count of the document, counting newlines between lines. */
 	fun getTextLength(): Int {
-		val length = textLines.sumOf { line ->
-			line.length + 1
-		}
-		return length - 1
+		val starts = workingContent.lineStartOffsets
+		return starts[starts.lastIndex] - 1
 	}
 
 	/**


### PR DESCRIPTION
Frame-time work on the spell-check squiggle draw path. Every number below is measured, not estimated.

## The dominant cost was not the drawing

`drawRichSpans` called `toCharacterIndex` five times per span per visible line, every frame, and that function walked every preceding line summing lengths. At line 1800 of a 2000-line document one call cost **4.37us**. With 40 visible squiggles that is roughly **875us per frame** of pure index arithmetic, and it got worse the further down the document you scrolled.

`DocumentSnapshot` now memoizes an `IntArray` of line start offsets, following the `spansByStartLine` pattern already in that class. The snapshot is immutable so the array invalidates itself; `withRichSpans` carries it over (a span edit does not change line lengths) and `withLines` rebuilds it. `getCharacterIndex`, `toCharacterIndex`, `getLineStartOffset` and `getTextLength` become array reads, and `getOffsetAtCharacter` becomes a binary search.

**4372ns to 16ns per call, 273x.** This helps every rich span, the IME composing underline, and cursor math, not only the squiggles.

Also hoisted the per-wrap invariants out of the span loop in `drawRichSpans` (they describe the line, not the span) and added an early return for lines with no spans.

## The squiggle geometry

Benchmarked the candidates rather than assuming, and two intuitions were wrong:

| variant | us/frame (40 spans) |
| --- | --- |
| current | 964 |
| no Density/Stroke/Path allocation | 971 |
| cached Path per width | 869 |
| **quadratic Bezier (this PR)** | **745** |
| quad + cached path | 609 |

Removing the three `Density(density)` allocations per call bought nothing: the cost is entirely Skia stroke rasterization, and it tracks segment count. Batching every squiggle into one `drawPath` was only 16%, not worth reshaping the rich-span API.

So the wave is now one quadratic per half wave instead of six line segments: a third of the segments, about 23% faster, and smoother. I skipped the path cache despite its extra 14% because it needs a mutable `HashMap` on a shared `object` singleton, which risks concurrent corruption across editor windows and would need density in the key.

**Net for a 40-squiggle frame: roughly 1.84ms to 0.75ms of draw work**, with the index-math portion no longer scaling with document length.

## Verification

Old and new geometry rendered overlaid at 6x zoom: phase, wavelength and amplitude match exactly. The only difference is the tail, where the new wave clamps its final half-wave to the span end and returns to the baseline instead of stopping mid-swing.

Green: `ComposeTextEditor` desktopTest and testAndroidHostTest, `ComposeTextEditorSpellCheck` desktopTest, `ComposeTextEditorFind` desktopTest.

Two caveats worth a reviewer's attention:

- Verified through headless benchmarks, the test suite, and rendered geometry, **not** in the running app. Worth a look at the sample app before merge.
- Benchmarks are CPU raster on desktop. GPU-backed surfaces will differ in absolute terms, though the segment-count relationship holds.