### PR TITLE
Fix rich span rebasing through replace, undo restore, and duplicate merges

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
@@ -3,6 +3,7 @@ package com.darkrockstudios.texteditor.state
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.LineWrap
 import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.richstyle.BlockSpanStyle
 import com.darkrockstudios.texteditor.richstyle.RichSpan
 import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
 
@@ -34,6 +35,43 @@ class RichSpanManager(
 
 	internal fun addRichSpan(range: TextEditorRange, style: RichSpanStyle) {
 		spans = spans + RichSpan(range, style)
+	}
+
+	/**
+	 * Adds a span whose range was computed against an earlier revision of the
+	 * document, coerced onto the lines that exist now. Undo restoration and rich
+	 * paste replay recorded offsets; the document they land in may have shifted.
+	 */
+	internal fun addRichSpanClamped(range: TextEditorRange, style: RichSpanStyle) {
+		val clamped = clampRangeToDocument(range) ?: return
+		if (clamped.start == clamped.end && !style.rendersWhenEmpty) return
+		spans = spans + RichSpan(clamped, style)
+	}
+
+	// Sticky gutter markers render on empty lines, and placeholder blocks (rules,
+	// images) own their whole line no matter how wide its text is.
+	private val RichSpanStyle.rendersWhenEmpty: Boolean
+		get() = stickyAtStart || this is BlockSpanStyle
+
+	/**
+	 * Coerces [range] onto lines and columns that exist right now, or null when the
+	 * document has no lines at all. Zero-width results are the caller's decision:
+	 * sticky gutter markers render on empty lines, other styles do not.
+	 */
+	private fun clampRangeToDocument(range: TextEditorRange): TextEditorRange? {
+		val lastLine = state.textLines.lastIndex
+		if (lastLine < 0) return null
+		val startLine = range.start.line.coerceIn(0, lastLine)
+		val endLine = range.end.line.coerceIn(startLine, lastLine)
+		val startChar = range.start.char.coerceIn(0, state.textLines[startLine].length)
+		val endChar = range.end.char.coerceIn(
+			if (startLine == endLine) startChar else 0,
+			state.textLines[endLine].length,
+		)
+		return TextEditorRange(
+			CharLineOffset(startLine, startChar),
+			CharLineOffset(endLine, endChar),
+		)
 	}
 
 	internal fun addRichSpan(start: CharLineOffset, end: CharLineOffset, style: RichSpanStyle) {
@@ -85,8 +123,24 @@ class RichSpanManager(
 			}
 		}
 
-		spans = mergeLineAnchoredDuplicates(updatedSpans)
+		spans = clampAllToDocument(mergeLineAnchoredDuplicates(updatedSpans))
 	}
