### PR TITLE
Give TextEditorState identity equality; content comparison via contentEquals

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
@@ -162,23 +162,6 @@ class HtmlExtension(
 		}
 	}
 
-	override fun equals(other: Any?): Boolean {
-		if (this === other) return true
-		if (other == null || this::class != other::class) return false
-
-		other as HtmlExtension
-
-		if (editorState != other.editorState) return false
-		if (configuration != other.configuration) return false
-
-		return true
-	}
-
-	override fun hashCode(): Int {
-		var result = editorState.hashCode()
-		result = 31 * result + configuration.hashCode()
-		return result
-	}
 }
 
 /**

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
@@ -161,7 +161,6 @@ class HtmlExtension(
 			else -> "<p>$content</p>"
 		}
 	}
-
 }
 
 /**

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/markdown/MarkdownExtension.kt
@@ -523,24 +523,6 @@ class MarkdownExtension(
 	private fun toggleLineBlock(lines: IntRange, block: LineBlockStyle) {
 		editorState.editManager.toggleLineBlock(lines, block)
 	}
-
-	override fun equals(other: Any?): Boolean {
-		if (this === other) return true
-		if (other == null || this::class != other::class) return false
-
-		other as MarkdownExtension
-
-		if (editorState != other.editorState) return false
-		if (markdownConfiguration != other.markdownConfiguration) return false
-
-		return true
-	}
-
-	override fun hashCode(): Int {
-		var result = editorState.hashCode()
-		result = 31 * result + markdownConfiguration.hashCode()
-		return result
-	}
 }
 
 /**

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -1367,8 +1367,9 @@ class TextEditorState(
 	}
 
 	/**
-	 * Returns a hash of the document content (text and spans), suitable for cheaply
-	 * detecting whether the document has changed.
+	 * Returns a hash of the document text and inline character spans, suitable for
+	 * cheaply detecting whether the document has changed. Rich spans (headings,
+	 * links, line blocks) live outside [textLines] and do not affect the hash.
 	 */
 	fun computeTextHash(): Int {
 		var hash = 3
@@ -1380,7 +1381,9 @@ class TextEditorState(
 	}
 
 	/**
-	 * Returns true when [other] holds the same document content (text and spans).
+	 * Returns true when [other] holds the same document text and inline character
+	 * spans. Rich spans (headings, links, line blocks) live outside [textLines]
+	 * and are not compared.
 	 *
 	 * Equality on the state itself is reference identity: a mutable controller
 	 * object is not a value, and content-based equals/hashCode would make

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -1379,34 +1379,28 @@ class TextEditorState(
 		return hash
 	}
 
-	init {
-		setText(initialText ?: AnnotatedString(""))
-	}
-
-	override fun equals(other: Any?): Boolean {
-		if (this === other) return true
-		if (other == null || this::class != other::class) return false
-
-		other as TextEditorState
-
-		if (compareLines(textLines, other.textLines).not()) return false
-
-		return true
-	}
-
-	private fun compareLines(list1: List<AnnotatedString>, list2: List<AnnotatedString>): Boolean {
-		if (list1 === list2) return true
-		if (list1.size != list2.size) return false
-		for (i in list1.indices) {
-			if (list1[i] != list2[i]) {
+	/**
+	 * Returns true when [other] holds the same document content (text and spans).
+	 *
+	 * Equality on the state itself is reference identity: a mutable controller
+	 * object is not a value, and content-based equals/hashCode would make
+	 * instances unusable as keys in hash-keyed collections or `remember` keys.
+	 */
+	fun contentEquals(other: TextEditorState): Boolean {
+		val mine = textLines
+		val theirs = other.textLines
+		if (mine === theirs) return true
+		if (mine.size != theirs.size) return false
+		for (i in mine.indices) {
+			if (mine[i] != theirs[i]) {
 				return false
 			}
 		}
 		return true
 	}
 
-	override fun hashCode(): Int {
-		return 31 + textLines.hashCode()
+	init {
+		setText(initialText ?: AnnotatedString(""))
 	}
 }
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/MarkdownExtensionEqualityTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/MarkdownExtensionEqualityTest.kt
@@ -10,9 +10,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 
 class MarkdownExtensionEqualityTest {
 
@@ -32,86 +30,30 @@ class MarkdownExtensionEqualityTest {
 	}
 
 	@Test
-	fun `test equals same object reference`() = runTest {
-		val extension = createMarkdownExtension("")
+	fun `equals is reference identity`() = runTest {
+		val extension = createMarkdownExtension("# Header")
 		assertEquals(extension, extension)
 	}
 
 	@Test
-	fun `test equals null object`() = runTest {
-		val extension = createMarkdownExtension("")
-		assertFalse(extension.equals(null))
-	}
-
-	@Test
-	fun `test equals different type`() = runTest {
-		val extension = createMarkdownExtension("")
-		assertFalse(extension.equals("not a MarkdownExtension"))
-	}
-
-	@Test
-	fun `test equals same content and configuration`() = runTest {
+	fun `distinct instances with same content are not equal`() = runTest {
 		val text = "# Header\nSome content"
-		val config = MarkdownConfiguration.DEFAULT
+		val extension1 = createMarkdownExtension(text)
+		val extension2 = createMarkdownExtension(text)
 
-		val extension1 = createMarkdownExtension(text, config)
-		val extension2 = createMarkdownExtension(text, config)
-
-		assertTrue(extension1 == extension2)
+		assertNotEquals(extension1, extension2)
 	}
 
 	@Test
-	fun `test equals different content same configuration`() = runTest {
-		val extension1 = createMarkdownExtension("# Header 1")
-		val extension2 = createMarkdownExtension("# Different Header")
+	fun `hashCode is stable across edits and configuration changes`() = runTest {
+		val extension = createMarkdownExtension("# Header")
+		val before = extension.hashCode()
 
-		assertFalse(extension1 == extension2)
-	}
-
-	@Test
-	fun `test equals same content different configuration`() = runTest {
-		val text = "# Header"
-		val config1 = MarkdownConfiguration.DEFAULT
-		val config2 = MarkdownConfiguration.DEFAULT.copy(
+		extension.editorState.setText("entirely new content")
+		extension.markdownConfiguration = MarkdownConfiguration.DEFAULT.copy(
 			header1Style = MarkdownConfiguration.DEFAULT.header1Style.copy(color = Color.Red)
 		)
 
-		val extension1 = createMarkdownExtension(text, config1)
-		val extension2 = createMarkdownExtension(text, config2)
-
-		assertFalse(extension1 == extension2)
-	}
-
-	@Test
-	fun `test hashCode consistency`() = runTest {
-		val text = "# Header\nSome content"
-		val config = MarkdownConfiguration.DEFAULT
-
-		val extension1 = createMarkdownExtension(text, config)
-		val extension2 = createMarkdownExtension(text, config)
-
-		assertEquals(extension1.hashCode(), extension2.hashCode())
-	}
-
-	@Test
-	fun `test hashCode different content`() = runTest {
-		val extension1 = createMarkdownExtension("# Header 1")
-		val extension2 = createMarkdownExtension("# Different Header")
-
-		assertNotEquals(extension1.hashCode(), extension2.hashCode())
-	}
-
-	@Test
-	fun `test hashCode different configuration`() = runTest {
-		val text = "# Header"
-		val config1 = MarkdownConfiguration.DEFAULT
-		val config2 = MarkdownConfiguration.DEFAULT.copy(
-			header1Style = MarkdownConfiguration.DEFAULT.header1Style.copy(color = Color.Red)
-		)
-
-		val extension1 = createMarkdownExtension(text, config1)
-		val extension2 = createMarkdownExtension(text, config2)
-
-		assertNotEquals(extension1.hashCode(), extension2.hashCode())
+		assertEquals(before, extension.hashCode())
 	}
 }

--- a/ComposeTextEditor/src/desktopTest/kotlin/texteditor/state/TextEditorStateEqualityTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/texteditor/state/TextEditorStateEqualityTest.kt
@@ -21,73 +21,85 @@ class TextEditorStateEqualityTest {
 		)
 
 	@Test
-	fun `test equals same object reference`() = runTest {
-		val state = createState("")
+	fun `equals is reference identity`() = runTest {
+		val state = createState("content")
 		assertEquals(state, state)
 	}
 
 	@Test
-	fun `test equals null object`() = runTest {
-		val state = createState("")
-		assertFalse(state.equals(null))
+	fun `distinct instances with same content are not equal`() = runTest {
+		val state1 = createState("Line 1\nLine 2")
+		val state2 = createState("Line 1\nLine 2")
+
+		assertNotEquals(state1, state2)
 	}
 
 	@Test
-	fun `test equals different type`() = runTest {
-		val state = createState("")
-		assertFalse(state.equals("not a TextEditorState"))
+	fun `hashCode is stable across edits`() = runTest {
+		val state = createState("Line 1")
+		val before = state.hashCode()
+
+		state.setText("completely different content\nwith more lines")
+
+		assertEquals(before, state.hashCode())
 	}
 
 	@Test
-	fun `test equals same content`() = runTest {
-		val lines = listOf(
-			"Line 1",
-			"Line 2"
-		)
+	fun `instances are usable as hash keys`() = runTest {
+		val state1 = createState("same")
+		val state2 = createState("same")
 
-		// Add same content to both states
-		val state1 = createState(lines.joinToString("\n"))
-		val state2 = createState(lines.joinToString("\n"))
+		val map = HashMap<TextEditorState, String>()
+		map[state1] = "first"
+		map[state2] = "second"
 
-		assertTrue(state1 == state2)
+		assertEquals(2, map.size)
+		assertEquals("first", map[state1])
+		assertEquals("second", map[state2])
+
+		state1.setText("edited")
+		assertEquals("first", map[state1])
 	}
 
 	@Test
-	fun `test equals different content`() = runTest {
+	fun `contentEquals same instance`() = runTest {
+		val state = createState("content")
+		assertTrue(state.contentEquals(state))
+	}
+
+	@Test
+	fun `contentEquals same content`() = runTest {
+		val state1 = createState("Line 1\nLine 2")
+		val state2 = createState("Line 1\nLine 2")
+
+		assertTrue(state1.contentEquals(state2))
+		assertTrue(state2.contentEquals(state1))
+	}
+
+	@Test
+	fun `contentEquals different content`() = runTest {
 		val state1 = createState("Line 1")
 		val state2 = createState("Different line")
 
-		assertFalse(state1 == state2)
+		assertFalse(state1.contentEquals(state2))
 	}
 
 	@Test
-	fun `test equals different number of lines`() = runTest {
+	fun `contentEquals different number of lines`() = runTest {
 		val state1 = createState("Line 1")
 		val state2 = createState("Line 1\nLine 2")
 
-		assertFalse(state1 == state2)
+		assertFalse(state1.contentEquals(state2))
 	}
 
 	@Test
-	fun `test hashCode consistency`() = runTest {
-		val lines = listOf(
-			"Line 1",
-			"Line 2"
-		)
+	fun `contentEquals diverges after an edit`() = runTest {
+		val state1 = createState("shared")
+		val state2 = createState("shared")
+		assertTrue(state1.contentEquals(state2))
 
-		val state1 = createState(lines.joinToString("\n"))
-		val state2 = createState(lines.joinToString("\n"))
+		state1.setText("changed")
 
-		// Equal objects should have equal hash codes
-		assertEquals(state1.hashCode(), state2.hashCode())
-	}
-
-	@Test
-	fun `test hashCode different content`() = runTest {
-		val state1 = createState("Line 1")
-		val state2 = createState("Different line")
-
-		// Different content should (likely) have different hash codes
-		assertNotEquals(state1.hashCode(), state2.hashCode())
+		assertFalse(state1.contentEquals(state2))
 	}
 }


### PR DESCRIPTION
Fixes #81.

`TextEditorState` overrode `equals`/`hashCode` to compare document content, so two independent editors with the same text were "equal" and an instance's hash changed on every keystroke. That made instances unusable as keys in any hash-keyed collection or as `remember` keys; the e2e harness's `WeakHashMap` flaps (root-caused in the #64 stack) were one symptom. The library itself keys `remember(state, ...)` in `BasicTextEditor` and `RichTextView`, where content equality could silently keep input bound to a stale state instance after swapping in a new one with identical content.

Changes:
- `TextEditorState` drops the overrides and inherits reference equality. Content comparison moves to an explicit `contentEquals(other)`.
- `MarkdownExtension` and `HtmlExtension` drop their overrides too: they only delegated to the state's content equality and mix in a mutable `var configuration`, so they had the same unstable-key problem.
- Equality tests rewritten for identity semantics: distinct same-content instances are not equal, hash codes stay stable across edits and config changes, instances work as `HashMap` keys through mutation, and `contentEquals` covers the content-comparison cases.

No internal hash-keyed uses of these types remain (audited per the issue).