### PR TITLE
Prove clipboard provenance before re-applying the copied span buffer

### DIFF
--- a/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.android.kt
+++ b/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.android.kt
@@ -26,8 +26,13 @@ actual object ClipboardHelper {
 		clipboard: Clipboard,
 		text: AnnotatedString,
 		configuration: MarkdownConfiguration,
+		copyId: Long?,
 	) {
 		val clipData = ClipData.newPlainText("text", text.text)
 		clipboard.setClipEntry(clipData.toClipEntry())
 	}
+
+	actual suspend fun readCopyId(clipboard: Clipboard): Long? = null
+
+	actual val supportsCopyProvenance: Boolean get() = false
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.kt
@@ -35,12 +35,26 @@ expect object ClipboardHelper {
 	/**
 	 * Writes text to the clipboard.
 	 * On Desktop, offers the selection as HTML for other applications and as an
-	 * exact copy within this process.
-	 * On other platforms, writes plain text only.
+	 * exact copy within this process; [copyId] rides along so a later paste can
+	 * prove the clipboard content is still this copy.
+	 * On other platforms, writes plain text only and [copyId] is ignored.
 	 */
 	suspend fun setText(
 		clipboard: Clipboard,
 		text: AnnotatedString,
 		configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT,
+		copyId: Long? = null,
 	)
+
+	/**
+	 * The [copyId] this editor attached to the current clipboard content, or null
+	 * when another application wrote the clipboard or the platform cannot carry it.
+	 */
+	suspend fun readCopyId(clipboard: Clipboard): Long?
+
+	/**
+	 * Whether this platform's clipboard can carry a [copyId]. Where it cannot
+	 * (plain-text-only clipboards), paste falls back to matching copied text.
+	 */
+	val supportsCopyProvenance: Boolean
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/ContextMenuActions.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/ContextMenuActions.kt
@@ -41,11 +41,11 @@ class ContextMenuActions(
 	fun cut() {
 		state.selector.selection?.let { selection ->
 			val selectedText = state.selector.getSelectedText()
-			state.copyRichSpans(selection)
+			val copyId = state.copyRichSpans(selection)
 			state.preserveCopiedRichSpansThroughNextEdit()
 			state.selector.deleteSelection()
 			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration)
+				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
 			}
 		}
 	}
@@ -56,9 +56,9 @@ class ContextMenuActions(
 	fun copy() {
 		state.selector.selection?.let { selection ->
 			val selectedText = state.selector.getSelectedText()
-			state.copyRichSpans(selection)
+			val copyId = state.copyRichSpans(selection)
 			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration)
+				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
 			}
 		}
 	}
@@ -75,6 +75,7 @@ class ContextMenuActions(
 				// Read the clipboard's HTML before mutating: the text, the in-editor
 				// rich spans and the pasted block structure then land as one revision.
 				val htmlDocument = state.readHtmlPasteDocument(clipboard, text)
+				val clipboardCopyId = ClipboardHelper.readCopyId(clipboard)
 				state.preserveCopiedRichSpansThroughNextEdit()
 				state.withAtomicEdit {
 					if (curSelection != null) {
@@ -82,7 +83,12 @@ class ContextMenuActions(
 					} else {
 						state.insertStringAtCursor(text)
 					}
-					state.pasteRichSpans(insertPosition, text)
+					state.pasteRichSpans(
+						insertPosition,
+						text,
+						clipboardCopyId,
+						requireCopyIdMatch = ClipboardHelper.supportsCopyProvenance,
+					)
 					htmlDocument?.let { state.applyHtmlPasteBlocks(it, insertPosition, text) }
 				}
 				state.selector.clearSelection()

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
@@ -130,9 +130,9 @@ internal class TextEditorKeyCommandHandler(
 	private fun handleCopy(state: TextEditorState, clipboard: Clipboard, scope: CoroutineScope) {
 		state.selector.selection?.let { selection ->
 			val selectedText = state.selector.getSelectedText()
-			state.copyRichSpans(selection)
+			val copyId = state.copyRichSpans(selection)
 			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration)
+				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
 			}
 		}
 	}
@@ -140,11 +140,11 @@ internal class TextEditorKeyCommandHandler(
 	private fun handleCut(state: TextEditorState, clipboard: Clipboard, scope: CoroutineScope) {
 		state.selector.selection?.let { selection ->
 			val selectedText = state.selector.getSelectedText()
-			state.copyRichSpans(selection)
+			val copyId = state.copyRichSpans(selection)
 			state.preserveCopiedRichSpansThroughNextEdit()
 			state.selector.deleteSelection()
 			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration)
+				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
 			}
 		}
 	}
