### PR TITLE
Give links semantic identity and stop fabricating them from underlines

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
@@ -2,6 +2,8 @@ package com.darkrockstudios.texteditor.markdown
 
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.richstyle.Blockquote
 import com.darkrockstudios.texteditor.richstyle.BulletList
 import com.darkrockstudios.texteditor.richstyle.CodeFence
@@ -11,6 +13,7 @@ import com.darkrockstudios.texteditor.richstyle.IMAGE_PLACEHOLDER
 import com.darkrockstudios.texteditor.richstyle.ImageBlockSpanStyle
 import com.darkrockstudios.texteditor.richstyle.ImageProvider
 import com.darkrockstudios.texteditor.richstyle.LineBlockStyle
+import com.darkrockstudios.texteditor.richstyle.LinkSpanStyle
 import com.darkrockstudios.texteditor.richstyle.OrderedList
 import com.darkrockstudios.texteditor.richstyle.PlaceholderKind
 import com.darkrockstudios.texteditor.richstyle.allowedOn
@@ -20,6 +23,7 @@ import com.darkrockstudios.texteditor.richstyle.documentBlocksOf
 import com.darkrockstudios.texteditor.richstyle.hasLineBlock
 import com.darkrockstudios.texteditor.richstyle.headerBlock
 import com.darkrockstudios.texteditor.richstyle.lineBlockStyles
+import com.darkrockstudios.texteditor.richstyle.RichSpan
 import com.darkrockstudios.texteditor.richstyle.rebuildWithBlock
 import com.darkrockstudios.texteditor.richstyle.rebuildWithoutBlock
 import com.darkrockstudios.texteditor.state.TextEditorState
@@ -213,6 +217,9 @@ class MarkdownExtension(
 		val hrLines = blocks.horizontalRuleLines
 		val imageLines = blocks.imageLines
 		val codeFenceLines = blocks.linesFor(CodeFence)
+		val linkSpansByLine = content.richSpans
+			.filter { it.style is LinkSpanStyle }
+			.groupBy { it.range.start.line }
 
 		val annotated = content.getAllText()
 		val text = annotated.text
@@ -265,9 +272,25 @@ class MarkdownExtension(
 					val baked = registry.mapNotNull { block ->
 						block.textStyle?.takeIf { blocks.has(lineIndex, block) }
 					}
+					// Link spans live on the state, not in the AnnotatedString, so
+					// the serializer is handed this line's links in line-local
+					// character offsets.
+					val lineLength = end - cursor
+					val links = linkSpansByLine[lineIndex].orEmpty().mapNotNull { span ->
+						val start = span.range.start.char.coerceIn(0, lineLength)
+						val endChar = when (span.range.end.line) {
+							lineIndex -> span.range.end.char.coerceIn(start, lineLength)
+							else -> lineLength
+						}
+						if (endChar > start) {
+							(start until endChar) to (span.style as LinkSpanStyle).url
+						} else {
+							null
+						}
+					}
 					annotated.subSequence(cursor, end)
 						.withoutSpanStyles(baked)
-						.toMarkdown(markdownConfiguration)
+						.toMarkdown(markdownConfiguration, links)
 				}
 			}
 			// Fenced lines aren't subject to per-line block prefixes — code fences
@@ -359,7 +382,8 @@ class MarkdownExtension(
 			}
 		}
 		val processedMarkdown = processedLines.joinToString("\n")
-		val annotatedString = processedMarkdown.toAnnotatedStringFromMarkdown(markdownConfiguration)
+		val parsed = processedMarkdown.parseMarkdownWithLinks(markdownConfiguration)
+		val annotatedString = parsed.annotatedString
 		// setText publishes the text with no spans and applyDocumentBlocks attaches them
 		// afterwards. As one revision, so a concurrent export can't catch the document
 		// fully loaded but entirely unstyled.
@@ -370,8 +394,66 @@ class MarkdownExtension(
 				imageLines = imageLines.toMap(),
 				blockLines = blockHits + (CodeFence to codeFenceLineIndices),
 			)
+			attachLinkSpans(parsed.links, annotatedString.text)
 		}
 	}
