### PR TITLE
Shrink emphasis markers onto text when a styled run has edge whitespace

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/annotatedStringToMarkdown.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/annotatedStringToMarkdown.kt
@@ -44,9 +44,19 @@ fun AnnotatedString.toMarkdown(
 		var runStart = ranges.first().first
 		var runEnd = ranges.first().last + 1
 		fun emit() {
-			val length = runEnd - runStart
-			boundaries.add(StyleBoundary(runStart, true, marker, length))
-			boundaries.add(StyleBoundary(runEnd, false, marker, length))
+			var start = runStart
+			var end = runEnd
+			// CommonMark emphasis cannot open before or close after whitespace:
+			// "**word **" is literal asterisks to any parser, and re-importing it
+			// escalates into escaped garbage. Shrink the markers onto the text.
+			if (marker.trimsWhitespaceEdges) {
+				while (start < end && text[start].isWhitespace()) start++
+				while (end > start && text[end - 1].isWhitespace()) end--
+			}
+			if (start >= end) return
+			val length = end - start
+			boundaries.add(StyleBoundary(start, true, marker, length))
+			boundaries.add(StyleBoundary(end, false, marker, length))
 		}
 		for (i in 1 until ranges.size) {
 			val nextStart = ranges[i].first
@@ -167,5 +177,9 @@ private fun SpanStyle.matches(other: SpanStyle): Boolean {
 private data class StyleMarkerPair(
 	val openMarker: String,
 	val closeMarker: String
-)
+) {
+	/** Emphasis delimiters; code spans and headers tolerate edge whitespace. */
+	val trimsWhitespaceEdges: Boolean
+		get() = openMarker == "**" || openMarker == "*" || openMarker == "~~"
+}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/MarkdownRoundTripTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/MarkdownRoundTripTortureE2eTest.kt
@@ -167,6 +167,28 @@ class MarkdownRoundTripTortureE2eTest {
 	}
 
 	@Test
+	fun `bold overlapping an inline code span round trips`() = editorUiTest {
+		markdown.importMarkdown("`code` tail")
+		state.addStyleSpan(
+			com.darkrockstudios.texteditor.TextEditorRange(
+				state.getOffsetAtCharacter(2),
+				state.getOffsetAtCharacter(8),
+			),
+			SpanStyle(fontWeight = FontWeight.Bold),
+		)
+
+		// Emphasis markers are emitted positionally, so a bold run overlapping a
+		// code span opens inside the backticks; the parser reads literal asterisks
+		// and the following export escapes them.
+		val first = markdown.exportAsMarkdown()
+		markdown.importMarkdown(first)
+		val second = markdown.exportAsMarkdown()
+
+		assertEquals(first, second)
+		assertEquals("code tail", text, "no emphasis markers may leak into the text")
+	}
+
+	@Test
 	fun `empty list items round trip stably`() = editorUiTest {
 		markdown.importMarkdown("- a\n- \n- b")
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/MarkdownConverterTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/MarkdownConverterTest.kt
@@ -175,7 +175,9 @@ class MarkdownConverterTest {
 				append(" and universe")
 			}
 		}
-		assertEquals("**Hello *beautiful *world*** and universe*", input.toMarkdown())
+		// The italic ranges carry an edge space; the emphasis markers shrink onto the
+		// text because delimiters touching whitespace are not emphasis in CommonMark.
+		assertEquals("**Hello *beautiful* world** *and universe*", input.toMarkdown())
 	}
 
 	@Test

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
@@ -68,10 +68,10 @@ private fun FuzzOp.historyCost(): Int = when (this) {
  * restore, unrecorded demotions); those stay covered by the hand-written tests.
  *
  * [includeBold] excludes character styling. The fixpoint scripts need this
- * because any typing near a bold edge can grow the span onto a space, and
- * emphasis with edge spaces exports as invalid markdown (a known red-test
- * defect, see MarkdownRoundTripTortureE2eTest `a bold run ending in a space
- * round trips`). Lift both when the underlying defects are fixed.
+ * because edits can land bold onto fence-baked monospace, and emphasis
+ * overlapping a code span opens its markers inside the backticks (a known
+ * red-test defect, see MarkdownRoundTripTortureE2eTest `bold overlapping an
+ * inline code span round trips`). Lift both when the underlying defects are fixed.
  */
 fun generateFuzzScript(
 	seed: Long,
@@ -224,9 +224,7 @@ private fun wouldDemote(state: TextEditorState, markdown: MarkdownExtension, ent
 
 /**
  * Trims edge spaces off a candidate style range and rejects multi-line or empty
- * results. Emphasis wrapped around an edge space exports as invalid markdown (a
- * known red-test defect, see MarkdownRoundTripTortureE2eTest `a bold run ending
- * in a space round trips`), so the fuzzers only bold clean single-line ranges.
+ * results, so the fuzzers only bold clean single-line ranges.
  */
 private fun trimmedStyleRange(text: String, rawA: Int, rawB: Int): Pair<Int, Int>? {
 	val clampedA = rawA % (text.length + 1)


### PR DESCRIPTION
Follow-on to #64, stacked on #69. Fixes the fuzz-found invalid-emphasis export from the torture ledger.

## Defect

`AnnotatedString.toMarkdown` wrapped emphasis markers around the raw span range. A bold span whose text ends (or starts) with a space exported as `**word **`, which CommonMark defines as *not* emphasis, so the next import kept the asterisks as literal text and the export after that escaped them (`\*\*word \*\*`): silent, escalating corruption on every save/reload cycle. Any typing near a bold edge can grow the span onto a space, so this was reachable from ordinary editing.

## Change

When emitting boundaries, emphasis runs (`**`, `*`, `~~`) shrink onto their first and last non-whitespace characters; whitespace-only runs emit no markers. Code spans and headers tolerate edge whitespace and are unchanged. The styling difference is unobservable (whitespace renders identically styled or not) and the output is now valid CommonMark that round-trips.

`MarkdownConverterTest > test overlapping styles are properly nested` previously pinned the invalid form (`*beautiful *world***`) and now asserts the valid equivalent.

## New defect discovered (pinned red, not fixed here)

Lifting the fuzzers' bold exclusion surfaced the next layer: emphasis markers are emitted positionally, so a bold run overlapping an inline code span opens `**` *inside* the backticks, corrupting the same way. Pinned by the new red `MarkdownRoundTripTortureE2eTest > bold overlapping an inline code span round trips`; the fixpoint fuzz keeps bold excluded until it's fixed (the undo-to-origin fuzz exercises bold fully).

## Results

- Flips green: `a bold run ending in a space round trips`.
- Full `desktopTest`: 873 tests, 14 intentional torture reds (one of them the newly pinned code-span defect), no other changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)