### PR TITLE
Give cross-block line joins deterministic single-identity semantics

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
@@ -400,6 +400,28 @@ class RichSpanManager(
 			return
 		}
 
+		fun addTransformed(newStart: CharLineOffset, newEnd: CharLineOffset) {
+			val lineAnchored = span.style.stickyAtStart || span.style is BlockSpanStyle
+			if (lineAnchored && newStart.char != 0) {
+				// The marker was pulled off column 0: its line was consumed by a join.
+				// It survives only onto a receiving line that is already the same kind
+				// of item (rejoining split halves); otherwise the receiving line keeps
+				// its own identity and the marker dies with its line.
+				val receivingLineHasSameStyle = spans.any { other ->
+					other.style == span.style &&
+						other.range.start.line == newStart.line &&
+						other.range.start.char == 0
+				}
+				if (!receivingLineHasSameStyle) return
+			}
+			if (newStart == newEnd) {
+				// Emptied within its own line, an item survives as an empty item; a
+				// marker consumed by a multi-line delete goes with its deleted line.
+				if (!span.style.rendersWhenEmpty || !operation.range.isSingleLine()) return
+			}
+			updatedSpans.add(span.copy(range = TextEditorRange(newStart, newEnd)))
+		}
+
 		if (metadata.deletedText?.text == "\n") {
 			// A pure newline delete joins two lines: nothing on the first line moves,
 			// the second line's content slides onto the join point, and everything
@@ -417,27 +439,13 @@ class RichSpanManager(
 				else -> CharLineOffset(offset.line - 1, offset.char)
 			}
 
-			updatedSpans.add(
-				span.copy(
-					range = TextEditorRange(
-						start = joinOffset(start),
-						end = joinOffset(end)
-					)
-				)
-			)
+			addTransformed(joinOffset(start), joinOffset(end))
 		} else {
 			// Regular delete operation
-			val newStart = operation.transformOffset(start, state)
-			val newEnd = operation.transformOffset(end, state)
-			if (newStart != newEnd) {
-				updatedSpans.add(
-					span.copy(
-						range = TextEditorRange(
-							start = newStart, end = newEnd
-						)
-					)
-				)
-			}
+			addTransformed(
+				operation.transformOffset(start, state),
+				operation.transformOffset(end, state),
+			)
 		}
 	}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockBoundaryDeletionE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockBoundaryDeletionE2eTest.kt
@@ -8,7 +8,6 @@ import utils.assertRichSpanInvariants
 import utils.blockFlags
 import utils.editorUiTest
 import utils.linesWith
-import utils.markdown
 import utils.selectChars
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockToggleTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockToggleTortureE2eTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.text.AnnotatedString
 import utils.assertBlockState
 import utils.assertRichSpanInvariants
 import utils.editorUiTest
-import utils.markdown
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -226,8 +225,6 @@ class BlockToggleTortureE2eTest {
 
 		press(Key.Z, ctrl = true)
 
-		// demoteLineBlock mutates the line directly without recording a history
-		// entry, so the marker a user removed by accident cannot come back.
 		assertEquals(listOf("plain", "item"), lines, "undo must not fall through to an older edit")
 		assertBlockState(1, bullet = true)
 	}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorFuzzE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorFuzzE2eTest.kt
@@ -6,7 +6,6 @@ import utils.checkCheapInvariants
 import utils.editorUiTest
 import utils.fuzzSeed
 import utils.generateFuzzScript
-import utils.markdown
 import utils.runFuzzScript
 import utils.snapshotOf
 import utils.undoAll

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/MarkdownRoundTripTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/MarkdownRoundTripTortureE2eTest.kt
@@ -8,7 +8,6 @@ import com.darkrockstudios.texteditor.richstyle.HorizontalRuleSpanStyle
 import utils.blockFlags
 import utils.editorUiTest
 import utils.linesWith
-import utils.markdown
 import utils.pasteHtml
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/PasteOverSelectionTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/PasteOverSelectionTortureE2eTest.kt
@@ -9,7 +9,6 @@ import utils.assertRichSpanInvariants
 import utils.blockFlags
 import utils.editorUiTest
 import utils.linesWith
-import utils.markdown
 import utils.pasteHtml
 import utils.selectChars
 import kotlin.test.Test

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoStormE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoStormE2eTest.kt
@@ -11,7 +11,6 @@ import com.darkrockstudios.texteditor.richstyle.RichSpan
 import utils.assertBlockState
 import utils.assertRichSpanInvariants
 import utils.editorUiTest
-import utils.markdown
 import utils.selectChars
 import utils.undoAll
 import kotlin.test.Test

