### PR TITLE
Give markdown headings semantic identity

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
@@ -6,6 +6,7 @@ import com.darkrockstudios.texteditor.richstyle.Blockquote
 import com.darkrockstudios.texteditor.richstyle.BulletList
 import com.darkrockstudios.texteditor.richstyle.CodeFence
 import com.darkrockstudios.texteditor.richstyle.DocumentBlocks
+import com.darkrockstudios.texteditor.richstyle.HeaderSpanStyle
 import com.darkrockstudios.texteditor.richstyle.ImageBlockSpanStyle
 import com.darkrockstudios.texteditor.richstyle.ImageProvider
 import com.darkrockstudios.texteditor.richstyle.OrderedList
@@ -50,14 +51,26 @@ class HtmlExtension(
 	 */
 	fun exportAsHtml(): String {
 		val content = editorState.content
-		val blocks = documentBlocksOf(content.richSpans)
+		val blocks = documentBlocksOf(content.richSpans, configuration)
+		// Semantic heading levels, read from the spans rather than by matching
+		// font sizes, so a heading keeps its tag under any configuration.
+		val headerLevels = content.richSpans
+			.mapNotNull { span ->
+				(span.style as? HeaderSpanStyle)?.let { span.range.start.line to it.level }
+			}
+			.toMap()
 		val lines = content.lines
-		if (lines.size == 1 && lines[0].isEmpty() && blocks.isEmpty()) return ""
+		if (lines.size == 1 && lines[0].isEmpty() && blocks.isEmpty() && headerLevels.isEmpty()) {
+			return ""
+		}
 
 		val writer = HtmlWriter()
 		lines.forEachIndexed { index, line ->
 			writer.openContainers(containersFor(index, blocks))
-			writer.appendLine(lineHtml(index, line, blocks), inCodeFence = blocks.has(index, CodeFence))
+			writer.appendLine(
+				lineHtml(index, line, blocks, headerLevels[index]),
+				inCodeFence = blocks.has(index, CodeFence),
+			)
 		}
 		return writer.finish()
 	}
@@ -107,17 +120,28 @@ class HtmlExtension(
 		return containers
 	}
 
-	private fun lineHtml(index: Int, line: AnnotatedString, blocks: DocumentBlocks): String {
+	private fun lineHtml(
+		index: Int,
+		line: AnnotatedString,
+		blocks: DocumentBlocks,
+		headerLevel: Int?,
+	): String {
 		// Fenced lines are literal code: running them through `toHtml` would see the
 		// baked-in monospace as an inline code run and wrap every line in `<code>`.
 		if (blocks.has(index, CodeFence)) return line.text.escapeHtmlText()
 
 		val image = blocks.imageLines[index]
 		val isRule = index in blocks.horizontalRuleLines
-		// A uniformly styled heading line has no inner formatting left to render,
-		// so the tag is written here rather than by `toHtml` — which declines any
-		// heading level it cannot tell apart from bold body text.
-		val heading = if (isRule || image != null) null else line.uniformHeadingTag(configuration)
+		// A heading's span carries its level; font-size matching remains only as
+		// the fallback for spanless content. A uniformly styled heading line has
+		// no inner formatting left to render, so the tag is written here rather
+		// than by `toHtml`, which declines any heading level it cannot tell
+		// apart from bold body text.
+		val heading = when {
+			isRule || image != null -> null
+			headerLevel != null -> HtmlTag.entries[headerLevel - 1]
+			else -> line.uniformHeadingTag(configuration)
+		}
 		val content = when {
 			isRule -> "<hr>"
 			image != null -> "<img src=\"${image.source.escapeHtmlAttribute()}\"" +

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/htmlToAnnotatedString.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/htmlToAnnotatedString.kt
@@ -10,6 +10,7 @@ import com.darkrockstudios.texteditor.richstyle.HR_PLACEHOLDER
 import com.darkrockstudios.texteditor.richstyle.IMAGE_PLACEHOLDER
 import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
 import com.darkrockstudios.texteditor.richstyle.OrderedList
+import com.darkrockstudios.texteditor.richstyle.headerBlock
 import com.fleeksoft.ksoup.Ksoup
 import com.fleeksoft.ksoup.nodes.Element
 import com.fleeksoft.ksoup.nodes.Node
@@ -316,6 +317,9 @@ private class HtmlSpanBuilder(
 		// A bare `<li>` with no list ancestor still reads as a bullet.
 		"li" -> scope.listBlock ?: BulletList
 		"pre" -> CodeFence
+		// Heading elements land as heading blocks so the level survives as a
+		// HeaderSpanStyle span, the same way markdown import attaches it.
+		"h1", "h2", "h3", "h4", "h5", "h6" -> headerBlock(name[1] - '0', config)
 		else -> null
 	}
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
@@ -1,21 +1,27 @@
 package com.darkrockstudios.texteditor.markdown
 
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
 import com.darkrockstudios.texteditor.richstyle.Blockquote
 import com.darkrockstudios.texteditor.richstyle.BulletList
 import com.darkrockstudios.texteditor.richstyle.CodeFence
 import com.darkrockstudios.texteditor.richstyle.HR_PLACEHOLDER
+import com.darkrockstudios.texteditor.richstyle.HeaderSpanStyle
 import com.darkrockstudios.texteditor.richstyle.IMAGE_PLACEHOLDER
 import com.darkrockstudios.texteditor.richstyle.ImageBlockSpanStyle
 import com.darkrockstudios.texteditor.richstyle.ImageProvider
-import com.darkrockstudios.texteditor.richstyle.LINE_BLOCK_STYLES
 import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
 import com.darkrockstudios.texteditor.richstyle.OrderedList
 import com.darkrockstudios.texteditor.richstyle.PlaceholderKind
 import com.darkrockstudios.texteditor.richstyle.allowedOn
 import com.darkrockstudios.texteditor.richstyle.applyDocumentBlocks
+import com.darkrockstudios.texteditor.richstyle.conflicts
 import com.darkrockstudios.texteditor.richstyle.documentBlocksOf
 import com.darkrockstudios.texteditor.richstyle.hasLineBlock
-import com.darkrockstudios.texteditor.richstyle.mutuallyExcluded
+import com.darkrockstudios.texteditor.richstyle.headerBlock
+import com.darkrockstudios.texteditor.richstyle.lineBlockStyles
+import com.darkrockstudios.texteditor.richstyle.rebuildWithBlock
+import com.darkrockstudios.texteditor.richstyle.rebuildWithoutBlock
 import com.darkrockstudios.texteditor.state.TextEditorState
 
 private val HR_LINE_TOKENS = setOf("---", "***", "___")
@@ -93,17 +99,18 @@ private data class PeeledLine(
 
 /**
  * Peels stacked block markers off [line] as the exact mirror of how export
- * emits them: styles are tried in [LINE_BLOCK_STYLES] registry order, each at
+ * emits them: styles are tried in [registry] order (see
+ * [com.darkrockstudios.texteditor.richstyle.lineBlockStyles]), each at
  * most once, and only when it can stack with everything already peeled.
  * `> - item` peels quote then bullet; `- 1990. plans` peels only the bullet,
  * because the two list styles are mutually exclusive, so `1990. ` stays in the
  * body text. A nested `> > quoted` keeps its second level as body text.
  */
-private fun peelLineBlocks(line: String): PeeledLine {
+private fun peelLineBlocks(line: String, registry: List<LineBlockStyle>): PeeledLine {
 	var body = line
 	val peeled = mutableListOf<LineBlockStyle>()
-	for (block in LINE_BLOCK_STYLES) {
-		if (peeled.any { block in mutuallyExcluded(it) }) continue
+	for (block in registry) {
+		if (peeled.any { conflicts(block.spanStyle, it.spanStyle) }) continue
 		val match = block.markdownPattern.matchEntire(body) ?: continue
 		peeled += block
 		body = match.groupValues[1]
@@ -135,6 +142,16 @@ private fun String.escapeResidualMarker(): String {
 	}
 }
 
+/** This string with every span range whose style equals one of [styles] dropped. */
+private fun AnnotatedString.withoutSpanStyles(styles: Collection<SpanStyle>): AnnotatedString {
+	if (styles.isEmpty() || spanStyles.none { it.item in styles }) return this
+	return AnnotatedString(
+		text = text,
+		spanStyles = spanStyles.filter { it.item !in styles },
+		paragraphStyles = paragraphStyles,
+	)
+}
+
 /**
  * An extension to TextEditorState that provides markdown functionality.
  * This separates markdown concerns from the core text editor functionality.
@@ -146,10 +163,31 @@ class MarkdownExtension(
 ) {
 	var markdownConfiguration: MarkdownConfiguration = initialConfiguration
 		set(value) {
+			val previous = field
 			field = value
 			markdownStyles = MarkdownStyles(markdownConfiguration)
 			editorState.markdownConfiguration = value
+			if (previous != value) rebakeHeaderLines(previous, value)
 		}
+
+	/**
+	 * Swaps every heading line's baked display style from [previous]'s to
+	 * [current]'s. A heading's identity lives in its [HeaderSpanStyle] span; the
+	 * baked SpanStyle is presentation only, so this is a display migration on
+	 * the direct line-update path, not an undoable edit.
+	 */
+	private fun rebakeHeaderLines(
+		previous: MarkdownConfiguration,
+		current: MarkdownConfiguration,
+	) {
+		editorState.withAtomicEdit {
+			editorState.textLines.forEachIndexed { line, existing ->
+				val level = headerLevel(line) ?: return@forEachIndexed
+				val stripped = rebuildWithoutBlock(existing, headerBlock(level, previous))
+				editorState.updateLine(line, rebuildWithBlock(stripped, headerBlock(level, current)))
+			}
+		}
+	}
 
 	var markdownStyles: MarkdownStyles = MarkdownStyles(markdownConfiguration)
 		private set
@@ -170,7 +208,8 @@ class MarkdownExtension(
 	 */
 	fun exportAsMarkdown(): String {
 		val content = editorState.content
-		val blocks = documentBlocksOf(content.richSpans)
+		val registry = lineBlockStyles(markdownConfiguration)
+		val blocks = documentBlocksOf(content.richSpans, markdownConfiguration)
 		val hrLines = blocks.horizontalRuleLines
 		val imageLines = blocks.imageLines
 		val codeFenceLines = blocks.linesFor(CodeFence)
@@ -219,16 +258,26 @@ class MarkdownExtension(
 				// backticks. Inside a fence the content is literal anyway.
 				isFenceLine -> text.substring(cursor, end)
 
-				else -> annotated.subSequence(cursor, end).toMarkdown(markdownConfiguration)
+				else -> {
+					// A prefix block's baked display style must not reach the
+					// inline serializer: a heading's SpanStyle would also match
+					// the legacy font-size branch and emit a second `# ` inline.
+					val baked = registry.mapNotNull { block ->
+						block.textStyle?.takeIf { blocks.has(lineIndex, block) }
+					}
+					annotated.subSequence(cursor, end)
+						.withoutSpanStyles(baked)
+						.toMarkdown(markdownConfiguration)
+				}
 			}
 			// Fenced lines aren't subject to per-line block prefixes — code fences
 			// don't stack with bullet/blockquote/ordered, and the mutual-exclusion
 			// rule in `applyLineBlock` already enforces this. Reset the run
 			// positions so a fence between two OL runs doesn't continue numbering.
 			if (isFenceLine) {
-				LINE_BLOCK_STYLES.forEach { runPositions.remove(it) }
+				registry.forEach { runPositions.remove(it) }
 			} else {
-				LINE_BLOCK_STYLES.forEach { block ->
+				registry.forEach { block ->
 					if (blocks.has(lineIndex, block)) {
 						val pos = runPositions[block] ?: 0
 						sb.append(block.markdownPrefix(pos))
@@ -265,6 +314,7 @@ class MarkdownExtension(
 		val imageLines = mutableListOf<Pair<Int, ImageBlockSpanStyle>>()
 		val blockHits = mutableMapOf<LineBlockStyle, MutableList<Int>>()
 		val provider = imageProvider
+		val registry = lineBlockStyles(markdownConfiguration)
 		val processedLines = fenceStrip.text.lines().mapIndexed { index, line ->
 			if (index in codeFenceLineIndices) {
 				return@mapIndexed line.escapeMarkdownSpecials()
@@ -272,7 +322,7 @@ class MarkdownExtension(
 			// Markers peel before the body is classified, so a rule or image keeps
 			// a stacked blockquote (`> ---`), and a `- ---` line comes back as the
 			// rule it once was rather than a bullet holding literal dashes.
-			val peeled = peelLineBlocks(line)
+			val peeled = peelLineBlocks(line, registry)
 			val imageMatch = STANDALONE_IMAGE_REGEX.matchEntire(peeled.body)
 			fun record(blocks: List<LineBlockStyle>) = blocks.forEach { block ->
 				blockHits.getOrPut(block) { mutableListOf() } += index
@@ -365,6 +415,28 @@ class MarkdownExtension(
 	 * line — the four block styles can't coexist visually.
 	 */
 	fun toggleCodeFence(lines: IntRange) = toggleLineBlock(lines, CodeFence)
+
+	/**
+	 * Makes each line in [lines] a heading of [level] (1..6), or removes the
+	 * heading where every targeted line already carries that exact level.
+	 * Applying over a different heading level swaps the level. The heading is
+	 * semantic: it survives configuration changes and exports as `#` markers
+	 * regardless of the display style in force. One atomic undo entry covers
+	 * the whole toggle.
+	 */
+	fun toggleHeader(lines: IntRange, level: Int) {
+		editorState.editManager.toggleLineBlock(lines, headerBlock(level, markdownConfiguration))
+	}
+
+	/**
+	 * The heading level (1..6) of [line], or null when the line is not a
+	 * heading. Reads the line's [HeaderSpanStyle] span, so the answer is
+	 * independent of the display styles in the active configuration.
+	 */
+	fun headerLevel(line: Int): Int? =
+		editorState.richSpanManager.getRichSpansStartingOn(line)
+			.firstNotNullOfOrNull { it.style as? HeaderSpanStyle }
+			?.level
 
 	private fun toggleLineBlock(lines: IntRange, block: LineBlockStyle) {
 		editorState.editManager.toggleLineBlock(lines, block)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/SpanStyleSemantics.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/SpanStyleSemantics.kt
@@ -1,0 +1,34 @@
+package com.darkrockstudios.texteditor.markdown
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.TextUnit
+
+/**
+ * Structural predicates for reading inline markdown semantics off a
+ * [SpanStyle]. Serializers ask what a style IS (bold, italic, code), not
+ * whether it equals a configured style, so restyling a configuration cannot
+ * change what a span means.
+ */
+
+/**
+ * Bold body text. Requires an unspecified font size: a bold style carrying an
+ * explicit size is a legacy font-size heading, not inline emphasis.
+ */
+internal val SpanStyle.isBoldStyle: Boolean
+	get() = fontWeight == FontWeight.Bold && fontSize == TextUnit.Unspecified
+
+internal val SpanStyle.isItalicStyle: Boolean
+	get() = fontStyle == FontStyle.Italic
+
+internal val SpanStyle.isCodeStyle: Boolean
+	get() = fontFamily == FontFamily.Monospace
+
+internal val SpanStyle.isStrikethroughStyle: Boolean
+	get() = textDecoration == TextDecoration.LineThrough
+
+internal val SpanStyle.isUnderlineStyle: Boolean
+	get() = textDecoration == TextDecoration.Underline

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/annotatedStringToMarkdown.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/annotatedStringToMarkdown.kt
@@ -2,10 +2,7 @@ package com.darkrockstudios.texteditor.markdown
 
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.TextUnit
 
 /**
@@ -179,6 +176,11 @@ private fun getStyleMarker(
 	style: SpanStyle,
 	config: MarkdownConfiguration = MarkdownConfiguration.DEFAULT
 ): StyleMarkerPair? {
+	// Legacy heading path for content styled without a HeaderSpanStyle span
+	// (old documents, host apps writing raw font sizes). Checked first so a
+	// bold style with an explicit size never reads as inline bold. Heading
+	// lines carrying a span never reach here; export strips their baked style
+	// before serializing the line.
 	if (style.fontWeight == FontWeight.Bold && style.fontSize != TextUnit.Unspecified) {
 		return when (style.fontSize.value) {
 			config.header1Style.fontSize.value -> StyleMarkerPair("# ", "\n")
@@ -192,23 +194,12 @@ private fun getStyleMarker(
 	}
 
 	return when {
-		style.matches(config.boldStyle) -> StyleMarkerPair("**", "**")
-		style.matches(config.italicStyle) -> StyleMarkerPair("*", "*")
-		style.matches(config.codeStyle) -> StyleMarkerPair("`", "`")
-		style.matches(config.strikethroughStyle) -> StyleMarkerPair("~~", "~~")
-		style.matches(config.linkStyle) -> StyleMarkerPair("[", "]()")
+		style.isBoldStyle -> StyleMarkerPair("**", "**")
+		style.isItalicStyle -> StyleMarkerPair("*", "*")
+		style.isCodeStyle -> StyleMarkerPair("`", "`")
+		style.isStrikethroughStyle -> StyleMarkerPair("~~", "~~")
+		style.isUnderlineStyle -> StyleMarkerPair("[", "]()")
 		else -> null
-	}
-}
-
-private fun SpanStyle.matches(other: SpanStyle): Boolean {
-	return when {
-		this.fontWeight == FontWeight.Bold && other.fontWeight == FontWeight.Bold -> true
-		this.fontStyle == FontStyle.Italic && other.fontStyle == FontStyle.Italic -> true
-		this.fontFamily == FontFamily.Monospace && other.fontFamily == FontFamily.Monospace -> true
-		this.textDecoration == TextDecoration.LineThrough && other.textDecoration == TextDecoration.LineThrough -> true
-		this.textDecoration == TextDecoration.Underline && other.textDecoration == TextDecoration.Underline -> true
-		else -> false
 	}
 }
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/DocumentBlocks.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/DocumentBlocks.kt
@@ -3,6 +3,7 @@ package com.darkrockstudios.texteditor.richstyle
 import androidx.compose.ui.text.AnnotatedString
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import com.darkrockstudios.texteditor.state.TextEditorState
 
 /**
@@ -30,16 +31,19 @@ internal class DocumentBlocks(
 
 /** Collects every line-anchored decoration currently attached to this document. */
 internal fun TextEditorState.documentBlocks(): DocumentBlocks =
-	documentBlocksOf(richSpanManager.getAllRichSpans())
+	documentBlocksOf(richSpanManager.getAllRichSpans(), markdownConfiguration)
 
 /**
- * Collects the decorations in [allSpans].
+ * Collects the decorations in [allSpans], keyed by [config]'s block registry.
  *
  * Serializers take this from the same [TextEditorState.content] snapshot they read
  * the text from, so the blocks they place and the lines they place them on come
  * from one revision.
  */
-internal fun documentBlocksOf(allSpans: Set<RichSpan>): DocumentBlocks {
+internal fun documentBlocksOf(
+	allSpans: Set<RichSpan>,
+	config: MarkdownConfiguration,
+): DocumentBlocks {
 	return DocumentBlocks(
 		horizontalRuleLines = allSpans
 			.asSequence()
@@ -53,7 +57,7 @@ internal fun documentBlocksOf(allSpans: Set<RichSpan>): DocumentBlocks {
 				span.range.start.line to style
 			}
 			.toMap(),
-		blockLines = ALL_BLOCK_STYLES.associateWith { block ->
+		blockLines = allBlockStyles(config).associateWith { block ->
 			allSpans.asSequence()
 				.filter { it.style === block.spanStyle }
 				.map { it.range.start.line }
@@ -104,10 +108,10 @@ internal fun TextEditorState.applyDocumentBlocks(
 	}
 
 	// Invert to line -> requested blocks so each line is visited once. Within a line
-	// the [ALL_BLOCK_STYLES] order decides how a stack resolves: each block demotes
+	// the [allBlockRegistry] order decides how a stack resolves: each block demotes
 	// whatever it excludes, so a fence beats a list and blockquote stacks with both.
 	val requested = mutableMapOf<Int, MutableList<LineBlockStyle>>()
-	ALL_BLOCK_STYLES.forEach { block ->
+	allBlockRegistry.forEach { block ->
 		blockLines[block]?.forEach { line ->
 			requested.getOrPut(line) { mutableListOf() } += block
 		}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/HeaderSpanStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/HeaderSpanStyle.kt
@@ -1,0 +1,46 @@
+package com.darkrockstudios.texteditor.richstyle
+
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
+import com.darkrockstudios.texteditor.LineWrap
+import com.darkrockstudios.texteditor.state.TextEditorState
+
+/**
+ * Marks a line as a markdown heading of [level] (1..6). The span is the
+ * heading's semantic identity: serializers read the level from it instead of
+ * reverse-matching font sizes, so restyling the document cannot demote a
+ * heading to plain text. The visual treatment is a [androidx.compose.ui.text.SpanStyle]
+ * baked into the line text from the active markdown configuration; this span
+ * paints nothing itself.
+ *
+ * Instances are per-level singletons ([of]); block detection compares span
+ * styles by identity.
+ */
+class HeaderSpanStyle private constructor(val level: Int) : RichSpanStyle {
+	override val stickyAtStart: Boolean get() = true
+
+	override fun DrawScope.drawCustomStyle(
+		layoutResult: TextLayoutResult,
+		lineWrap: LineWrap,
+		textRange: TextRange,
+		state: TextEditorState,
+	) {
+	}
+
+	override fun toString(): String = "HeaderSpanStyle(level=$level)"
+
+	companion object {
+		private val LEVELS: List<HeaderSpanStyle> = List(6) { HeaderSpanStyle(it + 1) }
+
+		/** The singleton for [level], coerced into 1..6. */
+		fun of(level: Int): HeaderSpanStyle = LEVELS[level.coerceIn(1, 6) - 1]
+	}
+}
+
+/**
+ * Paragraph style for heading lines. Headings need no indent; the constant
+ * exists so heading blocks fit the [LineBlockStyle] apply/demote contract.
+ */
+val HEADER_PARAGRAPH_STYLE: ParagraphStyle = ParagraphStyle()

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockNormalization.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockNormalization.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.texteditor.richstyle
 
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import com.darkrockstudios.texteditor.state.DocumentSnapshot
 
 /**
@@ -19,12 +20,16 @@ import com.darkrockstudios.texteditor.state.DocumentSnapshot
  * (no line allocation) when the document is already valid, the overwhelmingly
  * common case.
  */
-internal fun normalizeLineBlocks(snapshot: DocumentSnapshot): DocumentSnapshot {
+internal fun normalizeLineBlocks(
+	snapshot: DocumentSnapshot,
+	config: MarkdownConfiguration,
+): DocumentSnapshot {
 	val kinds = placeholderKinds(snapshot.richSpans, snapshot.lines)
 	if (kinds.isEmpty()) return snapshot
 
+	val registry = allBlockStyles(config)
 	val violations = snapshot.richSpans.mapNotNull { span ->
-		val block = ALL_BLOCK_STYLES.firstOrNull { it.spanStyle === span.style }
+		val block = registry.firstOrNull { it.spanStyle === span.style }
 			?: return@mapNotNull null
 		val kind = kinds[span.range.start.line] ?: return@mapNotNull null
 		if (block.allowedOn(kind)) null else span to block

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockStyle.kt
@@ -7,7 +7,9 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.withStyle
 import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import com.darkrockstudios.texteditor.state.TextEditorState
+import kotlin.concurrent.Volatile
 
 /**
  * A line-anchored block style — bullet, blockquote, ordered-list item, fenced
@@ -82,43 +84,108 @@ internal val CodeFence = LineBlockStyle(
 	textStyle = SpanStyle(fontFamily = FontFamily.Monospace),
 )
 
+/** The heading block for [level] under [config]'s display styles, from the shared registry. */
+internal fun headerBlock(level: Int, config: MarkdownConfiguration): LineBlockStyle =
+	registryFor(config).headers[level.coerceIn(1, 6) - 1]
+
 /**
- * Registry of every prefix-style line block — those that roundtrip through a
- * single-line markdown prefix (`> `, `- `, `1. `). Iterated by
- * import/export and the editor's smart Enter/Backspace.
+ * Registry of every prefix-style line block (those that roundtrip through a
+ * single-line markdown prefix: `# `, `> `, `- `, `1. `) for documents styled
+ * with [config]. Iterated by import/export and the editor's smart
+ * Enter/Backspace.
  *
- * Order matters at import time: the first matching pattern wins. OrderedList
- * comes before BulletList so a line like `1. item` isn't accidentally captured
- * by a bullet regex (it isn't currently — but the ordering is still defensive).
+ * Order matters at import time: the first matching pattern wins. Heading
+ * patterns refuse a trailing `#` so the six levels cannot capture each other;
+ * OrderedList comes before BulletList so a line like `1. item` isn't
+ * accidentally captured by a bullet regex (it isn't currently, but the
+ * ordering is still defensive).
  *
- * `CodeFence` is intentionally NOT in this list — it roundtrips via wrapping
+ * `CodeFence` is intentionally NOT in this list; it roundtrips via wrapping
  * markers, not a per-line prefix, and is handled separately. See
- * [ALL_BLOCK_STYLES] for the union used by `detectLineBlock`.
+ * [allBlockStyles] for the union used by `detectLineBlock`.
  */
-internal val LINE_BLOCK_STYLES: List<LineBlockStyle> =
-	listOf(Blockquote, OrderedList, BulletList)
+internal fun lineBlockStyles(config: MarkdownConfiguration): List<LineBlockStyle> =
+	registryFor(config).prefixBlocks
 
-/** Every known line-block style, including wrap-style blocks like `CodeFence`. */
-internal val ALL_BLOCK_STYLES: List<LineBlockStyle> =
-	LINE_BLOCK_STYLES + CodeFence
+/** Every known line-block style under [config], including wrap-style blocks like `CodeFence`. */
+internal fun allBlockStyles(config: MarkdownConfiguration): List<LineBlockStyle> =
+	registryFor(config).allBlocks
+
+/** The prefix-block registry for this state's active markdown configuration. */
+internal val TextEditorState.lineBlockRegistry: List<LineBlockStyle>
+	get() = lineBlockStyles(markdownConfiguration)
+
+/** The full block registry for this state's active markdown configuration. */
+internal val TextEditorState.allBlockRegistry: List<LineBlockStyle>
+	get() = allBlockStyles(markdownConfiguration)
 
 /**
- * Returns the set of line-block styles that should be demoted from a line
- * before [applied] is added. Encodes the editor's stacking rules:
+ * The block styles that exist per configuration. Heading blocks bake the
+ * configured heading [androidx.compose.ui.text.SpanStyle] into the line text,
+ * so their [LineBlockStyle] instances are scoped to the configuration; the
+ * fixed blocks are shared so span-style identity stays global.
+ */
+private class LineBlockRegistry(config: MarkdownConfiguration) {
+	val headers: List<LineBlockStyle> = (1..6).map { level ->
+		LineBlockStyle(
+			spanStyle = HeaderSpanStyle.of(level),
+			paragraphStyle = HEADER_PARAGRAPH_STYLE,
+			markdownPrefix = { "#".repeat(level) + " " },
+			// (?!#) keeps each level from matching a deeper heading's marker run.
+			markdownPattern = Regex("^#{$level}(?!#)\\s+(.*)$"),
+			textStyle = config.getHeaderStyle(level),
+		)
+	}
+	val prefixBlocks: List<LineBlockStyle> =
+		listOf(Blockquote) + headers + listOf(OrderedList, BulletList)
+	val allBlocks: List<LineBlockStyle> = prefixBlocks + CodeFence
+}
+
+private const val REGISTRY_CACHE_LIMIT = 8
+
+/**
+ * Copy-on-write cache of registries by configuration. Instance identity within
+ * one configuration matters: resolved block lists and blockLines maps compare
+ * [LineBlockStyle] values, and the lambda/regex fields defeat data-class
+ * equality across separately built instances, so every lookup for an equal
+ * configuration must return the same registry.
+ */
+@Volatile
+private var registryCache: Map<MarkdownConfiguration, LineBlockRegistry> = emptyMap()
+
+private fun registryFor(config: MarkdownConfiguration): LineBlockRegistry {
+	registryCache[config]?.let { return it }
+	val built = LineBlockRegistry(config)
+	val cached = registryCache
+	registryCache = (if (cached.size >= REGISTRY_CACHE_LIMIT) emptyMap() else cached) +
+		(config to built)
+	return built
+}
+
+/**
+ * Whether two line blocks, identified by their span styles, refuse to share a
+ * line. Kind-level so it holds across configuration-scoped heading instances.
+ * Encodes the editor's stacking rules:
  *
- * - List styles ([BulletList], [OrderedList]) are mutually exclusive — Compose
+ * - List styles ([BulletList], [OrderedList]) are mutually exclusive; Compose
  *   rejects overlapping paragraph styles, blanking the line.
- * - [Blockquote] stacks with lists (`> - item` and `> 1. item` are legitimate
- *   markdown).
- * - [CodeFence] stacks with nothing — quoted/listed code blocks aren't
+ * - Headings exclude each other (a line has one level) and both list styles:
+ *   `- # item` is a bullet holding literal text, not a bulleted heading.
+ * - [Blockquote] stacks with lists and headings (`> - item` and `> # Title`
+ *   are legitimate markdown).
+ * - [CodeFence] stacks with nothing; quoted/listed code blocks aren't
  *   meaningful in our editor's model and the visual treatments would conflict.
  */
-internal fun mutuallyExcluded(applied: LineBlockStyle): Set<LineBlockStyle> = when (applied) {
-	CodeFence -> setOf(Blockquote, BulletList, OrderedList)
-	BulletList -> setOf(OrderedList, CodeFence)
-	OrderedList -> setOf(BulletList, CodeFence)
-	Blockquote -> setOf(CodeFence)
-	else -> emptySet()
+internal fun conflicts(a: RichSpanStyle, b: RichSpanStyle): Boolean {
+	if (a === b) return false
+	val aList = a === BulletListSpanStyle || a === OrderedListSpanStyle
+	val bList = b === BulletListSpanStyle || b === OrderedListSpanStyle
+	return when {
+		a === CodeFenceSpanStyle || b === CodeFenceSpanStyle -> true
+		a is HeaderSpanStyle -> b is HeaderSpanStyle || bList
+		b is HeaderSpanStyle -> aList
+		else -> aList && bList
+	}
 }
 
 /**
@@ -174,13 +241,13 @@ internal fun TextEditorState.hasLineBlock(line: Int, block: LineBlockStyle): Boo
 internal fun rebuildWithBlock(existing: AnnotatedString, block: LineBlockStyle): AnnotatedString =
 	buildAnnotatedString {
 		withStyle(block.paragraphStyle) {
-			if (block.textStyle != null) {
-				withStyle(block.textStyle) {
-					append(existing)
-				}
-			} else {
-				append(existing)
-			}
+			append(existing)
+		}
+		// Added after the line's own spans so its attributes win where they
+		// overlap: a heading's size must beat the body-text size the parser
+		// left on the line.
+		if (block.textStyle != null) {
+			addStyle(block.textStyle, 0, existing.length)
 		}
 	}
 
@@ -214,7 +281,7 @@ internal class ResolvedLineBlock(
  * Resolves [block] against a line holding [present] with content [text], or
  * returns null when [block] is already there and there is nothing to do.
  *
- * The one place [mutuallyExcluded] is turned into an actual demotion and rebuild:
+ * The one place [conflicts] is turned into an actual demotion and rebuild:
  * the per-line toggle and the batched importer both resolve through this, so a
  * stack of blocks produces the same line whether the user typed it or an import
  * placed it.
@@ -228,7 +295,7 @@ internal fun resolveLineBlock(
 	// Demote any conflicting block before applying — otherwise the new
 	// paragraph-style indent would overlap the old one and Compose blanks the
 	// line on the next measure pass.
-	val demoted = mutuallyExcluded(block).filter { it in present }
+	val demoted = present.filter { conflicts(block.spanStyle, it.spanStyle) }
 	var rebuilt = text
 	demoted.forEach { rebuilt = rebuildWithoutBlock(rebuilt, it) }
 	return ResolvedLineBlock(demoted, rebuildWithBlock(rebuilt, block))
@@ -292,11 +359,11 @@ internal fun TextEditorState.demoteLineBlock(line: Int, block: LineBlockStyle) =
 
 /** Returns the [LineBlockStyle] currently attached to [line], or null if none. */
 internal fun TextEditorState.detectLineBlock(line: Int): LineBlockStyle? =
-	ALL_BLOCK_STYLES.firstOrNull { hasLineBlock(line, it) }
+	allBlockRegistry.firstOrNull { hasLineBlock(line, it) }
 
-/** The line blocks currently attached to [line], in [ALL_BLOCK_STYLES] order. */
+/** The line blocks currently attached to [line], in [allBlockRegistry] order. */
 internal fun TextEditorState.lineBlocks(line: Int): List<LineBlockStyle> =
-	ALL_BLOCK_STYLES.filter { hasLineBlock(line, it) }
+	allBlockRegistry.filter { hasLineBlock(line, it) }
 
 /** The line-anchored block span styles currently attached to [line]. */
 internal fun TextEditorState.lineBlockSpanStyles(line: Int): List<RichSpanStyle> =
@@ -311,7 +378,7 @@ internal fun TextEditorState.setLineBlockSpans(
 	line: Int,
 	spanStyles: List<RichSpanStyle>,
 ) = withAtomicEdit {
-	ALL_BLOCK_STYLES.forEach { removeLineBlockSpans(line, it) }
+	allBlockRegistry.forEach { removeLineBlockSpans(line, it) }
 	val length = textLines.getOrNull(line)?.length ?: return@withAtomicEdit
 	spanStyles.forEach { style ->
 		richSpanManager.addRichSpan(

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -179,7 +179,7 @@ class TextEditorState(
 			// Every publish passes through line-block normalization, so no caller
 			// can commit a revision violating the placeholder-line invariant. A
 			// transaction that mutated nothing skips the scan and the republish.
-			draft?.let { if (it !== content) content = normalizeLineBlocks(it) }
+			draft?.let { if (it !== content) content = normalizeLineBlocks(it, markdownConfiguration) }
 			return result
 		} finally {
 			draft = null
@@ -206,7 +206,7 @@ class TextEditorState(
 		if (draft != null) {
 			draft = transform(workingContent)
 		} else {
-			content = normalizeLineBlocks(transform(content))
+			content = normalizeLineBlocks(transform(content), markdownConfiguration)
 		}
 	}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/blocks/LineBlockStackingParityTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/blocks/LineBlockStackingParityTest.kt
@@ -8,13 +8,14 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.TextEditorRange
-import com.darkrockstudios.texteditor.richstyle.ALL_BLOCK_STYLES
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import com.darkrockstudios.texteditor.richstyle.Blockquote
 import com.darkrockstudios.texteditor.richstyle.BulletList
 import com.darkrockstudios.texteditor.richstyle.CodeFence
 import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
 import com.darkrockstudios.texteditor.richstyle.OrderedList
 import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.richstyle.allBlockStyles
 import com.darkrockstudios.texteditor.richstyle.applyDocumentBlocks
 import com.darkrockstudios.texteditor.richstyle.applyLineBlock
 import com.darkrockstudios.texteditor.richstyle.lineBlockSpanStyles
@@ -69,10 +70,12 @@ class LineBlockStackingParityTest {
 	) {
 		val perLine = freshState("line text")
 		existing.forEach { perLine.applyLineBlock(0, it) }
-		// The batched path visits a line's blocks in ALL_BLOCK_STYLES order whatever
+		// The batched path visits a line's blocks in registry order whatever
 		// order they were requested in, so the per-line path has to be driven that way
 		// for the comparison to be about the rules rather than about the ordering.
-		ALL_BLOCK_STYLES.filter { it in blocks }.forEach { perLine.applyLineBlock(0, it) }
+		allBlockStyles(MarkdownConfiguration.DEFAULT)
+			.filter { it in blocks }
+			.forEach { perLine.applyLineBlock(0, it) }
 
 		val batched = freshState("line text")
 		existing.forEach { batched.applyLineBlock(0, it) }
@@ -94,7 +97,7 @@ class LineBlockStackingParityTest {
 
 	@Test
 	fun `mutually exclusive lists resolve the same way on both paths`() {
-		// ALL_BLOCK_STYLES puts OrderedList first, so BulletList demotes it.
+		// The registry puts OrderedList first, so BulletList demotes it.
 		assertPathsAgree(BulletList, OrderedList, expected = listOf(BulletList))
 	}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockBoundaryDeletionE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/BlockBoundaryDeletionE2eTest.kt
@@ -63,7 +63,7 @@ class BlockBoundaryDeletionE2eTest {
 		press(Key.Delete)
 
 		assertEquals(listOf("quode"), lines)
-		// Fence stacks with nothing (mutuallyExcluded), so whatever the join keeps,
+		// Fence stacks with nothing (conflicts), so whatever the join keeps,
 		// a quote+fence combination on one line is an invalid document.
 		assertEquals(setOf("quote"), blockFlags(0), "joined line must keep one valid block style")
 		assertRichSpanInvariants()

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/MarkdownRoundTripTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/MarkdownRoundTripTortureE2eTest.kt
@@ -144,6 +144,19 @@ class MarkdownRoundTripTortureE2eTest {
 	}
 
 	@Test
+	fun `a link url survives a round trip`() = editorUiTest {
+		markdown.importMarkdown("[text](https://example.com)")
+
+		// Import styles the link text but drops the URL, so export emits an
+		// empty target and the destination is silently lost.
+		val exported = markdown.exportAsMarkdown()
+		assertTrue(
+			exported.contains("https://example.com"),
+			"the link destination must survive a save; got: $exported",
+		)
+	}
+
+	@Test
 	fun `a bold run ending in a space round trips`() = editorUiTest {
 		markdown.importMarkdown("word tail")
 		state.addStyleSpan(

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/HeaderSemanticsTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/HeaderSemanticsTest.kt
@@ -1,0 +1,155 @@
+package markdown
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.HeaderSpanStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Headings as semantic line blocks: the level lives in a [HeaderSpanStyle]
+ * span, the display style is baked per configuration, and neither serializing
+ * nor restyling may lose the level.
+ */
+class HeaderSemanticsTest {
+
+	private fun editor(markdown: String? = null): MarkdownExtension {
+		val state = TextEditorState(scope = TestScope(), measurer = mockk(relaxed = true))
+		return MarkdownExtension(state).apply { markdown?.let { importMarkdown(it) } }
+	}
+
+	private fun MarkdownExtension.headerSpansOn(line: Int): List<HeaderSpanStyle> =
+		editorState.richSpanManager.getAllRichSpans()
+			.filter { it.range.start.line == line }
+			.mapNotNull { it.style as? HeaderSpanStyle }
+
+	private fun MarkdownExtension.lineCarries(line: Int, style: SpanStyle): Boolean =
+		editorState.textLines[line].spanStyles.any { it.item == style }
+
+	@Test
+	fun `import attaches the heading span and level`() {
+		val e = editor("# Title")
+
+		assertEquals(1, e.headerLevel(0))
+		assertEquals(listOf(HeaderSpanStyle.of(1)), e.headerSpansOn(0))
+		assertTrue(e.lineCarries(0, MarkdownConfiguration.DEFAULT.header1Style))
+	}
+
+	@Test
+	fun `toggleHeader applies span plus display style and one undo removes both`() {
+		val e = editor("Title")
+		e.toggleHeader(0..0, 2)
+
+		assertEquals(2, e.headerLevel(0))
+		assertTrue(e.lineCarries(0, MarkdownConfiguration.DEFAULT.header2Style))
+
+		e.editorState.undo()
+
+		assertNull(e.headerLevel(0), "one undo must remove the heading span")
+		assertFalse(
+			e.lineCarries(0, MarkdownConfiguration.DEFAULT.header2Style),
+			"one undo must strip the baked display style",
+		)
+	}
+
+	@Test
+	fun `toggleHeader with a different level swaps the level`() {
+		val e = editor("# Title")
+		e.toggleHeader(0..0, 3)
+
+		assertEquals(3, e.headerLevel(0))
+		assertEquals(listOf(HeaderSpanStyle.of(3)), e.headerSpansOn(0))
+		assertTrue(e.lineCarries(0, MarkdownConfiguration.DEFAULT.header3Style))
+		assertFalse(e.lineCarries(0, MarkdownConfiguration.DEFAULT.header1Style))
+	}
+
+	@Test
+	fun `toggleHeader with the same level removes the heading`() {
+		val e = editor("### Title")
+		e.toggleHeader(0..0, 3)
+
+		assertNull(e.headerLevel(0))
+		assertFalse(e.lineCarries(0, MarkdownConfiguration.DEFAULT.header3Style))
+	}
+
+	@Test
+	fun `a configuration change re-bakes the display style and keeps the level`() {
+		val e = editor("# Title\n\nbody")
+		val restyled = MarkdownConfiguration(
+			header1Style = SpanStyle(fontSize = 40.sp, fontWeight = FontWeight.Bold),
+		)
+
+		e.markdownConfiguration = restyled
+
+		assertEquals(1, e.headerLevel(0))
+		assertTrue(
+			e.lineCarries(0, restyled.header1Style),
+			"the heading line must carry the new configuration's display style",
+		)
+		assertFalse(
+			e.lineCarries(0, MarkdownConfiguration.DEFAULT.header1Style),
+			"the old configuration's display style must be stripped",
+		)
+		assertTrue(e.exportAsMarkdown().startsWith("# "))
+	}
+
+	@Test
+	fun `heading export import export is a fixpoint`() {
+		val e = editor("# Title\n\nbody")
+
+		val first = e.exportAsMarkdown()
+		e.importMarkdown(first)
+		val second = e.exportAsMarkdown()
+
+		assertEquals("# Title\n\nbody", first)
+		assertEquals(first, second)
+	}
+
+	@Test
+	fun `a heading between two ordered list runs restarts the numbering`() {
+		val source = "1. a\n2. b\n# H\n1. c\n2. d"
+		val e = editor(source)
+
+		assertEquals(source, e.exportAsMarkdown())
+	}
+
+	@Test
+	fun `a quote stacked on a heading round trips`() {
+		val e = editor("> # T")
+
+		assertEquals(1, e.headerLevel(0))
+		assertTrue(e.isBlockquote(0))
+		assertEquals("T", e.editorState.getAllText().text)
+
+		val exported = e.exportAsMarkdown()
+		assertEquals("> # T", exported)
+
+		e.importMarkdown(exported)
+		assertEquals(exported, e.exportAsMarkdown())
+	}
+
+	@Test
+	fun `a raw font size heading with no span still exports through the legacy path`() {
+		val e = editor()
+		val state = e.editorState
+		state.setText("Title")
+		state.addStyleSpan(
+			TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 5)),
+			MarkdownConfiguration.DEFAULT.header1Style,
+		)
+
+		assertNull(e.headerLevel(0), "precondition: no heading span, only the raw style")
+		assertTrue(e.exportAsMarkdown().startsWith("# "))
+	}
+}

--- a/sampleApp/src/commonMain/kotlin/TextEditorToolbarUi.kt
+++ b/sampleApp/src/commonMain/kotlin/TextEditorToolbarUi.kt
@@ -72,9 +72,7 @@ fun TextEditorToolbar(
 			isBulletListActive = richSpans.any { it.style === BulletListSpanStyle }
 			isOrderedListActive = richSpans.any { it.style === OrderedListSpanStyle }
 			isCodeFenceActive = richSpans.any { it.style === CodeFenceSpanStyle }
-			currentHeaderLevel = (1..6).firstOrNull { lvl ->
-				styles.contains(mardkown.markdownStyles.header(lvl))
-			} ?: 0
+			currentHeaderLevel = mardkown.headerLevel(position.line) ?: 0
 			isHighlightActive = richSpans.any { it.style == HIGHLIGHT }
 		}
 	}
@@ -473,6 +471,9 @@ private fun toggleStyle(
 	}
 }
 
+// Cycles none -> H1 -> H2 -> ... -> H6 -> none over the selected lines (or the
+// cursor's line). Headings are semantic line blocks: toggling the same level
+// removes it, toggling a new level swaps it.
 private fun cycleHeader(
 	state: TextEditorState,
 	markdown: MarkdownExtension,
@@ -480,20 +481,15 @@ private fun cycleHeader(
 ) {
 	val nextLevel = (currentLevel + 1) % 7
 	val selection = state.selector.selection
-	if (selection != null) {
-		(1..6).forEach { lvl ->
-			state.removeStyleSpan(selection, markdown.markdownStyles.header(lvl))
-		}
-		if (nextLevel != 0) {
-			state.addStyleSpan(selection, markdown.markdownStyles.header(nextLevel))
-		}
+	val lines = if (selection != null) {
+		selection.start.line..selection.end.line
 	} else {
-		(1..6).forEach { lvl ->
-			state.cursor.removeStyle(markdown.markdownStyles.header(lvl))
-		}
-		if (nextLevel != 0) {
-			state.cursor.addStyle(markdown.markdownStyles.header(nextLevel))
-		}
+		state.cursorPosition.line..state.cursorPosition.line
+	}
+	if (nextLevel != 0) {
+		markdown.toggleHeader(lines, nextLevel)
+	} else if (currentLevel != 0) {
+		markdown.toggleHeader(lines, currentLevel)
 	}
 }
 


### PR DESCRIPTION
Follow-on to #64, based on #75 (sibling of #77, disjoint files). Fixes the header-demotion entry from the torture ledger with the full semantic model.

## Problem

A heading had no identity: import and the toolbar baked `SpanStyle(fontSize, Bold)` and export reverse-matched the size against `MarkdownConfiguration` by exact float equality. Any configuration change between styling and export (theme switch, host-app defaults, platform drift) made `# Title` export as plain `Title` — silent data loss, pinned red by `switching header configuration must not silently demote headings`.

## Design

`HeaderSpanStyle(level)` — a line-anchored, visually inert rich span (six singletons) — is the heading's semantic identity, and headings become line blocks:

- Six configuration-scoped `LineBlockStyle` instances (`headerBlock(level, config)`) whose `textStyle` bakes the display style, exactly how CodeFence bakes monospace. The static block registries become `lineBlockStyles(config)` / `allBlockStyles(config)` behind a copy-on-write cache; `mutuallyExcluded` becomes a kind-level `conflicts` predicate (headings exclude headings and lists; blockquote stacks, so `> # Title` round-trips; fence beats all).
- Import peels `#{n} ` prefixes like any block; export emits them from the span; `toggleHeader(lines, level)` records one atomic undoable LineBlock op; `headerLevel(line)` reads the level back.
- Setting `markdownConfiguration` re-bakes every heading line's display style from its span: restyling the document visibly updates headings and can no longer lose levels.
- HTML: `<h1>`..`<h6>` import attaches the span; export prefers the span's level over `uniformHeadingTag` size matching.
- Legacy: spanless content styled with raw font sizes still exports via the old font-size match (kept verbatim as a fallback, covered by a test).

Also in this PR: `SpanStyle.matches` — which accepted a configuration and ignored it — is deleted in favor of structural predicates (`isBoldStyle` requires Unspecified size so headings never read as inline bold, `isItalicStyle`, `isCodeStyle`, `isStrikethroughStyle`, `isUnderlineStyle`). Marker behavior for bold/italic/code/strikethrough/links is byte-identical. The sampleApp toolbar's `cycleHeader` now drives `toggleHeader`/`headerLevel` instead of writing raw font sizes.

## Links (descoped, pinned)

Link matching stays legacy and is now pinned red by `a link url survives a round trip`: import styles link text but drops the URL, and underline-means-link fabricates empty links. Tracked in #76; fix follows this PR.

## Tests

- Flips green: `switching header configuration must not silently demote headings`.
- New `markdown/HeaderSemanticsTest` (9): span attach on import, one-undo toggle, level swap, same-level removal, config re-bake keeps the level and restyles, export fixpoint, ordered-run restart around a heading, `> # T` stack round trip, legacy fallback.
- No pre-existing expectations changed; all heading round-trip pins produce byte-identical output.
- Behavior note: `# ---` now imports as a rule (headings are excluded from placeholder lines, like lists); previously it was a heading containing literal dashes. Neither reading was pinned.
- Full `desktopTest`: 901 tests, 2 intentional reds (foreign paste, new link pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)