### PR TITLE
Index rich spans by covered line

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/DocumentSnapshot.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/DocumentSnapshot.kt
@@ -19,12 +19,12 @@ class DocumentSnapshot private constructor(
 	/** Every rich span in the document, its ranges addressing [lines]. */
 	val richSpans: Set<RichSpan>,
 	/**
-	 * Backs [richSpansByStartLine]. Held as the [Lazy] rather than the map so
+	 * Backs [richSpansByLine]. Held as the [Lazy] rather than the map so
 	 * [withLines] can hand the same one to the revision it produces, which keeps the
 	 * memoized index alive across a text-only edit. Sharing it also carries the
 	 * `PUBLICATION` safety over, where a plain field would publish the map unsafely.
 	 */
-	private val spansByStartLine: Lazy<Map<Int, List<RichSpan>>>,
+	private val spansByLine: Lazy<Map<Int, List<RichSpan>>>,
 	/**
 	 * Backs [lineStartOffsets]. Held as the [Lazy] for the same reasons as
 	 * [spansByStartLine], and shared with the revision [withRichSpans] produces
@@ -35,18 +35,17 @@ class DocumentSnapshot private constructor(
 	internal constructor(lines: List<AnnotatedString>, richSpans: Set<RichSpan>) : this(
 		lines = lines,
 		richSpans = richSpans,
-		spansByStartLine = lazy(LazyThreadSafetyMode.PUBLICATION) {
-			richSpans.groupBy { it.range.start.line }
-		},
+		spansByLine = spansByLineOf(richSpans),
 		lineStarts = lineStartsOf(lines),
 	)
 
 	/**
-	 * [richSpans] grouped by the line each one starts on. Built on first read and
-	 * reused until a revision changes the spans, so the line-anchored block queries
-	 * cost a map lookup instead of a scan of every span in the document.
+	 * [richSpans] grouped by every line each one covers; a multi-line span appears
+	 * under each of its lines. Built on first read and reused until a revision
+	 * changes the spans, so the per-line queries the layout pass runs once per
+	 * visual line cost a map lookup instead of a scan of every span in the document.
 	 */
-	internal val richSpansByStartLine: Map<Int, List<RichSpan>> get() = spansByStartLine.value
+	internal val richSpansByLine: Map<Int, List<RichSpan>> get() = spansByLine.value
 
 	/**
 	 * Flat character index at which each line starts, counting one newline between
@@ -74,17 +73,26 @@ class DocumentSnapshot private constructor(
 	 * start on are the same ones they started on before.
 	 */
 	internal fun withLines(lines: List<AnnotatedString>) =
-		DocumentSnapshot(lines, richSpans, spansByStartLine, lineStartsOf(lines))
+		DocumentSnapshot(lines, richSpans, spansByLine, lineStartsOf(lines))
 
 	internal fun withRichSpans(richSpans: Set<RichSpan>) = DocumentSnapshot(
 		lines = lines,
 		richSpans = richSpans,
-		spansByStartLine = lazy(LazyThreadSafetyMode.PUBLICATION) {
-			richSpans.groupBy { it.range.start.line }
-		},
+		spansByLine = spansByLineOf(richSpans),
 		lineStarts = lineStarts,
 	)
 }