+
+	/**
+	 * Coerces every transformed span onto the already-mutated document. Handler
+	 * arithmetic near line joins can land a hair past a shortened line; a span
+	 * shrunk to nothing dies unless its sticky marker renders on empty lines.
+	 */
+	private fun clampAllToDocument(updatedSpans: Set<RichSpan>): Set<RichSpan> =
+		updatedSpans.mapNotNullTo(mutableSetOf()) { span ->
+			clampRangeToDocument(span.range)?.let { clamped ->
+				if (clamped.start == clamped.end && !span.style.rendersWhenEmpty) {
+					null
+				} else {
+					span.copy(range = clamped)
+				}
+			}
+		}
 
 	/**
 	 * Collapses any same-line duplicates of line-anchored (sticky-at-start) styles
@@ -97,17 +151,19 @@ class RichSpanManager(
 	 */
 	private fun mergeLineAnchoredDuplicates(spans: Set<RichSpan>): Set<RichSpan> {
 		val (anchored, others) = spans.partition { it.style.stickyAtStart }
+		val positionOrder = compareBy<CharLineOffset>({ it.line }, { it.char })
 		val merged = anchored
 			.groupBy { it.style to it.range.start.line }
 			.map { (key, group) ->
 				if (group.size == 1) group.first() else {
-					val (style, line) = key
+					// The union must respect multi-line members: collapsing everything
+					// onto the start line invents columns past that line's end.
 					RichSpan(
 						range = TextEditorRange(
-							start = CharLineOffset(line, group.minOf { it.range.start.char }),
-							end = CharLineOffset(line, group.maxOf { it.range.end.char }),
+							start = group.minOfWith(positionOrder) { it.range.start },
+							end = group.maxOfWith(positionOrder) { it.range.end },
 						),
-						style = style,
+						style = key.first,
 					)
 				}
 			}
@@ -267,7 +323,6 @@ class RichSpanManager(
 						(span.range.end.line == operation.range.end.line &&
 								span.range.end.char > operation.range.end.char)
 					) {
-						// Create spanning span
 						updatedSpans.add(
 							span.copy(
 								range = TextEditorRange(
@@ -284,29 +339,44 @@ class RichSpanManager(
 					} else {
 						// Span ends within replacement - truncate at replacement start
 						updatedSpans.add(
-							span.copy(
-								range = TextEditorRange(
-									span.range.start,
-									operation.range.start
-								)
-							)
+							span.copy(range = TextEditorRange(span.range.start, operation.range.start))
 						)
 					}
 				} else if (span.range.end.line > operation.range.end.line ||
 					(span.range.end.line == operation.range.end.line &&
 							span.range.end.char > operation.range.end.char)
 				) {
-					// Span starts within replacement but ends after - preserve end portion
+					// Span starts within replacement but ends after - preserve the end
+					// portion. A line-anchored marker re-anchors to the start of the
+					// line its tail survives on; without the sticky start, replacing a
+					// selection that begins at the item start detaches the gutter marker.
+					val newStart = if (span.style.stickyAtStart) {
+						CharLineOffset(newEnd.line, 0)
+					} else {
+						newEnd
+					}
 					updatedSpans.add(
 						span.copy(
 							range = TextEditorRange(
-								newEnd,
+								newStart,
 								CharLineOffset(
 									newEnd.line + (span.range.end.line - operation.range.end.line),
 									if (span.range.end.line == operation.range.end.line)
 										newEnd.char + (span.range.end.char - operation.range.end.char)
 									else span.range.end.char
 								)
+							)
+						)
+					)
+				} else if (span.style.stickyAtStart && operation.range.isSingleLine()) {
+					// A line-anchored marker whose text is replaced within its own line
+					// survives: that is editing the item, not deleting it. A multi-line
+					// replacement removed the marker's line, so the marker goes with it.
+					updatedSpans.add(
+						span.copy(
+							range = TextEditorRange(
+								CharLineOffset(operation.range.start.line, 0),
+								newEnd,
 							)
 						)
 					)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditManager.kt
@@ -846,8 +846,12 @@ class TextEditManager(private val state: TextEditorState) {
 			)
 
 			// Bypass the history-recording path: this restoration is itself part of
-			// an undo/redo and must not push a new edit onto the queue.
-			state.richSpanManager.addRichSpan(startPos, endPos, preserved.style)
+			// an undo/redo and must not push a new edit onto the queue. The recorded
+			// offsets predate the undo's text mutation, so land them clamped.
+			state.richSpanManager.addRichSpanClamped(
+				TextEditorRange(startPos, endPos),
+				preserved.style,
+			)
 		}
 	}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
@@ -206,21 +206,6 @@ private fun blockToggleTarget(
 }
 
 /**
- * True when the live selection touches any block-styled line. Replacing across a
- * block line can leave block spans past the line end (a known red-test defect,
- * see the PasteOverSelectionTortureE2eTest reds), so the fuzz interpreters
- * collapse such selections before typing instead of replacing through them.
- * Lift when the handleReplace rebase is fixed.
- */
-private fun selectionTouchesBlockLine(state: TextEditorState, markdown: MarkdownExtension): Boolean {
-	val selection = state.selector.selection ?: return false
-	return selection.affectedLines().any { line ->
-		markdown.isBlockquote(line) || markdown.isBulletList(line) ||
-			markdown.isOrderedList(line) || markdown.isCodeFence(line)
-	}
-}
-
-/**
  * True when a Backspace at the current cursor, or an Enter on the current line,
  * would trigger the smart block demotion. Demotions bypass undo history (a known
  * red-test defect), so the undo-to-origin fuzz scripts step around them.
@@ -265,16 +250,7 @@ class StateFuzzInterpreter(
 
 	private fun offset(raw: Int): CharLineOffset = state.getOffsetAtCharacter(clampIndex(raw))
 
-	private fun collapseSelection() {
-		val start = state.selector.selection?.start
-		state.selector.clearSelection()
-		start?.let { state.cursor.updatePosition(it) }
-	}
-
 	private fun typeOrReplace(text: String) {
-		if (selectionTouchesBlockLine(state, markdown)) {
-			collapseSelection()
-		}
 		val selection = state.selector.selection
 		if (selection != null) {
 			state.replace(selection, AnnotatedString(text), inheritStyle = true)
@@ -364,19 +340,8 @@ class StateFuzzInterpreter(
 fun EditorUiTestScope.applyFuzzOpUi(op: FuzzOp, skipDemotions: Boolean) {
 	fun clampIndex(raw: Int): Int = raw % (text.length + 1)
 
-	// An unshifted arrow collapses the selection, sidestepping the replace-over-block
-	// rebase defect the same way the state interpreter does.
-	fun collapseSelectionIfGuarded() {
-		if (selectionTouchesBlockLine(state, markdown) && state.selector.selection != null) {
-			press(Key.DirectionLeft)
-		}
-	}
-
 	when (op) {
-		is FuzzOp.TypeText -> {
-			collapseSelectionIfGuarded()
-			typeText(op.text)
-		}
+		is FuzzOp.TypeText -> typeText(op.text)
 
 		is FuzzOp.Enter -> {
 			if (skipDemotions && wouldDemote(state, markdown, enter = true)) return
@@ -429,7 +394,6 @@ fun EditorUiTestScope.applyFuzzOpUi(op: FuzzOp, skipDemotions: Boolean) {
 		}
 
 		is FuzzOp.PastePlain -> {
-			collapseSelectionIfGuarded()
 			setPlainClipboardText(op.text)
 			press(Key.V, ctrl = true)
 		}
@@ -440,7 +404,6 @@ fun EditorUiTestScope.applyFuzzOpUi(op: FuzzOp, skipDemotions: Boolean) {
 
 		is FuzzOp.SelectAllType -> {
 			press(Key.A, ctrl = true)
-			collapseSelectionIfGuarded()
 			typeText(op.text)
 		}
 	}


### PR DESCRIPTION
Follow-on to #64, stacked on #67; addresses the `handleReplace` span-rebase family from the torture-suite ledger.

## Defects fixed

**`handleReplace` ignored `stickyAtStart`.** Pasting over a selection that starts exactly at a list item's start shifted the gutter marker's span off column 0 (`paste over a selection anchored at the item start keeps the bullet anchored` was red at `start.char = 2`). And a marker whose text was wholly inside the replaced range was dropped, so replacing an item's text deleted the item. Line-anchored spans now re-anchor to the start of the line their content survives on: the tail-preserving branch anchors at `(newEnd.line, 0)`, and a marker fully covered by a single-line replacement survives re-anchored across the new text. Markers whose *line* is consumed by a multi-line replacement still die with the line.

**`mergeLineAnchoredDuplicates` flattened multi-line spans.** The sticky-duplicate union built its result on the group's start line using raw max column, so a multi-line fence span merged with a single-line one produced ranges like `(0,0)-(0,69)` on a 48-char line. Found by fuzz seed 42 as an out-of-bounds span surfacing mid-undo-burst. The union now compares `(line, char)` positions properly.

**Nothing bounded republished spans.** `updateSpans` now clamps every span it publishes onto the already-mutated document (merge first, clamp last), and `restorePreservedRichSpans` — which re-adds spans at offsets recorded before the undo's text mutation — lands them through a new `addRichSpanClamped`. Zero-width results survive for sticky markers *and* placeholder blocks (`BlockSpanStyle`), both of which render independent of the line's text width; the plain `addRichSpan` path is untouched because the #57 normalization machinery treats deliberately out-of-range placeholder adds as its input signal (`PlaceholderLineBlockTest`).

## Test results

- Flips green: `paste over a selection anchored at the item start keeps the bullet anchored`, `EditorStateFuzzTest markdown fixpoint seed 42`.
- The fuzz interpreters' replace-over-block-selection guard is removed; typing and pasting now replace through block-line selections in all seeds.
- `typing over a fully selected bulleted item keeps the bullet` stays red: the UI character-input path is `deleteSelection()` + insert, not Replace, so that defect belongs to the delete-path family (empty-item marker drops) and its ledger entry moves there.
- Full `desktopTest`: 872 tests, 15 intentional torture reds (all pre-existing ledger entries), no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)