### PR TITLE
Stop addStyleSpan bridging the character between two same-style runs

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/SpanManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/SpanManager.kt
@@ -227,7 +227,10 @@ class SpanManager {
 
 		for (i in 1 until spanRanges.size) {
 			val (nextStart, nextEnd) = spanRanges[i]
-			if (nextStart <= currentEnd + 1) {
+			// Adjacency means touching (nextStart == currentEnd), matching
+			// SpanInfo.isAdjacent on the edit path; `+ 1` here would swallow the
+			// unstyled character sitting between two same-style runs.
+			if (nextStart <= currentEnd) {
 				// Ranges overlap or are adjacent, extend current range
 				currentEnd = maxOf(currentEnd, nextEnd)
 			} else {


### PR DESCRIPTION
Follow-on to #64, stacked on #68. Smallest entry in the torture ledger.

`SpanManager.mergeOverlaps` (the `addStyleSpan` path) merged same-style ranges when `nextStart <= currentEnd + 1`, which fuses two bold runs separated by a single unstyled character and silently bolds that character: with bold on `[0,3)` and `[4,7)` of `"abcdefgh"`, bolding `[7,8)` produced one span `[0,8)`. The edit path (`SpanInfo.isAdjacent`) already used exact adjacency, with a comment explaining why `+1` is wrong; the two passes now agree.

- Flips green: `SpanConsistencyTortureTest addStyleSpan does not bridge unrelated same style runs across a one char gap`.
- Full `desktopTest`: 872 tests, 14 intentional torture reds, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)