### PR TITLE
Record smart block demotions in undo history

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -423,8 +423,9 @@ class TextEditorState(
 		// Enter on an empty bullet/quote item exits the block — drop the gutter
 		// marker and indent, eat the keystroke. Matches Notion / Google Docs and
 		// gives a discoverable way to leave a list or quote without backspacing.
+		// Routed through the toggle so the demotion lands in undo history.
 		if (lineText.isEmpty() && activeBlock != null) {
-			demoteLineBlock(originalLine, activeBlock)
+			editManager.toggleLineBlock(originalLine..originalLine, activeBlock)
 			return
 		}
 
@@ -468,7 +469,11 @@ class TextEditorState(
 			if (activeBlock != null) {
 				val prevBlock = detectLineBlock(cursorPosition.line - 1)
 				if (prevBlock != activeBlock) {
-					demoteLineBlock(cursorPosition.line, activeBlock)
+					// Routed through the toggle so the demotion lands in undo history.
+					editManager.toggleLineBlock(
+						cursorPosition.line..cursorPosition.line,
+						activeBlock,
+					)
 					return
 				}
 			}


### PR DESCRIPTION
Follow-on to #64, stacked on #70.

## Defect

The smart demotions — Backspace at column 0 of a list/quote item, and Enter on an empty item — called `demoteLineBlock`, which rewrites the line and its spans directly without recording anything. The demotion was silently permanent: Ctrl+Z did not restore the marker and instead undid whatever edit preceded it. Both torture reds asserted the marker comes back on undo.

## Change

Both smart paths now route through `TextEditManager.toggleLineBlock` over the single line. The line already carries the block, so the toggle takes its demote branch (identical semantics, same single-block priority as before) and records the change as an atomic `TextEditOperation.LineBlock`, exactly like a toolbar toggle.

## Results

- Flips green: `a smart backspace demotion is undoable`, `a smart enter exit from a list is undoable`.
- Full `desktopTest`: 873 tests, 12 intentional torture reds, no new failures. (`enter on an empty list item exits the list` flapped red in one full-suite run; it is the ledger's known nondeterministic test and passes consistently in isolation, unchanged by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)