### PR TITLE
Fix paragraph overlap crash when typing at a joined block boundary

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/utils/mergeAnnotatedStrings.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/utils/mergeAnnotatedStrings.kt
@@ -69,18 +69,33 @@ internal fun SpanManager.mergeAnnotatedStrings(
 	val insertedLen = newText?.length ?: 0
 	val deletedLen = (end - start).coerceAtLeast(0)
 	val finalLen = original.length - deletedLen + insertedLen
-	original.paragraphStyles.forEach { para ->
-		val newStart = adjustStartForEdit(para.start, start, end, insertedLen)
-		val newEnd = adjustEndForEdit(para.end, start, end, insertedLen)
-		if (newStart < newEnd && newEnd <= finalLen) {
-			addStyle(para.item, newStart, newEnd)
+	val adjusted = buildList {
+		original.paragraphStyles.forEach { para ->
+			val newStart = adjustStartForEdit(para.start, start, end, insertedLen)
+			val newEnd = adjustEndForEdit(para.end, start, end, insertedLen)
+			if (newStart < newEnd && newEnd <= finalLen) {
+				add(AnnotatedString.Range(para.item, newStart, newEnd))
+			}
+		}
+		newText?.paragraphStyles?.forEach { para ->
+			val newStart = (para.start + start).coerceAtMost(finalLen)
+			val newEnd = (para.end + start).coerceAtMost(finalLen)
+			if (newStart < newEnd) {
+				add(AnnotatedString.Range(para.item, newStart, newEnd))
+			}
 		}
 	}
-	newText?.paragraphStyles?.forEach { para ->
-		val newStart = (para.start + start).coerceAtMost(finalLen)
-		val newEnd = (para.end + start).coerceAtMost(finalLen)
-		if (newStart < newEnd) {
-			addStyle(para.item, newStart, newEnd)
+	// Two paragraphs that touch at the edit point both claim the inserted text
+	// (greedy end on the left, sticky start on the right), and AnnotatedString
+	// rejects overlapping paragraphs. The left paragraph wins — typing at a
+	// boundary stays in the paragraph the caret came from — and the right one
+	// is pushed to where the left ends.
+	var previousEnd = 0
+	adjusted.sortedBy { it.start }.forEach { para ->
+		val clampedStart = maxOf(para.start, previousEnd)
+		if (clampedStart < para.end) {
+			addStyle(para.item, clampedStart, para.end)
+			previousEnd = para.end
 		}
 	}
 }

--- a/ComposeTextEditor/src/desktopTest/kotlin/texteditmanager/ParagraphBoundaryMergeTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/texteditmanager/ParagraphBoundaryMergeTest.kt
@@ -1,0 +1,105 @@
+package texteditmanager
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.style.TextIndent
+import androidx.compose.ui.unit.sp
+import com.darkrockstudios.texteditor.state.SpanManager
+import com.darkrockstudios.texteditor.utils.mergeAnnotatedStrings
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * A line carrying two adjacent ParagraphStyles (the shape a cross-block line join
+ * produces) used to crash mergeAnnotatedStrings on the next insert at the shared
+ * boundary: both paragraphs claimed the inserted text and AnnotatedString rejects
+ * overlapping paragraphs.
+ */
+class ParagraphBoundaryMergeTest {
+	private val manager = SpanManager()
+
+	private val indentA = ParagraphStyle(textIndent = TextIndent(firstLine = 10.sp))
+	private val indentB = ParagraphStyle(textIndent = TextIndent(firstLine = 20.sp))
+
+	private fun twoParagraphLine(): AnnotatedString = AnnotatedString(
+		"abcdef",
+		spanStyles = emptyList(),
+		paragraphStyles = listOf(
+			AnnotatedString.Range(indentA, 0, 3),
+			AnnotatedString.Range(indentB, 3, 6),
+		),
+	)
+
+	@Test
+	fun `insert at the boundary between two paragraphs joins the left one`() {
+		val result = manager.mergeAnnotatedStrings(
+			original = twoParagraphLine(),
+			start = 3,
+			newText = AnnotatedString("XX"),
+		)
+
+		assertEquals("abcXXdef", result.text)
+		val paragraphs = result.paragraphStyles.sortedBy { it.start }
+		assertEquals(2, paragraphs.size)
+		assertEquals(indentA, paragraphs[0].item)
+		assertEquals(0, paragraphs[0].start)
+		assertEquals(5, paragraphs[0].end)
+		assertEquals(indentB, paragraphs[1].item)
+		assertEquals(5, paragraphs[1].start)
+		assertEquals(8, paragraphs[1].end)
+	}
+
+	@Test
+	fun `insert inside the left paragraph leaves the boundary alone`() {
+		val result = manager.mergeAnnotatedStrings(
+			original = twoParagraphLine(),
+			start = 1,
+			newText = AnnotatedString("XX"),
+		)
+
+		assertEquals("aXXbcdef", result.text)
+		val paragraphs = result.paragraphStyles.sortedBy { it.start }
+		assertEquals(2, paragraphs.size)
+		assertEquals(0, paragraphs[0].start)
+		assertEquals(5, paragraphs[0].end)
+		assertEquals(5, paragraphs[1].start)
+		assertEquals(8, paragraphs[1].end)
+	}
+
+	@Test
+	fun `delete spanning the boundary keeps both paragraphs disjoint`() {
+		val result = manager.mergeAnnotatedStrings(
+			original = twoParagraphLine(),
+			start = 2,
+			end = 4,
+		)
+
+		assertEquals("abef", result.text)
+		val paragraphs = result.paragraphStyles.sortedBy { it.start }
+		assertEquals(2, paragraphs.size)
+		assertEquals(0, paragraphs[0].start)
+		assertEquals(2, paragraphs[0].end)
+		assertEquals(2, paragraphs[1].start)
+		assertEquals(4, paragraphs[1].end)
+	}
+
+	@Test
+	fun `single paragraph insert at end still extends it`() {
+		val original = AnnotatedString(
+			"abc",
+			spanStyles = emptyList(),
+			paragraphStyles = listOf(AnnotatedString.Range(indentA, 0, 3)),
+		)
+
+		val result = manager.mergeAnnotatedStrings(
+			original = original,
+			start = 3,
+			newText = AnnotatedString("X"),
+		)
+
+		assertEquals("abcX", result.text)
+		assertEquals(1, result.paragraphStyles.size)
+		assertEquals(0, result.paragraphStyles[0].start)
+		assertEquals(4, result.paragraphStyles[0].end)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
@@ -207,10 +207,10 @@ private fun blockToggleTarget(
 
 /**
  * True when the live selection touches any block-styled line. Replacing across a
- * block line leaves spans out of bounds today (a known red-test defect, see
- * SpanConsistencyTortureTest `replacing across a quoted line keeps spans inside
- * the document`), so the fuzz interpreters collapse such selections before
- * typing instead of replacing through them. Lift when the rebase is fixed.
+ * block line can leave block spans past the line end (a known red-test defect,
+ * see the PasteOverSelectionTortureE2eTest reds), so the fuzz interpreters
+ * collapse such selections before typing instead of replacing through them.
+ * Lift when the handleReplace rebase is fixed.
  */
 private fun selectionTouchesBlockLine(state: TextEditorState, markdown: MarkdownExtension): Boolean {
 	val selection = state.selector.selection ?: return false
@@ -218,41 +218,6 @@ private fun selectionTouchesBlockLine(state: TextEditorState, markdown: Markdown
 		markdown.isBlockquote(line) || markdown.isBulletList(line) ||
 			markdown.isOrderedList(line) || markdown.isCodeFence(line)
 	}
-}
-
-/**
- * True when deleting the live selection would join lines across a block boundary.
- * That join can bake overlapping ParagraphStyles and crash the next insert (a
- * known red-test defect, see ParagraphOverlapCrashTest), so the fuzz interpreters
- * collapse such selections instead of deleting through them.
- */
-private fun selectionDeleteIsGuarded(state: TextEditorState, markdown: MarkdownExtension): Boolean {
-	val selection = state.selector.selection ?: return false
-	if (selection.start.line == selection.end.line) return false
-	return selectionTouchesBlockLine(state, markdown)
-}
-
-private fun blockSetOf(markdown: MarkdownExtension, line: Int): Set<String> = buildSet {
-	if (markdown.isBlockquote(line)) add("quote")
-	if (markdown.isBulletList(line)) add("bullet")
-	if (markdown.isOrderedList(line)) add("ordered")
-	if (markdown.isCodeFence(line)) add("fence")
-}
-
-/**
- * True when a forward delete at the cursor would join two lines with different
- * block styles. Unlike backspace, forward delete has no demote-first step, so the
- * join stacks both blocks onto one line (a known red-test defect, see
- * BlockBoundaryDeletionE2eTest); the fuzz interpreters skip those deletes.
- */
-private fun forwardJoinIsGuarded(state: TextEditorState, markdown: MarkdownExtension): Boolean {
-	val pos = state.cursorPosition
-	if (pos.char != state.textLines[pos.line].length) return false
-	val next = pos.line + 1
-	if (next >= state.textLines.size) return false
-	val current = blockSetOf(markdown, pos.line)
-	val below = blockSetOf(markdown, next)
-	return current != below && (current.isNotEmpty() || below.isNotEmpty())
 }
 
 /**
@@ -330,7 +295,6 @@ class StateFuzzInterpreter(
 			}
 
 			is FuzzOp.Backspace -> {
-				if (selectionDeleteIsGuarded(state, markdown)) collapseSelection()
 				if (skipDemotions && state.selector.selection == null &&
 					wouldDemote(state, markdown, enter = false)
 				) return
@@ -344,13 +308,11 @@ class StateFuzzInterpreter(
 			}
 
 			is FuzzOp.DeleteForward -> {
-				if (selectionDeleteIsGuarded(state, markdown)) collapseSelection()
 				val selection = state.selector.selection
 				if (selection != null) {
 					state.delete(selection)
 					state.selector.clearSelection()
 				} else {
-					if (forwardJoinIsGuarded(state, markdown)) return
 					state.deleteAtCursor()
 				}
 			}
@@ -422,18 +384,13 @@ fun EditorUiTestScope.applyFuzzOpUi(op: FuzzOp, skipDemotions: Boolean) {
 		}
 
 		is FuzzOp.Backspace -> {
-			if (selectionDeleteIsGuarded(state, markdown)) press(Key.DirectionLeft)
 			if (skipDemotions && state.selector.selection == null &&
 				wouldDemote(state, markdown, enter = false)
 			) return
 			press(Key.Backspace)
 		}
 
-		is FuzzOp.DeleteForward -> {
-			if (selectionDeleteIsGuarded(state, markdown)) press(Key.DirectionLeft)
-			if (state.selector.selection == null && forwardJoinIsGuarded(state, markdown)) return
-			press(Key.Delete)
-		}
+		is FuzzOp.DeleteForward -> press(Key.Delete)
 
 		is FuzzOp.MoveCursor -> when (op.slot % 8) {
 			0 -> press(Key.MoveHome, ctrl = true)


### PR DESCRIPTION
Follow-on to #64 and stacked on #66; fixes the second fuzz-found crash from the torture-suite ledger.

## Root cause

A delete that joins a code-fence line with another block-styled line produces a line carrying two *adjacent* `ParagraphStyle` ranges (the fence indent, then the neighbor's indent, touching at the join point). That line is valid on its own. The crash came on the next keystroke at that boundary: `mergeAnnotatedStrings` maps paragraph edges through the edit with deliberately greedy rules, so the left paragraph's end extended over the inserted text while the right paragraph's start stayed put. Both claimed the insertion, `addStyle` produced overlapping paragraphs, and the `AnnotatedString` constructor threw `Paragraph overlap not allowed`.

Found by `EditorStateFuzzTest` seed 987654321 and hand-shrunk to the 4-step `ParagraphOverlapCrashTest` repros (fence+bullet in either order: toggle, delete across the boundary, type one character).

## Change

`mergeAnnotatedStrings` collects the adjusted paragraph ranges and resolves conflicts deterministically before adding them: paragraphs are laid out in start order, and each start is clamped to the previous paragraph's end. Typing at a shared boundary therefore stays in the paragraph the caret came from (left wins) and the right paragraph begins where the left ends. The greedy edge behavior is unchanged everywhere a single paragraph is involved.

Note this fixes the crash, not the upstream oddity that cross-block joins stack two block styles on one line; that remains red in `BlockBoundaryDeletionE2eTest` and is a separate semantics decision.

## Tests

- `ParagraphOverlapCrashTest` (2) flips green.
- New `texteditmanager/ParagraphBoundaryMergeTest` (4): insert at the shared boundary, insert inside the left paragraph, delete spanning the boundary, single-paragraph end-extend.
- Fuzz vocabulary guards for this crash (`selectionDeleteIsGuarded`, `forwardJoinIsGuarded`) are removed; multi-line selection deletes and cross-block forward-delete joins run unguarded and all seeds stay green.
- Full `desktopTest`: 872 tests, 16 intentional torture reds (all pre-existing ledger entries), no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)