--- a/ComposeTextEditor/src/desktopTest/kotlin/texteditmanager/undo/RichSpanSurvivalTests.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/texteditmanager/undo/RichSpanSurvivalTests.kt
@@ -92,8 +92,10 @@ class RichSpanSurvivalTests {
 		state.redo()
 
 		assertEquals("", state.textLines[1].text)
+		// Deleting all of an item's text within its own line empties the item but
+		// does not remove it; the marker stays on the now-empty line.
 		val lines = state.richSpanManager.getAllRichSpans().map { it.range.start.line }
-		assertEquals(listOf(0, 2), lines.sorted())
+		assertEquals(listOf(0, 1, 2), lines.sorted())
 	}
 
 	@Test

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
@@ -25,6 +25,8 @@ import com.darkrockstudios.texteditor.input.CtrlKeyBindings
 import com.darkrockstudios.texteditor.input.KeyBindings
 import com.darkrockstudios.texteditor.input.LocalKeyBindings
 import com.darkrockstudios.texteditor.input.MacKeyBindings
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.markdown.withMarkdown
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.rememberTextEditorState
 
@@ -68,6 +70,13 @@ internal fun editorUiTest(
 		}
 	}
 	waitForIdle()
+	// Key events are replayed against the scene's focused node; under a loaded
+	// JVM the autoFocus request can land after the first replayed keystrokes,
+	// which are then silently dropped. Don't hand control to the test until the
+	// editor actually holds focus.
+	if (enabled) {
+		waitUntil(timeoutMillis = 5_000) { state.isFocused }
+	}
 	EditorUiTestScope(this, state, clipboard).block()
 }
 
@@ -77,6 +86,14 @@ class EditorUiTestScope(
 	val state: TextEditorState,
 	val clipboard: InMemoryClipboard,
 ) {
+	/**
+	 * Markdown extension for this editor, created on first use. Deliberately a
+	 * per-scope member: TextEditorState hashes by document content, so caching
+	 * extensions in any shared hash-keyed map hands a test another test's editor
+	 * whenever two documents happen to hold equal text.
+	 */
+	val markdown: MarkdownExtension by lazy { state.withMarkdown() }
+
 	/** Plain text of the whole document. */
 	val text: String get() = state.getAllText().text
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/TortureHelpers.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/TortureHelpers.kt
@@ -4,21 +4,12 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.ClipEntry
 import com.darkrockstudios.texteditor.TextEditorRange
-import com.darkrockstudios.texteditor.markdown.MarkdownExtension
-import com.darkrockstudios.texteditor.markdown.withMarkdown
 import com.darkrockstudios.texteditor.richstyle.RichSpan
 import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.getRichSpansInRange
-import java.util.WeakHashMap
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-
-private val markdownExtensions = WeakHashMap<TextEditorState, MarkdownExtension>()
-
-/** Markdown extension for this editor's state, created once per test. */
-val EditorUiTestScope.markdown: MarkdownExtension
-	get() = markdownExtensions.getOrPut(state) { state.withMarkdown() }
 
 /** Pastes [html] the way a foreign application would: a text/html clipboard flavor, then Ctrl+V. */
 @OptIn(ExperimentalComposeUiApi::class)


### PR DESCRIPTION
Follow-on to #64, stacked on #71. Closes out the cross-block join family from the torture ledger, and root-causes the suite's flapping tests.

## Join semantics

`RichSpanManager.handleDelete` transformed spans positionally, so deletes that joined lines produced invalid documents: a quote-to-fence join left one line carrying both styles (fence stacks with nothing by the editor's own rules), forward-deleting the newline before a bulleted line dragged the bullet onto the plain receiving line (opposite of backspace's demote-first behavior), and deleting a one-char item's character killed the marker even though empty items render markers by design.

Two rules now govern the transform:

1. **A line-anchored marker pulled off column 0 died with its line.** The receiving line keeps its own identity — unless it is already the same kind of item, in which case the marker survives and the duplicate-union rejoins split halves (this carve-out is what keeps undo-of-a-split working and same-style list merges seamless).
2. **A marker emptied within its own line survives as an empty item**; a marker consumed by a multi-line delete goes with its deleted line. `RichSpanSurvivalTests`' redo expectation updates to this contract (emptying an item's text no longer removes the item, matching Docs/Notion).

Flips green: all five `BlockBoundaryDeletionE2eTest` reds (join stacking, forward-delete identity, cross-block undo restore, one-char item, word delete) plus `typing over a fully selected bulleted item keeps the bullet` (the UI character path is deleteSelection + insert, so it was this family, not replace).

## The flapping tests, root-caused

Two torture tests flapped red/green only in multi-class runs. Diagnosis: `TextEditorState` overrides `equals`/`hashCode` **by document content**. The test harness cached `MarkdownExtension`s in a shared `WeakHashMap<TextEditorState, _>`; a state cached while holding text and later emptied corrupts its hash bucket (mutated key), and a later test's fresh empty-document state could then look up the *previous test's dead editor* and mutate it instead of its own — dependent on map resize history, hence the flapping. The extension is now a per-scope lazy member and the harness additionally waits for focus before replaying keystrokes.

Worth an upstream look: content-based `equals`/`hashCode` on a mutable editor state makes it unusable as a hash key and is an easy trap for host apps (e.g. `remember` keys, caches). Verified: 6 consecutive runs of the previously-flapping pair and 2 full-suite runs, all deterministic.

## Results

Full `desktopTest`: 873 tests, exactly 5 intentional torture reds remaining, stable across repeated runs: bold-over-code-span export, header config demotion, foreign-paste span resurrection, partial-copy marker leak, and the 100-entry history cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)