+
+	/**
+	 * Attaches a [LinkSpanStyle] over each parsed link. Like
+	 * [applyDocumentBlocks] this goes through the direct span-manager path:
+	 * loading a document is not something the user should undo one link at a
+	 * time. Markdown links cannot span lines; a range that somehow does is
+	 * clamped to its first line.
+	 */
+	private fun attachLinkSpans(links: List<ParsedLink>, text: String) {
+		if (links.isEmpty()) return
+		val lineStarts = mutableListOf(0)
+		text.forEachIndexed { index, char ->
+			if (char == '\n') lineStarts += index + 1
+		}
+
+		fun lineOf(flat: Int): Int {
+			val found = lineStarts.binarySearch(flat)
+			return if (found >= 0) found else -found - 2
+		}
+
+		val spans = links.map { link ->
+			val line = lineOf(link.start)
+			val lineEnd = (lineStarts.getOrNull(line + 1)?.minus(1)) ?: text.length
+			RichSpan(
+				range = TextEditorRange(
+					start = CharLineOffset(line, link.start - lineStarts[line]),
+					end = CharLineOffset(line, link.end.coerceAtMost(lineEnd) - lineStarts[line]),
+				),
+				style = LinkSpanStyle(link.url),
+			)
+		}
+		editorState.richSpanManager.addRichSpans(spans)
+		editorState.updateBookKeeping()
+	}
+
+	/**
+	 * Makes [range] a hyperlink to [url]: bakes the configuration's link display
+	 * style over the text and attaches the [LinkSpanStyle] that carries the
+	 * destination through serialization. Both go through the undoable edit
+	 * pipeline as two recorded operations (the display style and the span), so
+	 * fully reverting a `setLink` takes two undo steps.
+	 */
+	fun setLink(range: TextEditorRange, url: String) {
+		editorState.withAtomicEdit {
+			editorState.addStyleSpan(range, markdownConfiguration.linkStyle)
+			editorState.addRichSpan(range, LinkSpanStyle(url))
+		}
+	}
+
+	/**
+	 * The destination URL of the link covering [position], or null when the
+	 * position is not inside a link.
+	 */
+	fun linkAt(position: CharLineOffset): String? =
+		editorState.richSpanManager.getRichSpansStartingOn(position.line)
+			.firstOrNull { it.style is LinkSpanStyle && it.containsPosition(position) }
+			?.let { (it.style as LinkSpanStyle).url }
 
 	/** Returns whether [line] is currently rendered as a blockquote. */
 	fun isBlockquote(line: Int): Boolean = editorState.hasLineBlock(line, Blockquote)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/SpanStyleSemantics.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/SpanStyleSemantics.kt
@@ -29,6 +29,3 @@ internal val SpanStyle.isCodeStyle: Boolean
 
 internal val SpanStyle.isStrikethroughStyle: Boolean
 	get() = textDecoration == TextDecoration.LineThrough
-
-internal val SpanStyle.isUnderlineStyle: Boolean
-	get() = textDecoration == TextDecoration.Underline

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/annotatedStringToMarkdown.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/annotatedStringToMarkdown.kt
@@ -8,9 +8,14 @@ import androidx.compose.ui.unit.TextUnit
 /**
  * Converts an AnnotatedString to a markdown string, handling supported markdown styles.
  * Only converts styles that match our supported markdown styles, dropping any unsupported styles.
+ *
+ * @param links Hyperlinks to emit, as text ranges (in this string's character
+ * offsets) paired with their destination URLs. Each becomes `[text](url)`,
+ * with the markers enclosing any emphasis inside the range.
  */
 fun AnnotatedString.toMarkdown(
-	configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT
+	configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT,
+	links: List<Pair<IntRange, String>> = emptyList(),
 ): String {
 	if (text.isEmpty()) return ""
 
@@ -88,12 +93,31 @@ fun AnnotatedString.toMarkdown(
 		}
 	}
 
