### PR TITLE
Lift the fuzz vocabulary guards whose defects are fixed

### DIFF
--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorFuzzE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorFuzzE2eTest.kt
@@ -27,11 +27,10 @@ class EditorFuzzE2eTest {
 			seed = fuzzSeed(seed),
 			count = 60,
 			mutatingBudget = 80,
-			includeBlocks = false,
 		)
 
 		runFuzzScript(fuzzSeed(seed), script) { op ->
-			applyFuzzOpUi(op, skipDemotions = true)
+			applyFuzzOpUi(op)
 			checkCheapInvariants(state)
 		}
 
@@ -48,7 +47,7 @@ class EditorFuzzE2eTest {
 		val script = generateFuzzScript(seed = fuzzSeed(seed), count = 60)
 
 		runFuzzScript(fuzzSeed(seed), script) { op ->
-			applyFuzzOpUi(op, skipDemotions = false)
+			applyFuzzOpUi(op)
 			checkCheapInvariants(state)
 		}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorStateFuzzTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/EditorStateFuzzTest.kt
@@ -36,9 +36,8 @@ class EditorStateFuzzTest {
 			seed = fuzzSeed(seed),
 			count = 250,
 			mutatingBudget = 80,
-			includeBlocks = false,
 		)
-		val interpreter = StateFuzzInterpreter(state, markdown, skipDemotions = true)
+		val interpreter = StateFuzzInterpreter(state, markdown)
 
 		runFuzzScript(fuzzSeed(seed), script) { op ->
 			interpreter.apply(op)
@@ -57,7 +56,7 @@ class EditorStateFuzzTest {
 	private fun markdownFixpoint(seed: Long) {
 		val (state, markdown) = editor("seed line\n- item\n> quoted")
 		val script = generateFuzzScript(seed = fuzzSeed(seed), count = 250)
-		val interpreter = StateFuzzInterpreter(state, markdown, skipDemotions = false)
+		val interpreter = StateFuzzInterpreter(state, markdown)
 
 		runFuzzScript(fuzzSeed(seed), script) { op ->
 			interpreter.apply(op)

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoReplayCrashTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/UndoReplayCrashTest.kt
@@ -22,7 +22,7 @@ class UndoReplayCrashTest {
 		val state = TextEditorState(scope = TestScope(), measurer = mockk(relaxed = true))
 		val markdown = MarkdownExtension(state)
 		markdown.importMarkdown("seed line\nsecond line")
-		val interpreter = StateFuzzInterpreter(state, markdown, skipDemotions = true)
+		val interpreter = StateFuzzInterpreter(state, markdown)
 
 		val script = listOf(
 			FuzzOp.SelectAllType("日本"),

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/FuzzScript.kt
@@ -62,25 +62,17 @@ private fun FuzzOp.historyCost(): Int = when (this) {
  * (per keystroke, see [historyCost]) reach [mutatingBudget], which keeps a whole
  * script inside the 100-entry undo cap so the undo-to-origin invariant is honest;
  * the rest are navigation and undo/redo.
- *
- * [includeBlocks] excludes block toggles from the vocabulary. The undo-to-origin
- * scripts need this because block undo has known red-test defects (cross-block
- * restore); those stay covered by the hand-written tests.
  */
 fun generateFuzzScript(
 	seed: Long,
 	count: Int,
 	mutatingBudget: Int = Int.MAX_VALUE,
-	includeBlocks: Boolean = true,
 ): List<FuzzOp> {
 	val random = Random(seed)
 	var budget = mutatingBudget
 	val script = mutableListOf<FuzzOp>()
 	while (script.size < count) {
-		var op = randomOp(random)
-		if (!includeBlocks && op is FuzzOp.ToggleBlock) {
-			op = FuzzOp.TypeText(WORDS.random(random))
-		}
+		val op = randomOp(random)
 		if (op.isMutating()) {
 			val cost = op.historyCost()
 			if (cost > budget) {
@@ -184,32 +176,8 @@ private fun blockToggleTarget(
 	val lineCount = state.textLines.size
 	val start = op.lineSeed % lineCount
 	val range = start..minOf(start + op.extent, lineCount - 1)
-	val (name, toggle) = BLOCK_TOGGLES[op.styleIndex % BLOCK_TOGGLES.size]
-	// D3-shaped documents (quote stacked on a list) corrupt on round trip today, so
-	// the fuzzers refuse to create them. Lift this guard when D2-D4 are fixed.
-	val wouldStack = when (name) {
-		"quote" -> range.any { markdown.isBulletList(it) || markdown.isOrderedList(it) }
-		"bullet", "ordered" -> range.any { markdown.isBlockquote(it) }
-		else -> false
-	}
-	return if (wouldStack) null else range to toggle
-}
-
-/**
- * True when a Backspace at the current cursor, or an Enter on the current line,
- * would trigger the smart block demotion. Demotions bypass undo history (a known
- * red-test defect), so the undo-to-origin fuzz scripts step around them.
- */
-private fun wouldDemote(state: TextEditorState, markdown: MarkdownExtension, enter: Boolean): Boolean {
-	val line = state.cursorPosition.line
-	val hasBlock = markdown.isBlockquote(line) || markdown.isBulletList(line) ||
-		markdown.isOrderedList(line) || markdown.isCodeFence(line)
-	if (!hasBlock) return false
-	return if (enter) {
-		state.textLines[line].text.isEmpty()
-	} else {
-		state.cursorPosition.char == 0
-	}
+	val (_, toggle) = BLOCK_TOGGLES[op.styleIndex % BLOCK_TOGGLES.size]
+	return range to toggle
 }
 
 /**
@@ -232,7 +200,6 @@ private fun trimmedStyleRange(text: String, rawA: Int, rawB: Int): Pair<Int, Int
 class StateFuzzInterpreter(
 	private val state: TextEditorState,
 	private val markdown: MarkdownExtension,
-	private val skipDemotions: Boolean,
 ) {
 	private fun clampIndex(raw: Int): Int = raw % (state.getAllText().text.length + 1)
 
@@ -253,15 +220,11 @@ class StateFuzzInterpreter(
 			is FuzzOp.TypeText -> typeOrReplace(op.text)
 
 			is FuzzOp.Enter -> {
-				if (skipDemotions && wouldDemote(state, markdown, enter = true)) return
 				state.selector.clearSelection()
 				state.insertNewlineAtCursor()
 			}
 
 			is FuzzOp.Backspace -> {
-				if (skipDemotions && state.selector.selection == null &&
-					wouldDemote(state, markdown, enter = false)
-				) return
 				val selection = state.selector.selection
 				if (selection != null) {
 					state.delete(selection)
@@ -325,23 +288,15 @@ class StateFuzzInterpreter(
 }
 
 /** Applies [op] through real key events and the clipboard, the UI twin of [StateFuzzInterpreter]. */
-fun EditorUiTestScope.applyFuzzOpUi(op: FuzzOp, skipDemotions: Boolean) {
+fun EditorUiTestScope.applyFuzzOpUi(op: FuzzOp) {
 	fun clampIndex(raw: Int): Int = raw % (text.length + 1)
 
 	when (op) {
 		is FuzzOp.TypeText -> typeText(op.text)
 
-		is FuzzOp.Enter -> {
-			if (skipDemotions && wouldDemote(state, markdown, enter = true)) return
-			press(Key.Enter)
-		}
+		is FuzzOp.Enter -> press(Key.Enter)
 
-		is FuzzOp.Backspace -> {
-			if (skipDemotions && state.selector.selection == null &&
-				wouldDemote(state, markdown, enter = false)
-			) return
-			press(Key.Backspace)
-		}
+		is FuzzOp.Backspace -> press(Key.Backspace)
 
 		is FuzzOp.DeleteForward -> press(Key.Delete)
 


### PR DESCRIPTION
Follow-on to #64, based on #75. Test-only: widens fuzz coverage now that the defects the guards stepped around are fixed.

Three guards and their plumbing removed from the fuzz vocabulary:

- `includeBlocks = false` on the undo-to-origin runs, which excluded block toggles because cross-block undo restore (#72) and unrecorded smart demotions (#71) made exact restoration impossible.
- The `skipDemotions` interpreter machinery, which stepped around smart Enter/Backspace demotions for the same reason.
- The `wouldStack` check in `blockToggleTarget`, which refused to stack a quote on a list line because D3-shaped documents corrupted on round trip (fixed upstream in #57/#63).

The undo-to-origin storms now exercise block toggles, demotions, and stacked-marker documents against byte-exact restoration, and the fixpoint storms build quote-on-list stacks freely. All committed seeds pass in both harnesses; full `desktopTest` is 891 tests with only the two reds expected below the semantic-headers branch (header demotion, foreign paste).

🤖 Generated with [Claude Code](https://claude.com/claude-code)