### PR TITLE
Copy line markers only when the copy covers the whole span

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -1196,6 +1196,15 @@ class TextEditorState(
 		// offset and a corrupt span on paste, so clamp each span to the copy range
 		// and drop any that collapse to empty/inverted.
 		val preserved = richSpanManager.getSpansInRange(range).mapNotNull { span ->
+			// A line marker or placeholder block belongs to its line, not to the
+			// characters copied out of it: a fragment of an item's text pastes as
+			// plain text, only a copy covering the whole span carries the marker.
+			val lineAnchored = span.style.stickyAtStart || span.style is BlockSpanStyle
+			if (lineAnchored &&
+				(span.range.start < range.start || span.range.end > range.end)
+			) {
+				return@mapNotNull null
+			}
 			val clampedStart = maxOf(span.range.start, range.start)
 			val clampedEnd = minOf(span.range.end, range.end)
 			if (clampedStart >= clampedEnd) return@mapNotNull null


### PR DESCRIPTION
Follow-on to #64, stacked on #73. Fixes the partial-copy marker leak from the torture ledger.

## Defect

`copyRichSpans` clamps overlapping spans into the rich-span buffer, which is right for character-level styles but wrong for line-anchored markers: copying two characters out of `- item` captured a clamped fragment of the bullet span, and pasting into the middle of a quote line re-applied that fragment there, leaving a line that reports as both quote and bullet — the stacked-marker shape the join fixes just eliminated, reachable again through the clipboard.

## Change

A line-anchored marker or placeholder block belongs to its line, not to the characters copied out of it. `copyRichSpans` now carries those styles only when the copied range covers the whole span (matching Docs: copying an item's full line brings the bullet, copying a fragment brings text). Non-anchored styles keep the existing clamping.

## Results

- Flips green: `a partial copy of a list item pastes as plain text`.
- Whole-line copy behavior is unchanged (`re-copying a pasted list inside the editor keeps the bullets` and the select-all copy tests stay green).
- Full `desktopTest`: 873 tests, 3 intentional torture reds remaining, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)