+	// The destination is emitted verbatim inside `(...)`; a URL whose characters
+	// would terminate or corrupt the destination gets the CommonMark
+	// angle-bracket form instead.
+	links.forEach { (range, url) ->
+		val start = range.first.coerceAtLeast(0)
+		val end = (range.last + 1).coerceAtMost(text.length)
+		if (start >= end) return@forEach
+		val marker = StyleMarkerPair(
+			openMarker = "[",
+			closeMarker = "](${markdownLinkDestination(url)})",
+			isLink = true,
+		)
+		boundaries.add(StyleBoundary(start, true, marker, end - start))
+		boundaries.add(StyleBoundary(end, false, marker, end - start))
+	}
+
 	// Sort boundaries:
 	// 1. By index
 	// 2. For same index, close markers come before open markers
-	// 3. For same index and type, sort by run length (longer runs close first)
+	// 3. Link markers enclose inline emphasis sharing the boundary: a link
+	//    opens before and closes after any other marker at the same index
+	// 4. For same index and type, sort by run length (longer runs close first)
 	boundaries.sortWith(compareBy<StyleBoundary> { it.index }
 		.thenBy { it.isStart }
+		.thenBy { if (it.marker.isLink == it.isStart) 0 else 1 }
 		.thenByDescending { it.length })
 
 	val result = StringBuilder()
@@ -198,14 +222,21 @@ private fun getStyleMarker(
 		style.isItalicStyle -> StyleMarkerPair("*", "*")
 		style.isCodeStyle -> StyleMarkerPair("`", "`")
 		style.isStrikethroughStyle -> StyleMarkerPair("~~", "~~")
-		style.isUnderlineStyle -> StyleMarkerPair("[", "]()")
 		else -> null
 	}
 }
 