@@ -157,6 +157,7 @@ internal class TextEditorKeyCommandHandler(
 				// Read the clipboard's HTML before mutating: the text, the in-editor
 				// rich spans and the pasted block structure then land as one revision.
 				val htmlDocument = state.readHtmlPasteDocument(clipboard, text)
+				val clipboardCopyId = ClipboardHelper.readCopyId(clipboard)
 				state.preserveCopiedRichSpansThroughNextEdit()
 				state.withAtomicEdit {
 					if (curSelection != null) {
@@ -164,7 +165,12 @@ internal class TextEditorKeyCommandHandler(
 					} else {
 						state.insertStringAtCursor(text)
 					}
-					state.pasteRichSpans(insertPosition, text)
+					state.pasteRichSpans(
+						insertPosition,
+						text,
+						clipboardCopyId,
+						requireCopyIdMatch = ClipboardHelper.supportsCopyProvenance,
+					)
 					htmlDocument?.let { state.applyHtmlPasteBlocks(it, insertPosition, text) }
 				}
 				state.selector.clearSelection()

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditHistory.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditHistory.kt
@@ -152,7 +152,9 @@ data class PreservedRichSpan(
 
 data class CopiedRichSpans(
 	val text: String,
-	val spans: List<PreservedRichSpan>
+	val spans: List<PreservedRichSpan>,
+	/** Identifies the copy that filled this buffer; pasted clipboard content must prove it. */
+	val copyId: Long,
 )
 
 data class OperationMetadata(

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -1187,9 +1187,11 @@ class TextEditorState(
 	/**
 	 * Remembers the rich spans (ordered/bullet list, blockquote, etc.) within
 	 * [range] so a subsequent [pasteRichSpans] can restore them. Call from the
-	 * copy/cut handlers alongside writing the text to the system clipboard.
+	 * copy/cut handlers alongside writing the text to the system clipboard, and
+	 * attach the returned copy id to the clipboard content so paste can prove
+	 * the clipboard still holds this copy.
 	 */
-	fun copyRichSpans(range: TextEditorRange) {
+	fun copyRichSpans(range: TextEditorRange): Long {
 		// getSpansInRange returns spans that merely OVERLAP the copy range. A span
 		// starting before range.start (partial selection of a list item, or a
 		// multi-line span only partly covered) would yield a negative relative
@@ -1214,11 +1216,13 @@ class TextEditorState(
 				style = span.style
 			)
 		}
+		val copyId = nextCopyId++
 		copiedRichSpans = if (preserved.isEmpty()) {
 			null
 		} else {
-			CopiedRichSpans(text = getStringInRange(range), spans = preserved)
+			CopiedRichSpans(text = getStringInRange(range), spans = preserved, copyId = copyId)
 		}
+		return copyId
 	}
 
 	/**
@@ -1246,18 +1250,23 @@ class TextEditorState(
 
 	/**
 	 * Re-applies the rich spans captured by [copyRichSpans] at [insertPosition].
-	 * No-op unless [pastedText] matches the text that was copied. The text match
-	 * is a secondary guard; the primary protection against stale spans is
-	 * [invalidateCopiedRichSpans], which clears the buffer on any intervening edit.
-	 *
-	 * Residual limitation: if the user copies identical text from another app with
-	 * no editor edit in between, the text match still succeeds and the in-editor
-	 * spans apply. Fully closing this needs platform-clipboard ownership tracking,
-	 * which is out of scope here.
+	 * No-op unless [pastedText] matches the text that was copied, and, when
+	 * [requireCopyIdMatch] is set, unless [clipboardCopyId] proves the clipboard
+	 * still holds the copy that filled the buffer. Platforms whose clipboard
+	 * carries a copy id pass both, so identical text written by another
+	 * application can never resurrect stale spans; plain-text-only clipboards
+	 * fall back to the text match, guarded by [invalidateCopiedRichSpans]
+	 * clearing the buffer on any intervening edit.
 	 */
-	fun pasteRichSpans(insertPosition: CharLineOffset, pastedText: AnnotatedString) = withAtomicEdit {
+	fun pasteRichSpans(
+		insertPosition: CharLineOffset,
+		pastedText: AnnotatedString,
+		clipboardCopyId: Long? = null,
+		requireCopyIdMatch: Boolean = false,
+	) = withAtomicEdit {
 		val copied = copiedRichSpans ?: return@withAtomicEdit
 		if (copied.text != pastedText.text) return@withAtomicEdit
+		if (requireCopyIdMatch && clipboardCopyId != copied.copyId) return@withAtomicEdit
 		copied.spans.forEach { preserved ->
 			val startPos = CharLineOffset(
 				line = insertPosition.line + preserved.relativeStart.lineDiff,
@@ -1400,3 +1409,7 @@ class TextEditorState(
 		return 31 + textLines.hashCode()
 	}
 }
+
+// Process-wide so two editors in one window can never mint the same id; copies
+// only happen on the UI thread, so a plain increment is race-free in practice.
+private var nextCopyId: Long = 1L

--- a/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.desktop.kt
+++ b/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.desktop.kt
@@ -14,6 +14,7 @@ import java.awt.datatransfer.UnsupportedFlavorException
 @OptIn(ExperimentalComposeUiApi::class)
 actual object ClipboardHelper {
 	private val annotatedStringFlavor = DataFlavor(AnnotatedString::class.java, "AnnotatedString")
+	internal val copyIdFlavor = DataFlavor(java.lang.Long::class.java, "ComposeTextEditorCopyId")
 
 	actual suspend fun getText(
 		clipboard: Clipboard,
@@ -29,9 +30,20 @@ actual object ClipboardHelper {
 		clipboard: Clipboard,
 		text: AnnotatedString,
 		configuration: MarkdownConfiguration,
+		copyId: Long?,
 	) {
-		clipboard.setClipEntry(ClipEntry(AnnotatedStringTransferable(text, configuration)))
+		clipboard.setClipEntry(ClipEntry(AnnotatedStringTransferable(text, configuration, copyId)))
 	}
+
+	actual suspend fun readCopyId(clipboard: Clipboard): Long? {
+		val transferable = clipboard.getClipEntry()?.nativeClipEntry as? Transferable ?: return null
+		return runCatching {
+			if (!transferable.isDataFlavorSupported(copyIdFlavor)) return null
+			transferable.getTransferData(copyIdFlavor) as? Long
+		}.getOrNull()
+	}
+
+	actual val supportsCopyProvenance: Boolean get() = true
 
 	private fun Transferable.readAnnotatedString(): AnnotatedString? = runCatching {
 		if (!isDataFlavorSupported(annotatedStringFlavor)) return null
@@ -58,10 +70,14 @@ actual object ClipboardHelper {
  * Offers the selection as HTML, as an in-process [AnnotatedString], and as plain
  * text. External applications take the HTML and keep the formatting; another
  * editor in this process takes the [AnnotatedString] and keeps it exactly.
+ * [copyId] identifies the copy that produced this content: pasting consults it
+ * before re-applying the in-editor rich-span buffer, so identical text written
+ * by any other source can never resurrect stale spans.
  */
 internal class AnnotatedStringTransferable(
 	private val annotatedString: AnnotatedString,
 	private val configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT,
+	private val copyId: Long? = null,
 ) : Transferable {
 
 	private val annotatedStringFlavor = DataFlavor(AnnotatedString::class.java, "AnnotatedString")
@@ -69,8 +85,12 @@ internal class AnnotatedStringTransferable(
 
 	private val html by lazy { annotatedString.toHtml(configuration) }
 
-	override fun getTransferDataFlavors(): Array<DataFlavor> =
-		arrayOf(annotatedStringFlavor, htmlFlavor, DataFlavor.stringFlavor)
+	override fun getTransferDataFlavors(): Array<DataFlavor> = buildList {
+		add(annotatedStringFlavor)
+		add(htmlFlavor)
+		add(DataFlavor.stringFlavor)
+		if (copyId != null) add(ClipboardHelper.copyIdFlavor)
+	}.toTypedArray()
 
 	override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
 		transferDataFlavors.any { it.match(flavor) }
@@ -78,6 +98,7 @@ internal class AnnotatedStringTransferable(
 	override fun getTransferData(flavor: DataFlavor): Any = when {
 		flavor.match(annotatedStringFlavor) -> annotatedString
 		flavor.match(htmlFlavor) -> html
+		copyId != null && flavor.match(ClipboardHelper.copyIdFlavor) -> copyId
 		flavor.match(DataFlavor.stringFlavor) -> annotatedString.text
 		else -> throw UnsupportedFlavorException(flavor)
 	}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/PasteOverSelectionTortureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/torture/PasteOverSelectionTortureE2eTest.kt
@@ -1,8 +1,11 @@
 package e2e.torture
 
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.clipboard.AnnotatedStringTransferable
 import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
 import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
 import utils.assertRichSpanInvariants
@@ -196,13 +199,39 @@ class PasteOverSelectionTortureE2eTest {
 		press(Key.V, ctrl = true)
 
 		assertEquals(listOf("item", "plainitem"), lines)
-		// Documented residual limitation: identical text from a foreign source with no
-		// intervening edit still matches the in-editor buffer and re-applies its spans.
+		// Foreign clipboard content carries no copy id, so the span buffer must not
+		// apply no matter how exactly the text matches.
 		assertEquals(
 			setOf<String>(),
 			blockFlags(1),
 			"plain text from another application must never arrive styled",
 		)
+		assertRichSpanInvariants()
+	}
+
+	@OptIn(ExperimentalComposeUiApi::class)
+	@Test
+	fun `a copy from another editor instance must not resurrect this buffer`() = editorUiTest {
+		markdown.importMarkdown("- item\nplain")
+
+		selectChars(0, 4)
+		press(Key.C, ctrl = true)
+		clipboard.seed(
+			ClipEntry(
+				AnnotatedStringTransferable(
+					AnnotatedString("item"),
+					state.markdownConfiguration,
+					copyId = 999_999L,
+				)
+			)
+		)
+		press(Key.MoveEnd, ctrl = true)
+		press(Key.V, ctrl = true)
+
+		assertEquals(listOf("item", "plainitem"), lines)
+		// The other instance's copy id does not match this buffer's, so its text
+		// pastes rich via its own flavors but this editor's stale spans stay dead.
+		assertEquals(setOf<String>(), blockFlags(1))
 		assertRichSpanInvariants()
 	}
 }

--- a/ComposeTextEditor/src/iosMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.ios.kt
+++ b/ComposeTextEditor/src/iosMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.ios.kt
@@ -23,7 +23,12 @@ actual object ClipboardHelper {
 		clipboard: Clipboard,
 		text: AnnotatedString,
 		configuration: MarkdownConfiguration,
+		copyId: Long?,
 	) {
 		UIPasteboard.generalPasteboard.string = text.text
 	}
+
+	actual suspend fun readCopyId(clipboard: Clipboard): Long? = null
+
+	actual val supportsCopyProvenance: Boolean get() = false
 }

--- a/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.wasmJs.kt
+++ b/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.wasmJs.kt
@@ -27,6 +27,7 @@ actual object ClipboardHelper {
 		clipboard: Clipboard,
 		text: AnnotatedString,
 		configuration: MarkdownConfiguration,
+		copyId: Long?,
 	) {
 		try {
 			writeClipboardText(text.text).await<JsAny?>()
@@ -34,6 +35,10 @@ actual object ClipboardHelper {
 			// Clipboard access may be denied or unavailable
 		}
 	}
+
+	actual suspend fun readCopyId(clipboard: Clipboard): Long? = null
+
+	actual val supportsCopyProvenance: Boolean get() = false
 }
 
 // Top-level external functions for browser clipboard API


### PR DESCRIPTION
Follow-on to #64, based on #78. Closes the last mechanical entry in the torture ledger — the documented `CopiedRichSpans` residual limitation.

## Defect

`pasteRichSpans` guarded the in-editor rich-span buffer with a text comparison: if another application wrote the *identical string* to the clipboard with no intervening editor edit, paste re-applied this editor's stale spans to foreign content. Pinned red by `a foreign paste matching the copy buffer must not resurrect spans`.

## Design

Provenance by clipboard flavor rather than AWT ownership callbacks (deterministic, no platform quirks, works with the in-memory test clipboard):

- Every copy/cut mints a process-unique `copyId`; `AnnotatedStringTransferable` offers it as its own `DataFlavor` alongside the AnnotatedString/HTML/plain flavors, and `CopiedRichSpans` remembers the id it was filled under.
- Paste reads the clipboard's copy id and, on platforms whose clipboard can carry one (`ClipboardHelper.supportsCopyProvenance`, desktop), applies the buffer only when the ids match. Foreign applications never write the flavor; a different editor instance writes a different id; both fail closed.
- Plain-text-only platforms (Android, iOS, wasm) cannot carry the id and keep the existing text-match behavior — their in-app rich copy/paste depends on it, and the buffer invalidation on any intervening edit still guards it.

## Tests

- Flips green: `a foreign paste matching the copy buffer must not resurrect spans`.
- New: `a copy from another editor instance must not resurrect this buffer` — a transferable carrying the same text under a different copy id pastes without applying this editor's spans.
- In-editor rich copy/paste is unchanged (the buffer round-trip tests and `re-copying a pasted list` stay green).
- Full `desktopTest`: 902 tests, 1 red — the link pin owned by the in-flight #76 branch. Android, wasm, and iosArm64 mains compile.

Stacking note: this branch is intentionally the tail of the stack; once `fix/semantic-links` lands I'll rebase it on top so the chain stays linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)