### PR TITLE
Coalesce typing into wordwise undo entries and raise the history cap to 1000

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditHistory.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditHistory.kt
@@ -5,7 +5,7 @@ import com.darkrockstudios.texteditor.richstyle.RichSpan
 import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
 
 // History manager for undo/redo support
-class TextEditHistory(private val maxHistorySize: Int = 100) {
+class TextEditHistory(private val maxHistorySize: Int = 1000) {
 	private val undoQueue = ArrayDeque<HistoryEntry>(maxHistorySize)
 	private val redoQueue = ArrayDeque<HistoryEntry>(maxHistorySize)
 
@@ -13,11 +13,116 @@ class TextEditHistory(private val maxHistorySize: Int = 100) {
 	fun hasRedoLevels(): Boolean = redoQueue.isNotEmpty()
 
 	fun recordEdit(operation: TextEditOperation, metadata: OperationMetadata) {
-		if (undoQueue.size >= maxHistorySize) {
-			undoQueue.removeFirstOrNull()
+		val merged = coalesceWithLast(operation, metadata)
+		if (merged != null) {
+			undoQueue.removeLast()
+			undoQueue.addLast(merged)
+		} else {
+			if (undoQueue.size >= maxHistorySize) {
+				undoQueue.removeFirstOrNull()
+			}
+			undoQueue.addLast(HistoryEntry(operation, metadata, operation.isSingleTypedChar(metadata)))
 		}
-		undoQueue.addLast(HistoryEntry(operation, metadata))
 		redoQueue.clear() // Clear redo queue when new edit is made
+	}
+
+	/**
+	 * Merges a single typed or backspaced character into the typing run it
+	 * continues, so undo works in words rather than keystrokes. A run never
+	 * crosses a line break, a gap in position, or the start of a new word, and
+	 * never grows out of a multi-character operation like a paste.
+	 */
+	private fun coalesceWithLast(
+		operation: TextEditOperation,
+		metadata: OperationMetadata,
+	): HistoryEntry? {
+		val last = undoQueue.lastOrNull() ?: return null
+		if (!last.typingRun) return null
+		return when {
+			operation is TextEditOperation.Insert && last.operation is TextEditOperation.Insert ->
+				coalesceInsert(last, last.operation, operation)
+
+			operation is TextEditOperation.Delete && last.operation is TextEditOperation.Delete ->
+				coalesceDelete(last, last.operation, operation, metadata)
+
+			else -> null
+		}
+	}
+
+	private fun coalesceInsert(
+		last: HistoryEntry,
+		previous: TextEditOperation.Insert,
+		operation: TextEditOperation.Insert,
+	): HistoryEntry? {
+		val newChar = operation.text.text.singleOrNull() ?: return null
+		if (newChar == '\n') return null
+		if (operation.position.line != previous.position.line) return null
+		if (operation.position.char != previous.position.char + previous.text.length) return null
+		// A new word starts a new entry: the run ended in whitespace and the new
+		// character begins the next word, so undo peels one word at a time.
+		val runLast = previous.text.text.last()
+		if (runLast.isWhitespace() && !newChar.isWhitespace()) return null
+		return HistoryEntry(
+			operation = TextEditOperation.Insert(
+				position = previous.position,
+				text = previous.text + operation.text,
+				cursorBefore = previous.cursorBefore,
+				cursorAfter = operation.cursorAfter,
+			),
+			metadata = last.metadata,
+			typingRun = true,
+		)
+	}
+
+	private fun coalesceDelete(
+		last: HistoryEntry,
+		previous: TextEditOperation.Delete,
+		operation: TextEditOperation.Delete,
+		metadata: OperationMetadata,
+	): HistoryEntry? {
+		val newText = metadata.deletedText ?: return null
+		val newChar = newText.text.singleOrNull() ?: return null
+		if (newChar == '\n') return null
+		if (!operation.range.isSingleLine() || !previous.range.isSingleLine()) return null
+		// Span bookkeeping is anchored to each operation's own range and does not
+		// concatenate; a run that touched spans stays un-merged.
+		if (metadata.preservedRichSpans.isNotEmpty() || metadata.deletedSpans.isNotEmpty()) return null
+		if (last.metadata.preservedRichSpans.isNotEmpty() || last.metadata.deletedSpans.isNotEmpty()) return null
+		val runText = last.metadata.deletedText ?: return null
+
+		val backward = operation.range.end == previous.range.start
+		val forward = operation.range.start == previous.range.start
+		if (!backward && !forward) return null
+		// Breaking on the whitespace/word transition keeps deletion runs wordwise.
+		val runEdge = if (backward) runText.text.first() else runText.text.last()
+		if (newChar.isWhitespace() != runEdge.isWhitespace()) return null
+
+		val mergedRange = if (backward) {
+			previous.range.copy(start = operation.range.start)
+		} else {
+			previous.range.copy(
+				end = previous.range.end.copy(char = previous.range.end.char + 1),
+			)
+		}
+		val mergedText = if (backward) newText + runText else runText + newText
+		return HistoryEntry(
+			operation = TextEditOperation.Delete(
+				range = mergedRange,
+				cursorBefore = previous.cursorBefore,
+				cursorAfter = operation.cursorAfter,
+			),
+			metadata = OperationMetadata(deletedText = mergedText),
+			typingRun = true,
+		)
+	}
+
+	private fun TextEditOperation.isSingleTypedChar(metadata: OperationMetadata): Boolean = when (this) {
+		is TextEditOperation.Insert -> text.text.singleOrNull()?.let { it != '\n' } == true
+		is TextEditOperation.Delete ->
+			metadata.deletedText?.text?.singleOrNull()?.let { it != '\n' } == true &&
+				metadata.preservedRichSpans.isEmpty() && metadata.deletedSpans.isEmpty()
+
+		else -> false
 	}
 
 	fun undo(): HistoryEntry? {
@@ -58,5 +163,7 @@ data class OperationMetadata(
 
 data class HistoryEntry(
 	val operation: TextEditOperation,
-	val metadata: OperationMetadata
+	val metadata: OperationMetadata,
+	/** True for entries built from single typed/backspaced characters, which may coalesce. */
+	val typingRun: Boolean = false,
 )

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoStormE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoStormE2eTest.kt
@@ -61,9 +61,20 @@ class UndoStormE2eTest {
 
 		undoAll()
 
-		// The history silently caps at 100 entries; the 101st keystroke pushes the
-		// first edit off the stack and this document can never be fully restored.
+		// Typing coalesces into wordwise history entries, so a keystroke count far
+		// beyond the old per-keystroke cap still undoes back to the origin.
 		assertEquals("seed", text)
+	}
+
+	@Test
+	fun `undo removes the last word not the last letter`() = editorUiTest {
+		typeText("alpha beta")
+
+		press(Key.Z, ctrl = true)
+		assertEquals("alpha ", text)
+
+		press(Key.Z, ctrl = true)
+		assertEquals("", text)
 	}
 
 	@Test

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoStormE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoStormE2eTest.kt
@@ -78,6 +78,73 @@ class UndoStormE2eTest {
 	}
 
 	@Test
+	fun `redo restores a whole coalesced word`() = editorUiTest {
+		typeText("alpha beta")
+
+		press(Key.Z, ctrl = true)
+		assertEquals("alpha ", text)
+
+		press(Key.Y, ctrl = true)
+		assertEquals("alpha beta", text)
+		assertEquals(10, cursorIndex, "the caret lands at the end of the redone word")
+	}
+
+	@Test
+	fun `undo restores a backspaced word in one step`() = editorUiTest(
+		initialText = AnnotatedString("alpha beta"),
+	) {
+		press(Key.MoveEnd)
+		repeat(4) { press(Key.Backspace) }
+		assertEquals("alpha ", text)
+
+		press(Key.Z, ctrl = true)
+
+		assertEquals("alpha beta", text)
+	}
+
+	@Test
+	fun `undo separates typing from the paste it followed`() = editorUiTest {
+		setPlainClipboardText("pasted")
+		press(Key.V, ctrl = true)
+		typeText("x")
+
+		press(Key.Z, ctrl = true)
+		assertEquals("pasted", text, "the typed character undoes without the paste")
+
+		press(Key.Z, ctrl = true)
+		assertEquals("", text)
+	}
+
+	@Test
+	fun `enter breaks a typing run into separate undo steps`() = editorUiTest {
+		typeText("ab\ncd")
+
+		press(Key.Z, ctrl = true)
+		assertEquals(listOf("ab", ""), lines)
+
+		press(Key.Z, ctrl = true)
+		assertEquals(listOf("ab"), lines)
+
+		press(Key.Z, ctrl = true)
+		assertEquals("", text)
+	}
+
+	@Test
+	fun `clicking elsewhere breaks the typing run`() = editorUiTest(
+		initialText = AnnotatedString("stub "),
+	) {
+		press(Key.MoveEnd)
+		typeText("tail")
+		clickAtCharacter(0)
+		typeText("x")
+		assertEquals("xstub tail", text)
+
+		press(Key.Z, ctrl = true)
+
+		assertEquals("stub tail", text, "only the character typed after the click undoes")
+	}
+
+	@Test
 	fun `alternating type and undo leaves a bold span untouched`() = editorUiTest(
 		initialText = AnnotatedString("bold word"),
 	) {

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/TypingCoalescenceTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/TypingCoalescenceTest.kt
@@ -1,0 +1,203 @@
+package state
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Undo granularity contracts: consecutive typed characters coalesce into
+ * wordwise history entries, and everything that must NOT coalesce stays its
+ * own entry (newlines, pastes, moved cursors, span-touching deletes).
+ */
+class TypingCoalescenceTest {
+
+	private fun editor(initial: String = ""): TextEditorState =
+		TextEditorState(
+			scope = TestScope(),
+			measurer = mockk(relaxed = true),
+			initialText = AnnotatedString(initial),
+		)
+
+	private fun TextEditorState.typeChars(text: String) {
+		text.forEach { insertCharacterAtCursor(it) }
+	}
+
+	private fun TextEditorState.undoCount(max: Int = 50): Int {
+		var count = 0
+		while (count < max) {
+			val before = getAllText().text
+			undo()
+			if (getAllText().text == before) break
+			count++
+		}
+		return count
+	}
+
+	@Test
+	fun `typing a word is one undo step`() {
+		val state = editor()
+		state.typeChars("hello")
+
+		state.undo()
+
+		assertEquals("", state.getAllText().text)
+	}
+
+	@Test
+	fun `undo peels one word at a time`() {
+		val state = editor()
+		state.typeChars("hello world")
+
+		state.undo()
+		assertEquals("hello ", state.getAllText().text, "the trailing space belongs to the first word's run")
+
+		state.undo()
+		assertEquals("", state.getAllText().text)
+	}
+
+	@Test
+	fun `redo restores a whole coalesced word`() {
+		val state = editor()
+		state.typeChars("hello world")
+
+		state.undo()
+		state.redo()
+
+		assertEquals("hello world", state.getAllText().text)
+	}
+
+	@Test
+	fun `enter never joins a typing run`() {
+		val state = editor()
+		state.typeChars("ab")
+		state.insertNewlineAtCursor()
+		state.typeChars("cd")
+
+		state.undo()
+		assertEquals("ab\n", state.getAllText().text)
+
+		state.undo()
+		assertEquals("ab", state.getAllText().text)
+
+		state.undo()
+		assertEquals("", state.getAllText().text)
+	}
+
+	@Test
+	fun `typing after a cursor move is a separate step`() {
+		val state = editor()
+		state.typeChars("abc")
+		state.cursor.updatePosition(CharLineOffset(0, 0))
+		state.typeChars("x")
+
+		state.undo()
+
+		assertEquals("abc", state.getAllText().text, "only the character typed after the move is undone")
+	}
+
+	@Test
+	fun `typed characters do not merge into a paste`() {
+		val state = editor()
+		state.insertStringAtCursor("pasted")
+		state.typeChars("x")
+
+		state.undo()
+
+		assertEquals("pasted", state.getAllText().text, "the paste is its own undo step")
+	}
+
+	@Test
+	fun `backspacing a word is one undo step`() {
+		val state = editor("hello world")
+		state.cursor.updatePosition(CharLineOffset(0, 11))
+		repeat(5) { state.backspaceAtCursor() }
+		assertEquals("hello ", state.getAllText().text)
+
+		state.undo()
+
+		assertEquals("hello world", state.getAllText().text)
+	}
+
+	@Test
+	fun `backspace runs break at the whitespace transition`() {
+		val state = editor("hello world")
+		state.cursor.updatePosition(CharLineOffset(0, 11))
+		repeat(6) { state.backspaceAtCursor() }
+		assertEquals("hello", state.getAllText().text)
+
+		state.undo()
+		assertEquals("hello ", state.getAllText().text, "the space is its own run")
+
+		state.undo()
+		assertEquals("hello world", state.getAllText().text)
+	}
+
+	@Test
+	fun `forward deletes coalesce at a fixed position`() {
+		val state = editor("word tail")
+		state.cursor.updatePosition(CharLineOffset(0, 0))
+		repeat(4) { state.deleteAtCursor() }
+		assertEquals(" tail", state.getAllText().text)
+
+		state.undo()
+
+		assertEquals("word tail", state.getAllText().text)
+	}
+
+	@Test
+	fun `deleting styled text does not coalesce past its spans`() {
+		val state = editor()
+		state.setText(
+			AnnotatedString(
+				"bold",
+				spanStyles = listOf(
+					AnnotatedString.Range(SpanStyle(fontWeight = FontWeight.Bold), 0, 4),
+				),
+			)
+		)
+		state.addRichSpan(0, 4, com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle(
+			androidx.compose.ui.graphics.Color.Yellow,
+		))
+		state.cursor.updatePosition(CharLineOffset(0, 4))
+		repeat(4) { state.backspaceAtCursor() }
+
+		// Each of these deletes carried span metadata, so none may have coalesced:
+		// four undos must restore the text and the highlight exactly.
+		repeat(4) { state.undo() }
+
+		assertEquals("bold", state.getAllText().text)
+		assertTrue(
+			state.richSpanManager.getAllRichSpans().isNotEmpty(),
+			"the highlight must survive undoing the deletion run",
+		)
+	}
+
+	@Test
+	fun `a long typing burst stays within a handful of entries`() {
+		val state = editor()
+		state.typeChars("the quick brown fox jumps over the lazy dog and keeps going")
+
+		val undos = state.undoCount()
+
+		assertEquals("", state.getAllText().text)
+		assertTrue(undos <= 13, "12 words plus punctuation runs must not need $undos undos")
+	}
+
+	@Test
+	fun `101 characters of typing survive undo all the way back`() {
+		val state = editor("seed")
+		state.cursor.updatePosition(CharLineOffset(0, 4))
+		state.typeChars("y".repeat(101))
+
+		state.undoCount()
+
+		assertEquals("seed", state.getAllText().text)
+	}
+}


### PR DESCRIPTION
Follow-on to #64, stacked on #74. Resolves the history-cap entry from the torture ledger the way mainstream editors do.

## Problem

Every keystroke recorded its own history entry against a 100-entry cap. Effective undo depth was ~100 keystrokes — well under a minute of writing — and the tail fell off silently. Within the window, undoing a sentence took one Ctrl+Z per character.

## Change

`TextEditHistory.recordEdit` now coalesces:

- **Typing**: consecutive single-character inserts merge into one entry while they continue the same run — same line, exactly adjacent, and not starting a new word (a run ending in whitespace does not absorb the next word's first letter, so undo peels wordwise, trailing space included, Docs-style). Newlines never merge; multi-character inserts (paste) neither merge nor get absorbed — entries carry a `typingRun` flag so runs only grow out of typed characters.
- **Deleting**: single-character deletes merge both backward (backspace) and forward (delete at a fixed position), breaking at whitespace transitions. A delete whose metadata carries preserved or deleted spans never coalesces, so span restoration on undo keeps its per-operation anchoring.
- **No time rules.** Coalescing is a pure function of the operation sequence — deterministic under test and fuzzing.

The cap rises from 100 to 1000 entries. Memory-wise the heavy entries were never keystrokes but large delete/replace metadata, which coalescing doesn't touch.

## Tests

- New `state/TypingCoalescenceTest` (12): wordwise undo/redo, newline and paste isolation, cursor-move breaks, backward/forward delete runs, whitespace-transition breaks, span-carrying deletes staying un-merged, long-burst entry counts, and 101 characters undoing back to origin.
- New e2e: `undo removes the last word not the last letter`.
- Flips green: `101 edits then undoAll restores the initial document` (the last mechanical torture red).
- Undo-to-origin fuzzers pass unchanged in both harnesses — coalescing preserves exact restoration.
- Full `desktopTest`: 886 tests; the only remaining reds are the two awaiting design decisions (semantic headers, clipboard ownership).

Behavior note for review: undo granularity visibly changes from per-character to per-word. That is the point, but it is the one user-facing behavior change in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)