### PR TITLE
Split emphasis runs around code spans on markdown export

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/annotatedStringToMarkdown.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/annotatedStringToMarkdown.kt
@@ -38,14 +38,45 @@ fun AnnotatedString.toMarkdown(
 
 	// Coalesce touching/overlapping same-marker ranges into one run, so fragmented
 	// spans emit a single marker pair: **E****n****d** -> **End**.
+	fun coalesceRuns(ranges: List<IntRange>): List<Pair<Int, Int>> {
+		val sorted = ranges.sortedBy { it.first }
+		val runs = mutableListOf<Pair<Int, Int>>()
+		var runStart = sorted.first().first
+		var runEnd = sorted.first().last + 1
+		for (i in 1 until sorted.size) {
+			val nextStart = sorted[i].first
+			val nextEnd = sorted[i].last + 1
+			if (nextStart <= runEnd) {
+				// Touching or overlapping — extend the current run.
+				if (nextEnd > runEnd) runEnd = nextEnd
+			} else {
+				runs.add(runStart to runEnd)
+				runStart = nextStart
+				runEnd = nextEnd
+			}
+		}
+		runs.add(runStart to runEnd)
+		return runs
+	}
+
+	val codeRuns = rangesByMarker.entries
+		.firstOrNull { it.key.openMarker == "`" }
+		?.let { coalesceRuns(it.value) }
+		?: emptyList()
+
 	val boundaries = mutableListOf<StyleBoundary>()
 	rangesByMarker.forEach { (marker, ranges) ->
-		ranges.sortBy { it.first }
-		var runStart = ranges.first().first
-		var runEnd = ranges.first().last + 1
-		fun emit() {
-			var start = runStart
-			var end = runEnd
+		var runs = coalesceRuns(ranges)
+		if (marker.trimsWhitespaceEdges) {
+			// CommonMark code spans take their content literally, so an emphasis run
+			// crossing one would open its markers inside the backticks and corrupt on
+			// the next import. The run splits around code spans; markdown cannot
+			// express styled code, so the overlap itself is unrepresentable anyway.
+			runs = runs.flatMap { run -> subtractRuns(run, codeRuns) }
+		}
+		runs.forEach { (rawStart, rawEnd) ->
+			var start = rawStart
+			var end = rawEnd
 			// CommonMark emphasis cannot open before or close after whitespace:
 			// "**word **" is literal asterisks to any parser, and re-importing it
 			// escalates into escaped garbage. Shrink the markers onto the text.
@@ -53,24 +84,11 @@ fun AnnotatedString.toMarkdown(
 				while (start < end && text[start].isWhitespace()) start++
 				while (end > start && text[end - 1].isWhitespace()) end--
 			}
-			if (start >= end) return
+			if (start >= end) return@forEach
 			val length = end - start
 			boundaries.add(StyleBoundary(start, true, marker, length))
 			boundaries.add(StyleBoundary(end, false, marker, length))
 		}
-		for (i in 1 until ranges.size) {
-			val nextStart = ranges[i].first
-			val nextEnd = ranges[i].last + 1
-			if (nextStart <= runEnd) {
-				// Touching or overlapping — extend the current run.
-				if (nextEnd > runEnd) runEnd = nextEnd
-			} else {
-				emit()
-				runStart = nextStart
-				runEnd = nextEnd
-			}
-		}
-		emit()
 	}
 
 	// Sort boundaries:
@@ -135,6 +153,26 @@ fun AnnotatedString.toMarkdown(
 	}
 
 	return escapeOrderedListMarkers(result.toString())
+}
+
+/** Splits [run] into the segments left after removing every overlap with [holes]. */
+private fun subtractRuns(
+	run: Pair<Int, Int>,
+	holes: List<Pair<Int, Int>>,
+): List<Pair<Int, Int>> {
+	var segments = listOf(run)
+	holes.forEach { (holeStart, holeEnd) ->
+		segments = segments.flatMap { (start, end) ->
+			when {
+				holeEnd <= start || holeStart >= end -> listOf(start to end)
+				else -> buildList {
+					if (start < holeStart) add(start to holeStart)
+					if (holeEnd < end) add(holeEnd to end)
+				}
+			}
+		}
+	}
+	return segments
 }
 
 private fun getStyleMarker(

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorFuzzE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorFuzzE2eTest.kt
@@ -45,7 +45,7 @@ class EditorFuzzE2eTest {
 
 	private fun markdownFixpoint(seed: Long) = editorUiTest {
 		markdown.importMarkdown("seed line\n- item\n> quoted")
-		val script = generateFuzzScript(seed = fuzzSeed(seed), count = 60, includeBold = false)
+		val script = generateFuzzScript(seed = fuzzSeed(seed), count = 60)
 
 		runFuzzScript(fuzzSeed(seed), script) { op ->
 			applyFuzzOpUi(op, skipDemotions = false)

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorStateFuzzTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorStateFuzzTest.kt
@@ -56,7 +56,7 @@ class EditorStateFuzzTest {
 
 	private fun markdownFixpoint(seed: Long) {
 		val (state, markdown) = editor("seed line\n- item\n> quoted")
-		val script = generateFuzzScript(seed = fuzzSeed(seed), count = 250, includeBold = false)
+		val script = generateFuzzScript(seed = fuzzSeed(seed), count = 250)
 		val interpreter = StateFuzzInterpreter(state, markdown, skipDemotions = false)
 
 		runFuzzScript(fuzzSeed(seed), script) { op ->

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
@@ -65,20 +65,13 @@ private fun FuzzOp.historyCost(): Int = when (this) {
  *
  * [includeBlocks] excludes block toggles from the vocabulary. The undo-to-origin
  * scripts need this because block undo has known red-test defects (cross-block
- * restore, unrecorded demotions); those stay covered by the hand-written tests.
- *
- * [includeBold] excludes character styling. The fixpoint scripts need this
- * because edits can land bold onto fence-baked monospace, and emphasis
- * overlapping a code span opens its markers inside the backticks (a known
- * red-test defect, see MarkdownRoundTripTortureE2eTest `bold overlapping an
- * inline code span round trips`). Lift both when the underlying defects are fixed.
+ * restore); those stay covered by the hand-written tests.
  */
 fun generateFuzzScript(
 	seed: Long,
 	count: Int,
 	mutatingBudget: Int = Int.MAX_VALUE,
 	includeBlocks: Boolean = true,
-	includeBold: Boolean = true,
 ): List<FuzzOp> {
 	val random = Random(seed)
 	var budget = mutatingBudget
@@ -86,9 +79,6 @@ fun generateFuzzScript(
 	while (script.size < count) {
 		var op = randomOp(random)
 		if (!includeBlocks && op is FuzzOp.ToggleBlock) {
-			op = FuzzOp.TypeText(WORDS.random(random))
-		}
-		if (!includeBold && op is FuzzOp.ToggleBold) {
 			op = FuzzOp.TypeText(WORDS.random(random))
 		}
 		if (op.isMutating()) {


### PR DESCRIPTION
Follow-on to #64, stacked on #72. Fixes the bold-over-code-span export corruption pinned in #70.

## Defect

`toMarkdown` emitted style markers purely positionally. A bold span overlapping an inline code span (trivially reachable: fence lines bake monospace, so bolding text that touches a fence does it) produced `` `**text`** `` — emphasis opening inside the backticks. Code spans take their content literally, so the next import kept the asterisks as text and the export after that escaped them: the same escalating save/reload corruption family as the edge-space bug.

## Change

Emphasis runs (`**`, `*`, `~~`) subtract the coalesced code-span ranges before boundary emission and emit one marker pair per surviving segment: bold covering `pre `code` post` exports as `**pre** `code` **post**`. The styling lost on the overlap itself is unrepresentable in markdown either way, and the output now round-trips. Code spans, headers, and links are unchanged.

## Results

- Flips green: `bold overlapping an inline code span round trips`.
- The fixpoint fuzzers run with bold fully enabled again (the `includeBold` vocabulary exclusion is deleted); all committed seeds green in both harnesses.
- Full `desktopTest`: 873 tests, 4 intentional torture reds remaining, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)