+
+private fun spansByLineOf(richSpans: Set<RichSpan>): Lazy<Map<Int, List<RichSpan>>> =
+	lazy(LazyThreadSafetyMode.PUBLICATION) {
+		val byLine = mutableMapOf<Int, MutableList<RichSpan>>()
+		for (span in richSpans) {
+			for (line in span.range.start.line..span.range.end.line) {
+				byLine.getOrPut(line) { mutableListOf() }.add(span)
+			}
+		}
+		byLine
+	}
 
 private fun lineStartsOf(lines: List<AnnotatedString>): Lazy<IntArray> =
 	lazy(LazyThreadSafetyMode.PUBLICATION) {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/RichSpanManager.kt
@@ -31,7 +31,11 @@ class RichSpanManager(
 	 * carrying thousands of spans.
 	 */
 	internal fun getRichSpansStartingOn(line: Int): List<RichSpan> =
-		state.workingContent.richSpansByStartLine[line] ?: emptyList()
+		spansOnLine(line).filter { it.range.start.line == line }
+
+	/** Every span covering [line], from the snapshot's memoized per-line index. */
+	private fun spansOnLine(line: Int): List<RichSpan> =
+		state.workingContent.richSpansByLine[line] ?: emptyList()
 
 	internal fun addRichSpan(range: TextEditorRange, style: RichSpanStyle) {
 		spans = spans + RichSpan(range, style)
@@ -119,27 +123,40 @@ class RichSpanManager(
 	}
 
 	fun getSpansForLineWrap(lineWrap: LineWrap): List<RichSpan> {
-		return spans.filter { it.intersectsWith(lineWrap) }
+		// The layout pass runs this once per visual line; the per-line index keeps
+		// each call proportional to the spans on that line, not in the document.
+		return spansOnLine(lineWrap.line).filter { it.intersectsWith(lineWrap) }
 	}
 
 	fun updateSpans(operation: TextEditOperation, metadata: OperationMetadata?) {
-		val updatedSpans = mutableSetOf<RichSpan>()
+		// Span-only operations move no text, so every existing span keeps its range
+		// verbatim; only the shared clamp and duplicate-merge passes apply.
+		val updatedSpans = when (operation) {
+			is TextEditOperation.StyleSpan,
+			is TextEditOperation.RichSpan,
+			is TextEditOperation.LineBlock -> spans
 
-		spans.forEach { span ->
-			span.range.apply {
-				when (operation) {
-					is TextEditOperation.Insert -> handleInsert(operation, updatedSpans, span)
-					is TextEditOperation.Delete -> handleDelete(
-						metadata,
-						operation,
-						updatedSpans,
-						span
-					)
-					is TextEditOperation.Replace -> handleReplace(operation, updatedSpans, span)
-					is TextEditOperation.StyleSpan -> handleSpanOnly(updatedSpans, span)
-					is TextEditOperation.RichSpan -> handleSpanOnly(updatedSpans, span)
-					is TextEditOperation.LineBlock -> handleSpanOnly(updatedSpans, span)
+			is TextEditOperation.Insert,
+			is TextEditOperation.Delete,
+			is TextEditOperation.Replace -> {
+				val transformed = mutableSetOf<RichSpan>()
+				spans.forEach { span ->
+					span.range.apply {
+						when (operation) {
+							is TextEditOperation.Insert ->
+								handleInsert(operation, transformed, span)
+
+							is TextEditOperation.Delete ->
+								handleDelete(metadata, operation, transformed, span)
+
+							is TextEditOperation.Replace ->
+								handleReplace(operation, transformed, span)
+
+							else -> error("unreachable")
+						}
+					}
 				}
+				transformed
 			}
 		}
 
@@ -469,17 +486,20 @@ class RichSpanManager(
 		}
 	}
 
-	private fun handleSpanOnly(
-		updatedSpans: MutableSet<RichSpan>,
-		span: RichSpan
-	) {
-		// Span-only operations leave existing spans in place.
-		updatedSpans.add(span)
-	}
-
 	fun getSpansInRange(range: TextEditorRange): List<RichSpan> {
-		return spans.filter { span ->
-			span.range.start isBeforeOrEqual range.end && span.range.end isAfterOrEqual range.start
+		// Any span whose character range intersects [range] covers at least one of
+		// its lines, so walking the per-line index misses nothing. A multi-line
+		// span appears under several lines; the set keeps it once.
+		val result = linkedSetOf<RichSpan>()
+		for (line in range.start.line..range.end.line) {
+			spansOnLine(line).forEach { span ->
+				if (span.range.start isBeforeOrEqual range.end &&
+					span.range.end isAfterOrEqual range.start
+				) {
+					result.add(span)
+				}
+			}
 		}
+		return result.toList()
 	}
 }

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/DocumentSnapshotIndexTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/DocumentSnapshotIndexTest.kt
@@ -15,15 +15,20 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
- * `DocumentSnapshot` indexes its rich spans by the line each one starts on. The index
- * is what keeps the line-anchored block queries from scanning every span in the
- * document, so it has to survive an edit that cannot invalidate it and be discarded by
- * one that can.
+ * `DocumentSnapshot` indexes its rich spans by every line each one covers. The index
+ * is what keeps the per-line span queries the layout pass runs from scanning every
+ * span in the document, so it has to survive an edit that cannot invalidate it and be
+ * discarded by one that can.
  */
 class DocumentSnapshotIndexTest {
 
 	private fun lineSpan(line: Int, style: RichSpanStyle) = RichSpan(
 		range = TextEditorRange(CharLineOffset(line, 0), CharLineOffset(line, 4)),
+		style = style,
+	)
+
+	private fun multiLineSpan(startLine: Int, endLine: Int, style: RichSpanStyle) = RichSpan(
+		range = TextEditorRange(CharLineOffset(startLine, 0), CharLineOffset(endLine, 4)),
 		style = style,
 	)
 
@@ -33,12 +38,12 @@ class DocumentSnapshotIndexTest {
 	)
 
 	@Test
-	fun `index groups spans by the line they start on`() {
+	fun `index groups spans by every line they cover`() {
 		val bullet = lineSpan(1, BulletListSpanStyle)
 		val quote = lineSpan(1, BlockquoteSpanStyle)
 		val other = lineSpan(3, BulletListSpanStyle)
 
-		val index = snapshot(bullet, quote, other).richSpansByStartLine
+		val index = snapshot(bullet, quote, other).richSpansByLine
 
 		assertEquals(setOf(bullet, quote), index.getValue(1).toSet())
 		assertEquals(listOf(other), index.getValue(3))
@@ -46,27 +51,39 @@ class DocumentSnapshotIndexTest {
 	}
 
 	@Test
+	fun `a multi-line span appears under each covered line`() {
+		val quote = multiLineSpan(1, 3, BlockquoteSpanStyle)
+
+		val index = snapshot(quote).richSpansByLine
+
+		assertTrue(0 !in index)
+		for (line in 1..3) {
+			assertEquals(listOf(quote), index.getValue(line), "line $line")
+		}
+	}
+
+	@Test
 	fun `a text-only revision keeps the built index`() {
 		val original = snapshot(lineSpan(1, BulletListSpanStyle))
-		val index = original.richSpansByStartLine
+		val index = original.richSpansByLine
 
 		val rewritten = original.withLines(List(4) { AnnotatedString("edited") })
 
 		// Same instance, not merely equal: a text edit leaves every span range alone,
 		// so rebuilding the index would be pure work for an identical result.
-		assertSame(index, rewritten.richSpansByStartLine)
+		assertSame(index, rewritten.richSpansByLine)
 	}
 
 	@Test
 	fun `a span revision rebuilds the index`() {
 		val original = snapshot(lineSpan(1, BulletListSpanStyle))
-		val index = original.richSpansByStartLine
+		val index = original.richSpansByLine
 
 		val added = lineSpan(2, BulletListSpanStyle)
 		val respanned = original.withRichSpans(original.richSpans + added)
 
-		assertNotSame(index, respanned.richSpansByStartLine)
-		assertEquals(listOf(added), respanned.richSpansByStartLine.getValue(2))
+		assertNotSame(index, respanned.richSpansByLine)
+		assertEquals(listOf(added), respanned.richSpansByLine.getValue(2))
 	}
 
 	@Test
@@ -74,6 +91,6 @@ class DocumentSnapshotIndexTest {
 		val bullet = lineSpan(2, BulletListSpanStyle)
 		val rewritten = snapshot(bullet).withLines(List(4) { AnnotatedString("edited") })
 
-		assertEquals(listOf(bullet), rewritten.richSpansByStartLine.getValue(2))
+		assertEquals(listOf(bullet), rewritten.richSpansByLine.getValue(2))
 	}
 }

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/SpanScanCostTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/SpanScanCostTest.kt
@@ -1,0 +1,66 @@
+package state
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.richstyle.RichSpan
+import com.darkrockstudios.texteditor.richstyle.SpellCheckStyle
+import kotlinx.coroutines.test.runTest
+import utils.MeasureCounter
+import utils.editorWithCounter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A layout pass reads the flat span set a constant number of times (the memoized
+ * per-line index plus the ordered-list and code-fence pre-scans), never once per
+ * visual line. With shaping already incremental, a per-line scan of every span is
+ * the dominant remaining cost on span-heavy documents, so this pins the bound by
+ * counting how often the span set is iterated.
+ */
+class SpanScanCostTest {
+
+	private class CountingSpanSet(
+		private val backing: Set<RichSpan>,
+	) : Set<RichSpan> by backing {
+		var iterations = 0
+		override fun iterator(): Iterator<RichSpan> {
+			iterations++
+			return backing.iterator()
+		}
+	}
+
+	private val lineCount = 100
+
+	@Test
+	fun `a full relayout iterates the span set a constant number of times`() = runTest {
+		val counter = MeasureCounter()
+		val state = editorWithCounter(counter)
+		state.setText(AnnotatedString((0 until lineCount).joinToString("\n") { "line $it text" }))
+
+		val spans = CountingSpanSet(
+			(0 until lineCount).map { line ->
+				RichSpan(
+					TextEditorRange(CharLineOffset(line, 0), CharLineOffset(line, 4)),
+					SpellCheckStyle,
+				)
+			}.toSet()
+		)
+		state.setRichSpans(spans)
+		spans.iterations = 0
+
+		state.updateBookKeeping()
+
+		assertEquals(
+			lineCount,
+			state.lineOffsets.count { it.richSpans.isNotEmpty() },
+			"every line's span must still be resolved",
+		)
+		assertTrue(
+			spans.iterations <= 5,
+			"a relayout iterated the flat span set ${spans.iterations} times for " +
+					"$lineCount lines; per-line scans are back",
+		)
+	}
+}

--- a/docs/design/incremental-relayout.md
+++ b/docs/design/incremental-relayout.md
@@ -173,11 +173,18 @@ shared across modules):
 - `LayoutUpdateMergeTest` and `UpdateRichSpansClampTest`: the merge soundness
   rules and batch clamping.
 
-## 7. Deferred follow-ups (from issue #36)
+## 7. Per-line span queries
 
-- **Per-line span index.** `getSpansForLineWrap` still filters the flat span
-  set once per virtual line, O(virtual lines x spans) per pass. Measure-free
-  passes made this the dominant remaining term on span-heavy documents.
+`DocumentSnapshot` memoizes a per-line span index (`richSpansByLine`, every
+span grouped under each line it covers), built lazily once per span revision
+and shared across text-only revisions. `getSpansForLineWrap`,
+`getSpansInRange`, and the line-anchored block queries all read it, so each
+per-line query the layout pass runs costs the spans on that line, not the
+spans in the document. `SpanScanCostTest` pins a relayout to a constant number
+of flat span-set iterations.
+
+## 8. Deferred follow-ups (from issue #36)
+
 - **Semantics versioning.** `BasicTextEditor` still rebuilds
   `editableText = state.getAllText()` (an O(document) concatenation) whenever
   semantics are rebuilt.


### PR DESCRIPTION
First of two stacked PRs for #84 (follow-ups from #36).

With shaping incremental since #83, the dominant remaining relayout cost on span-heavy documents was `getSpansForLineWrap` filtering the flat span set once per visual line, O(virtual lines x spans) per pass.

- `DocumentSnapshot` now memoizes `richSpansByLine`: every span grouped under each line it covers (a multi-line span appears under each). Like the existing indices it is built lazily once per span revision and shared across text-only revisions.
- `getSpansForLineWrap`, `getSpansInRange`, and `getRichSpansStartingOn` read the index, so each per-line query costs the spans on that line, not the spans in the document. Soundness: the character-range intersection predicate implies line-interval overlap, so walking the covered lines misses nothing.
- Span-only operations (StyleSpan/RichSpan/LineBlock) skip the verbatim span-set copy in `updateSpans`; only the shared clamp and duplicate-merge passes run.
- `SpanScanCostTest` pins a full relayout of a 100-line, 100-span document to a constant number of flat span-set iterations via a counting `Set`, so per-line scans cannot come back silently.

No public API changes. Full `./gradlew check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1M4nuYBhRwRnpiBEjt3GZ