### PR TITLE
Fix multi-line replace with inheritStyle dropping the replacement text

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
@@ -315,7 +315,7 @@ class TextEditManager(private val state: TextEditorState) {
 				buildAnnotatedStringWithSpans { addSpan ->
 					append(newText.text)
 					inheritedStyles.forEach { style ->
-						addSpan(style, 0, newText.lastIndex)
+						addSpan(style, 0, newText.length)
 					}
 				}.splitAnnotatedString()
 			} else {
@@ -336,12 +336,14 @@ class TextEditManager(private val state: TextEditorState) {
 				buildAnnotatedString {
 					append(prefix)
 					if (inheritStyle) {
-						buildAnnotatedStringWithSpans { addSpan ->
-							append(newText.text)
-							inheritedStyles.forEach { style ->
-								addSpan(style, 0, newText.lastIndex)
+						append(
+							buildAnnotatedStringWithSpans { addSpan ->
+								append(newText.text)
+								inheritedStyles.forEach { style ->
+									addSpan(style, 0, newText.length)
+								}
 							}
-						}
+						)
 					} else {
 						append(newText)
 					}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorFuzzE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorFuzzE2eTest.kt
@@ -32,7 +32,7 @@ class EditorFuzzE2eTest {
 		)
 
 		runFuzzScript(fuzzSeed(seed), script) { op ->
-			applyFuzzOpUi(op, skipDemotions = true, replaceOverSelection = false)
+			applyFuzzOpUi(op, skipDemotions = true)
 			checkCheapInvariants(state)
 		}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorStateFuzzTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorStateFuzzTest.kt
@@ -38,11 +38,7 @@ class EditorStateFuzzTest {
 			mutatingBudget = 80,
 			includeBlocks = false,
 		)
-		val interpreter = StateFuzzInterpreter(
-			state, markdown,
-			skipDemotions = true,
-			replaceOverSelection = false,
-		)
+		val interpreter = StateFuzzInterpreter(state, markdown, skipDemotions = true)
 
 		runFuzzScript(fuzzSeed(seed), script) { op ->
 			interpreter.apply(op)

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/MultiLineReplaceInheritTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/MultiLineReplaceInheritTest.kt
@@ -1,0 +1,108 @@
+package state
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * replace() with a multi-line range and inheritStyle used to drop the new text
+ * entirely: the styled string was built but never appended, leaving prefix+suffix.
+ * Undoing that broken replace then crashed captureMetadata with offsets pointing
+ * past the shrunken document.
+ */
+class MultiLineReplaceInheritTest {
+
+	private val bold = SpanStyle(fontWeight = FontWeight.Bold)
+
+	private fun editor(initial: AnnotatedString): TextEditorState =
+		TextEditorState(scope = TestScope(), measurer = mockk(relaxed = true), initialText = initial)
+
+	@Test
+	fun `multi line range with inherit keeps the replacement text`() {
+		val state = editor(AnnotatedString("abc\ndef"))
+
+		state.replace(
+			TextEditorRange(CharLineOffset(0, 1), CharLineOffset(1, 1)),
+			AnnotatedString("XX"),
+			inheritStyle = true,
+		)
+
+		assertEquals("aXXef", state.getAllText().text)
+	}
+
+	@Test
+	fun `whole document replace with inherit keeps the replacement text`() {
+		val state = editor(AnnotatedString("abc\ndef"))
+
+		state.replace(
+			TextEditorRange(CharLineOffset(0, 0), CharLineOffset(1, 3)),
+			AnnotatedString("XX"),
+			inheritStyle = true,
+		)
+
+		assertEquals("XX", state.getAllText().text)
+	}
+
+	@Test
+	fun `inherited style covers the whole replacement including the last character`() {
+		val state = editor(
+			AnnotatedString(
+				"abc\ndef",
+				spanStyles = listOf(AnnotatedString.Range(bold, 0, 3)),
+			)
+		)
+
+		state.replace(
+			TextEditorRange(CharLineOffset(0, 1), CharLineOffset(1, 1)),
+			AnnotatedString("XX"),
+			inheritStyle = true,
+		)
+
+		assertEquals("aXXef", state.getAllText().text)
+		val boldSpans = state.getAllText().spanStyles.filter { it.item.fontWeight == FontWeight.Bold }
+		assertTrue(
+			boldSpans.any { it.start <= 1 && it.end >= 3 },
+			"both inserted characters must inherit bold, got $boldSpans",
+		)
+	}
+
+	@Test
+	fun `multi line replacement text with inherit styles every line`() {
+		val state = editor(
+			AnnotatedString(
+				"abc\ndef",
+				spanStyles = listOf(AnnotatedString.Range(bold, 0, 3)),
+			)
+		)
+
+		state.replace(
+			TextEditorRange(CharLineOffset(0, 1), CharLineOffset(1, 1)),
+			AnnotatedString("X\nY"),
+			inheritStyle = true,
+		)
+
+		assertEquals("aX\nYef", state.getAllText().text)
+	}
+
+	@Test
+	fun `undo of a whole document inherit replace restores the original`() {
+		val state = editor(AnnotatedString("abc\ndef"))
+
+		state.replace(
+			TextEditorRange(CharLineOffset(0, 0), CharLineOffset(1, 3)),
+			AnnotatedString("XX"),
+			inheritStyle = true,
+		)
+		state.undo()
+
+		assertEquals("abc\ndef", state.getAllText().text)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
@@ -290,19 +290,11 @@ private fun trimmedStyleRange(text: String, rawA: Int, rawB: Int): Pair<Int, Int
 	return start to end
 }
 
-/**
- * Applies [op] directly to the state, the pure-state twin of [applyFuzzOpUi].
- *
- * With [replaceOverSelection] off, typing and pasting collapse any selection
- * instead of replacing through it: undoing a Replace can crash in
- * captureMetadata (see UndoReplayCrashTest), so the undo-to-origin scripts
- * avoid creating Replace history entries. Lift when that crash is fixed.
- */
+/** Applies [op] directly to the state, the pure-state twin of [applyFuzzOpUi]. */
 class StateFuzzInterpreter(
 	private val state: TextEditorState,
 	private val markdown: MarkdownExtension,
 	private val skipDemotions: Boolean,
-	private val replaceOverSelection: Boolean = true,
 ) {
 	private fun clampIndex(raw: Int): Int = raw % (state.getAllText().text.length + 1)
 
@@ -315,7 +307,7 @@ class StateFuzzInterpreter(
 	}
 
 	private fun typeOrReplace(text: String) {
-		if (!replaceOverSelection || selectionTouchesBlockLine(state, markdown)) {
+		if (selectionTouchesBlockLine(state, markdown)) {
 			collapseSelection()
 		}
 		val selection = state.selector.selection
@@ -407,18 +399,15 @@ class StateFuzzInterpreter(
 }
 
 /** Applies [op] through real key events and the clipboard, the UI twin of [StateFuzzInterpreter]. */
-fun EditorUiTestScope.applyFuzzOpUi(
-	op: FuzzOp,
-	skipDemotions: Boolean,
-	replaceOverSelection: Boolean = true,
-) {
+fun EditorUiTestScope.applyFuzzOpUi(op: FuzzOp, skipDemotions: Boolean) {
 	fun clampIndex(raw: Int): Int = raw % (text.length + 1)
 
 	// An unshifted arrow collapses the selection, sidestepping the replace-over-block
-	// rebase defect and the Replace-undo crash the same way the state interpreter does.
+	// rebase defect the same way the state interpreter does.
 	fun collapseSelectionIfGuarded() {
-		val guarded = !replaceOverSelection || selectionTouchesBlockLine(state, markdown)
-		if (guarded && state.selector.selection != null) press(Key.DirectionLeft)
+		if (selectionTouchesBlockLine(state, markdown) && state.selector.selection != null) {
+			press(Key.DirectionLeft)
+		}
 	}
 
 	when (op) {


### PR DESCRIPTION
Follow-on to #64, fixing the first fuzz-found crash from the torture-suite ledger.

## Root cause

`TextEditManager.handleMultiLineReplace` has an inherit-style arm for single-line replacement text that built the styled string with `buildAnnotatedStringWithSpans { ... }` and then discarded the result: it was never appended to the surrounding `buildAnnotatedString` builder. Any `replace()` over a multi-line range with `inheritStyle = true` therefore deleted the old text and inserted nothing (`"abc\ndef"` replaced by `"XX"` produced `"aef"`).

The crash was the cascade: `undoReplace` recomputes the replaced range arithmetically from `newText.length`, so undoing the broken replace addressed a range that was never inserted, and once positions drifted, a later undo's `captureMetadata` called `subSequence` past the end of a line (`StringIndexOutOfBoundsException`). Reachable in-product through the IME composing-region replace and any API consumer; found by `EditorStateFuzzTest` seed 42 and minimized to the 19-op `UndoReplayCrashTest` replay.

Both inherit arms also styled `0..newText.lastIndex`, silently dropping the inherited style from the last character; the sibling single-line path in `applyReplace` already used `length`. Fixed to match.

## Changes

- `TextEditManager.handleMultiLineReplace`: append the inherited-style string; `lastIndex` -> `length` in both arms.
- `state/MultiLineReplaceInheritTest`: 5 regression tests (text kept for partial/whole-document ranges, last-character style, multi-line replacement text, undo round trip).
- Fuzzers: the `replaceOverSelection` guard that stepped around this crash is removed; undo-to-origin scripts exercise Replace history entries again and stay green.

## Results

- `UndoReplayCrashTest` flips green.
- Full `desktopTest`: 868 tests, the same 18 intentional torture reds as before this fix, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)