+/**
+ * The destination as it appears inside `(...)`: angle-bracketed when it holds
+ * a character CommonMark cannot take in a bare destination.
+ */
+private fun markdownLinkDestination(url: String): String =
+	if (url.any { it == ')' || it == ' ' || it == '\n' }) "<$url>" else url
+
 private data class StyleMarkerPair(
 	val openMarker: String,
-	val closeMarker: String
+	val closeMarker: String,
+	val isLink: Boolean = false,
 ) {
 	/** Emphasis delimiters; code spans and headers tolerate edge whitespace. */
 	val trimsWhitespaceEdges: Boolean

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/markdownToAnnotatedString.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/markdownToAnnotatedString.kt
@@ -12,6 +12,18 @@ import org.intellij.markdown.flavours.gfm.GFMTokenTypes
 import org.intellij.markdown.parser.MarkdownParser
 
 /**
+ * A hyperlink found during a parse: [start] until [end] are flat character
+ * offsets into the produced [AnnotatedString]'s text, [url] the destination.
+ */
+internal data class ParsedLink(val start: Int, val end: Int, val url: String)
+
+/** A parse's styled text together with the links found inside it. */
+internal class MarkdownParseResult(
+	val annotatedString: AnnotatedString,
+	val links: List<ParsedLink>,
+)
+
+/**
  * Parses this string as GitHub Flavored Markdown and renders it into a styled
  * [AnnotatedString].
  *
@@ -20,25 +32,37 @@ import org.intellij.markdown.parser.MarkdownParser
  */
 fun String.toAnnotatedStringFromMarkdown(
 	configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT
-): AnnotatedString {
+): AnnotatedString = parseMarkdownWithLinks(configuration).annotatedString
+
+/**
+ * Parses like [toAnnotatedStringFromMarkdown] but also reports every inline
+ * link's text range and destination, so an importer can attach the semantic
+ * link spans the [AnnotatedString] itself cannot carry.
+ */
+internal fun String.parseMarkdownWithLinks(
+	configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT
+): MarkdownParseResult {
 	val styles = MarkdownStyles(configuration)
 
 	val flavour = GFMFlavourDescriptor()
 	val parsedTree = MarkdownParser(flavour).buildMarkdownTreeFromString(this)
-	return buildAnnotatedString {
-		appendMarkdownChildren(this@toAnnotatedStringFromMarkdown, parsedTree, 0, styles)
+	val links = mutableListOf<ParsedLink>()
+	val annotated = buildAnnotatedString {
+		appendMarkdownChildren(this@parseMarkdownWithLinks, parsedTree, 0, styles, links)
 	}
+	return MarkdownParseResult(annotated, links)
 }
 
 internal fun AnnotatedString.Builder.appendMarkdownChildren(
 	original: String,
 	node: ASTNode,
 	startOffset: Int,
-	styles: MarkdownStyles
+	styles: MarkdownStyles,
+	links: MutableList<ParsedLink> = mutableListOf(),
 ) {
 	var childOffset = startOffset
 	node.children.forEach { child ->
-		appendMarkdownNode(original, child, childOffset, styles)
+		appendMarkdownNode(original, child, childOffset, styles, links)
 		childOffset += child.getTextInNode(original).length
 	}
 }
@@ -47,14 +71,15 @@ private fun AnnotatedString.Builder.appendMarkdownNode(
 	original: String,
 	node: ASTNode,
 	startOffset: Int,
-	styles: MarkdownStyles
+	styles: MarkdownStyles,
+	links: MutableList<ParsedLink>,
 ) {
 	val nodeText = node.getTextInNode(original).toString()
 
 	when (node.type) {
 		MarkdownElementTypes.PARAGRAPH -> {
 			pushStyle(styles.BASE_TEXT)
-			appendMarkdownChildren(original, node, startOffset, styles)
+			appendMarkdownChildren(original, node, startOffset, styles, links)
 			pop()
 		}
 
@@ -67,19 +92,19 @@ private fun AnnotatedString.Builder.appendMarkdownNode(
 
 		MarkdownElementTypes.EMPH -> {
 			pushStyle(styles.ITALICS)
-			appendStyledContent(node, original, startOffset, styles)
+			appendStyledContent(node, original, startOffset, styles, links)
 			pop()
 		}
 
 		MarkdownElementTypes.STRONG -> {
 			pushStyle(styles.BOLD)
-			appendStyledContent(node, original, startOffset, styles)
+			appendStyledContent(node, original, startOffset, styles, links)
 			pop()
 		}
 
 		GFMElementTypes.STRIKETHROUGH -> {
 			pushStyle(styles.STRIKETHROUGH)
-			appendStyledContent(node, original, startOffset, styles)
+			appendStyledContent(node, original, startOffset, styles, links)
 			pop()
 		}
 
@@ -126,23 +151,47 @@ private fun AnnotatedString.Builder.appendMarkdownNode(
 			pop()
 		}
 
-		MarkdownElementTypes.ATX_1 -> handleHeader(original, node, startOffset, 1, styles)
-		MarkdownElementTypes.ATX_2 -> handleHeader(original, node, startOffset, 2, styles)
-		MarkdownElementTypes.ATX_3 -> handleHeader(original, node, startOffset, 3, styles)
-		MarkdownElementTypes.ATX_4 -> handleHeader(original, node, startOffset, 4, styles)
-		MarkdownElementTypes.ATX_5 -> handleHeader(original, node, startOffset, 5, styles)
-		MarkdownElementTypes.ATX_6 -> handleHeader(original, node, startOffset, 6, styles)
+		MarkdownElementTypes.ATX_1 -> handleHeader(original, node, startOffset, 1, styles, links)
+		MarkdownElementTypes.ATX_2 -> handleHeader(original, node, startOffset, 2, styles, links)
+		MarkdownElementTypes.ATX_3 -> handleHeader(original, node, startOffset, 3, styles, links)
+		MarkdownElementTypes.ATX_4 -> handleHeader(original, node, startOffset, 4, styles, links)
+		MarkdownElementTypes.ATX_5 -> handleHeader(original, node, startOffset, 5, styles, links)
+		MarkdownElementTypes.ATX_6 -> handleHeader(original, node, startOffset, 6, styles, links)
 
 		MarkdownElementTypes.INLINE_LINK -> {
 			pushStyle(styles.LINK)
+			val textStart = length
+			var childOffset = startOffset
 			node.children.forEach { child ->
-				if (child.type.toString() == "Markdown:LINK_TEXT") {
-					val text = child.getTextInNode(original).toString()
-						.removeSurrounding("[", "]")
-					append(text)
+				if (child.type == MarkdownElementTypes.LINK_TEXT) {
+					// The first and last children are the bracket tokens; the
+					// nodes between them are the link text, styles and all.
+					var gcOffset = childOffset
+					child.children.forEachIndexed { i, gc ->
+						if (i != 0 && i != child.children.lastIndex) {
+							appendMarkdownNode(original, gc, gcOffset, styles, links)
+						}
+						gcOffset += gc.getTextInNode(original).length
+					}
 				}
+				childOffset += child.getTextInNode(original).length
 			}
+			val textEnd = length
 			pop()
+			// A bare destination parses as LINK_DESTINATION; the GFM flavour
+			// reads an angle-bracketed one as an AUTOLINK child instead. Both
+			// carry any angle brackets in the node text; the URL itself is
+			// what round-trips.
+			val url = node.children
+				.firstOrNull {
+					it.type == MarkdownElementTypes.LINK_DESTINATION ||
+						it.type == MarkdownElementTypes.AUTOLINK
+				}
+				?.getTextInNode(original)?.toString()
+				?.removeSurrounding("<", ">")
+			if (url != null && textEnd > textStart) {
+				links += ParsedLink(textStart, textEnd, url)
+			}
 		}
 
 		MarkdownElementTypes.ORDERED_LIST,
@@ -153,11 +202,11 @@ private fun AnnotatedString.Builder.appendMarkdownNode(
 			// recurse into children — no glyph injection — so the body text survives
 			// without spurious bullet characters leaking into the AnnotatedString.
 			// Ordered list numbering is a follow-up.
-			appendMarkdownChildren(original, node, startOffset, styles)
+			appendMarkdownChildren(original, node, startOffset, styles, links)
 		}
 
 		MarkdownElementTypes.LIST_ITEM -> {
-			appendMarkdownChildren(original, node, startOffset, styles)
+			appendMarkdownChildren(original, node, startOffset, styles, links)
 		}
 
 		MarkdownElementTypes.BLOCK_QUOTE -> {
@@ -165,7 +214,7 @@ private fun AnnotatedString.Builder.appendMarkdownNode(
 			// this branch only fires for blockquotes outside that pipeline (e.g. callers
 			// of toAnnotatedStringFromMarkdown directly). Recurse without injecting a
 			// literal `> ` marker so the body text isn't visually corrupted.
-			appendMarkdownChildren(original, node, startOffset, styles)
+			appendMarkdownChildren(original, node, startOffset, styles, links)
 		}
 
 		MarkdownTokenTypes.TEXT -> {
@@ -178,7 +227,7 @@ private fun AnnotatedString.Builder.appendMarkdownNode(
 		}
 
 		MarkdownElementTypes.MARKDOWN_FILE -> {
-			appendMarkdownChildren(original, node, startOffset, styles)
+			appendMarkdownChildren(original, node, startOffset, styles, links)
 		}
 
 		else -> {
@@ -186,7 +235,7 @@ private fun AnnotatedString.Builder.appendMarkdownNode(
 			if (nodeText.isNotEmpty()) {
 				append(nodeText.removeMarkdownEscapes())
 			} else {
-				appendMarkdownChildren(original, node, startOffset, styles)
+				appendMarkdownChildren(original, node, startOffset, styles, links)
 			}
 		}
 	}
@@ -196,7 +245,8 @@ private fun AnnotatedString.Builder.appendStyledContent(
 	node: ASTNode,
 	original: String,
 	startOffset: Int,
-	styles: MarkdownStyles
+	styles: MarkdownStyles,
+	links: MutableList<ParsedLink>,
 ) {
 	var currentText = StringBuilder()
 
@@ -220,7 +270,7 @@ private fun AnnotatedString.Builder.appendStyledContent(
 					append(currentText.toString().removeMarkdownEscapes())
 					currentText.clear()
 				}
-				appendMarkdownNode(original, child, startOffset, styles)
+				appendMarkdownNode(original, child, startOffset, styles, links)
 			}
 		}
 	}
@@ -236,7 +286,8 @@ private fun AnnotatedString.Builder.handleHeader(
 	node: ASTNode,
 	startOffset: Int,
 	level: Int,
-	styles: MarkdownStyles
+	styles: MarkdownStyles,
+	links: MutableList<ParsedLink>,
 ) {
 	// Apply the header style
 	pushStyle(styles.header(level))
@@ -267,14 +318,14 @@ private fun AnnotatedString.Builder.handleHeader(
 						return@forEach
 					}
 					seenContent = true
-					appendMarkdownNode(original, gc, contentOffset, styles)
+					appendMarkdownNode(original, gc, contentOffset, styles, links)
 					contentOffset += gc.getTextInNode(original).length
 				}
 			}
 
 			else -> {
 				// Process any other nested styles or text
-				appendMarkdownNode(original, child, startOffset, styles)
+				appendMarkdownNode(original, child, startOffset, styles, links)
 			}
 		}
 	}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LinkSpanStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LinkSpanStyle.kt
@@ -1,0 +1,37 @@
+package com.darkrockstudios.texteditor.richstyle
+
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
+import com.darkrockstudios.texteditor.LineWrap
+import com.darkrockstudios.texteditor.state.TextEditorState
+
+/**
+ * Marks a character range as a hyperlink to [url]. The span is the link's
+ * semantic identity: serializers read the destination from it instead of
+ * reverse-matching the underline decoration, so restyling the document cannot
+ * fabricate or destroy a link. The visual treatment is the configuration's
+ * link [androidx.compose.ui.text.SpanStyle] baked into the text; this span
+ * paints nothing itself.
+ *
+ * Host apps receive it through `onRichSpanClick` and can navigate with [url].
+ *
+ * Equality is by [url], so identical links over identical ranges dedupe in the
+ * span set.
+ */
+class LinkSpanStyle(val url: String) : RichSpanStyle {
+	override fun DrawScope.drawCustomStyle(
+		layoutResult: TextLayoutResult,
+		lineWrap: LineWrap,
+		textRange: TextRange,
+		state: TextEditorState,
+	) {
+	}
+
+	override fun equals(other: Any?): Boolean =
+		this === other || (other is LinkSpanStyle && url == other.url)
+
+	override fun hashCode(): Int = url.hashCode()
+
+	override fun toString(): String = "LinkSpanStyle(url=$url)"
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/EditorEdgeCasesE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/EditorEdgeCasesE2eTest.kt
@@ -9,10 +9,13 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.text.AnnotatedString
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
+import com.darkrockstudios.texteditor.richstyle.LinkSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpan
 import com.darkrockstudios.texteditor.state.SpanClickType
 import utils.editorUiTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /** Boundary conditions, disabled state, unicode, rich span clicks, and scrolling. */
@@ -116,6 +119,26 @@ class EditorEdgeCasesE2eTest {
 			clickAtCharacter(6)
 
 			assertEquals(SpanClickType.PRIMARY_CLICK, clickedType)
+		}
+	}
+
+	@Test
+	fun `clicking a link fires the callback with its span and url`() {
+		var clickedSpan: RichSpan? = null
+		editorUiTest(
+			onRichSpanClick = { span, type, _ ->
+				if (type == SpanClickType.PRIMARY_CLICK) clickedSpan = span
+				true
+			},
+		) {
+			markdown.importMarkdown("go to [site](https://example.com) now")
+			waitForIdle()
+
+			clickAtCharacter(8)
+
+			val style = clickedSpan?.style
+			assertIs<LinkSpanStyle>(style, "the click must deliver the link span")
+			assertEquals("https://example.com", style.url)
 		}
 	}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/LinkSemanticsTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/LinkSemanticsTest.kt
@@ -1,0 +1,166 @@
+package markdown
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.style.TextDecoration
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.LinkSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpan
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A link's identity is its [LinkSpanStyle]: import must attach it with the
+ * destination, export must read it back out, and plain formatting must never
+ * fabricate one.
+ */
+class LinkSemanticsTest {
+
+	private fun editor(markdown: String? = null): MarkdownExtension {
+		val state = TextEditorState(scope = TestScope(), measurer = mockk(relaxed = true))
+		return MarkdownExtension(state).apply { markdown?.let { importMarkdown(it) } }
+	}
+
+	private fun MarkdownExtension.linkSpans(): List<RichSpan> =
+		editorState.richSpanManager.getAllRichSpans()
+			.filter { it.style is LinkSpanStyle }
+			.sortedWith(compareBy({ it.range.start.line }, { it.range.start.char }))
+
+	private fun RichSpan.url(): String = (style as LinkSpanStyle).url
+
+	@Test
+	fun `import attaches a link span with its url and range`() {
+		val extension = editor("before [text](https://example.com) after")
+
+		assertEquals("before text after", extension.editorState.getAllText().text)
+		val span = extension.linkSpans().single()
+		assertEquals("https://example.com", span.url())
+		assertEquals(CharLineOffset(0, 7), span.range.start)
+		assertEquals(CharLineOffset(0, 11), span.range.end)
+	}
+
+	@Test
+	fun `export emits the link text and destination`() {
+		val extension = editor("before [text](https://example.com) after")
+
+		assertEquals("before [text](https://example.com) after", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `export import export is a fixpoint`() {
+		val extension = editor("intro [one](https://one.example) mid [two](https://two.example) outro")
+
+		val first = extension.exportAsMarkdown()
+		extension.importMarkdown(first)
+		val second = extension.exportAsMarkdown()
+
+		assertEquals(first, second)
+	}
+
+	@Test
+	fun `a url with parentheses and spaces round trips through angle brackets`() {
+		val url = "https://en.wikipedia.org/wiki/A (disambiguation)"
+		val extension = editor()
+		extension.editorState.setText("click here now")
+		extension.setLink(
+			TextEditorRange(CharLineOffset(0, 6), CharLineOffset(0, 10)),
+			url,
+		)
+
+		val exported = extension.exportAsMarkdown()
+		assertEquals("click [here](<$url>) now", exported)
+
+		extension.importMarkdown(exported)
+		assertEquals(url, extension.linkAt(CharLineOffset(0, 7)))
+		assertEquals(exported, extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `two links on one line both survive`() {
+		val extension = editor("[a](https://one.example) and [b](https://two.example)")
+
+		assertEquals("a and b", extension.editorState.getAllText().text)
+		val spans = extension.linkSpans()
+		assertEquals(2, spans.size)
+		assertEquals("https://one.example", spans[0].url())
+		assertEquals("https://two.example", spans[1].url())
+		assertEquals(
+			"[a](https://one.example) and [b](https://two.example)",
+			extension.exportAsMarkdown(),
+		)
+	}
+
+	@Test
+	fun `link text with bold inside round trips`() {
+		val extension = editor("[**b**old](https://u.example)")
+
+		assertEquals("bold", extension.editorState.getAllText().text)
+		val span = extension.linkSpans().single()
+		assertEquals(CharLineOffset(0, 0), span.range.start)
+		assertEquals(CharLineOffset(0, 4), span.range.end)
+		assertEquals("[**b**old](https://u.example)", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `underlined text without a link span exports as plain text`() {
+		val extension = editor()
+		extension.editorState.setText("plain words")
+		extension.editorState.addStyleSpan(
+			TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 5)),
+			SpanStyle(textDecoration = TextDecoration.Underline),
+		)
+
+		assertEquals("plain words", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `setLink applies the style and the span and reverts in two undo steps`() {
+		val extension = editor()
+		val state = extension.editorState
+		state.setText("click here")
+		extension.setLink(
+			TextEditorRange(CharLineOffset(0, 6), CharLineOffset(0, 10)),
+			"https://example.com",
+		)
+
+		assertEquals("https://example.com", extension.linkAt(CharLineOffset(0, 7)))
+		assertEquals("click [here](https://example.com)", extension.exportAsMarkdown())
+
+		// setLink records two operations (display style, then span), so a full
+		// revert is two undo steps.
+		state.undo()
+		state.undo()
+		assertTrue(extension.linkSpans().isEmpty(), "undo must remove the link span")
+		assertEquals("click here", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `typing inside a link grows the span`() {
+		val extension = editor("[text](https://example.com)")
+		val state = extension.editorState
+
+		state.cursor.updatePosition(CharLineOffset(0, 2))
+		state.insertStringAtCursor("XY")
+
+		val span = extension.linkSpans().single()
+		assertEquals(CharLineOffset(0, 0), span.range.start)
+		assertEquals(CharLineOffset(0, 6), span.range.end)
+		assertEquals("[teXYxt](https://example.com)", extension.exportAsMarkdown())
+	}
+
+	@Test
+	fun `deleting the whole link text removes the span`() {
+		val extension = editor("[text](https://example.com) tail")
+		val state = extension.editorState
+
+		state.delete(TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 4)))
+
+		assertTrue(extension.linkSpans().isEmpty(), "an emptied link must not linger")
+		assertEquals(" tail", extension.exportAsMarkdown())
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/MarkdownConverterTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/MarkdownConverterTest.kt
@@ -116,6 +116,20 @@ class MarkdownConverterTest {
 	}
 
 	@Test
+	fun `underlined text without a link span stays plain text`() {
+		val input = buildAnnotatedString {
+			append("Click ")
+			withStyle(SpanStyle(color = Color.Blue, textDecoration = TextDecoration.Underline)) {
+				append("here")
+			}
+			append(" to continue")
+		}
+		// Markdown has no underline; a link's identity is its LinkSpanStyle, so
+		// bare decoration must not fabricate an empty link.
+		assertEquals("Click here to continue", input.toMarkdown())
+	}
+
+	@Test
 	fun `test link conversion`() {
 		val input = buildAnnotatedString {
 			append("Click ")
@@ -124,7 +138,10 @@ class MarkdownConverterTest {
 			}
 			append(" to continue")
 		}
-		assertEquals("Click [here]() to continue", input.toMarkdown())
+		assertEquals(
+			"Click [here](https://example.com) to continue",
+			input.toMarkdown(links = listOf(6..9 to "https://example.com")),
+		)
 	}
 
 //	@Test


### PR DESCRIPTION
Follow-on to #64, stacked on #78. Closes #76 with the same semantic model headings got.

## Defects

1. Importing `[text](https://example.com)` styled the text and stored the URL nowhere; export emitted `[text]()`, destroying every link target on save/reload. Pinned red by `a link url survives a round trip`.
2. Export decided link-ness by matching the underline decoration, so any underlined text exported as `[text]()` — an empty link fabricated from formatting.

## Design

`LinkSpanStyle(url)` — a public, character-ranged, visually inert rich span — is the link's identity (the baked `linkStyle` keeps rendering):

- Import parses via a new internal `parseMarkdownWithLinks`, capturing destinations from the GFM AST (including angle-bracketed `(<url with space>)` forms, which the parser surfaces as autolink children) and attaching spans over the link text. Link text now keeps its inline styles (`[**b**old](url)` previously imported with literal asterisks).
- Export threads each line's link spans into `toMarkdown`, which emits `[` / `](url)` through the existing boundary mechanism with a sort tiebreak so link markers enclose emphasis at shared boundaries; URLs containing `)`, space, or newline are angle-bracketed; URLs are never markdown-escaped.
- The underline-means-link branch is deleted: underlined text without a span serializes as plain text (markdown has no underline).
- New API: `setLink(range, url)` (bakes the display style and attaches the span in one revision; two undo steps, documented) and `linkAt(position)`. Link spans reach `onRichSpanClick` like any rich span — covered by a new UI click test asserting the style and URL.
- Editing needs no new logic: link spans ride the existing rich-span transform machinery (typing inside grows the range, deleting the text removes the span — both pinned).

## Out of scope (noted, not regressed)

HTML never emitted or parsed `<a>` (underline maps to `<u>`), so there was no fabricated-link defect there; adding `<a href>` support is a feature beyond #76. Reference-style links untouched. A legacy `[text]()` now imports as styled text and exports as plain text instead of resurrecting an empty link.

## Tests

- Flips green: `a link url survives a round trip`.
- New `markdown/LinkSemanticsTest` (10): range+URL capture, `[text](url)` emission, fixpoint, hostile URLs, two links per line, bold-inside-link, underline-is-not-a-link, setLink+undo contract, span growth, span death.
- `MarkdownConverterTest > test link conversion` pinned defect 2 (underline exporting `[here]()`); split into the plain-text assertion and a real link-parameter test.
- Full `desktopTest`: 913 tests, 1 red — the foreign-paste entry, fixed by #79 which will be rebased onto this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)