### PR TITLE
Memoize DocumentSnapshot.getAllText per text revision

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/DocumentSnapshot.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/DocumentSnapshot.kt
@@ -31,12 +31,18 @@ class DocumentSnapshot private constructor(
 	 * because a span-only edit leaves every line length untouched.
 	 */
 	private val lineStarts: Lazy<IntArray>,
+	/**
+	 * Backs [getAllText]. Depends only on the text, so like [lineStarts] it is
+	 * shared with the revision [withRichSpans] produces.
+	 */
+	private val allText: Lazy<AnnotatedString>,
 ) {
 	internal constructor(lines: List<AnnotatedString>, richSpans: Set<RichSpan>) : this(
 		lines = lines,
 		richSpans = richSpans,
 		spansByLine = spansByLineOf(richSpans),
 		lineStarts = lineStartsOf(lines),
+		allText = allTextOf(lines),
 	)
 
 	/**
@@ -60,28 +66,39 @@ class DocumentSnapshot private constructor(
 	 */
 	internal val lineStartOffsets: IntArray get() = lineStarts.value
 
-	/** The whole document as a single [AnnotatedString], lines joined with newlines. */
-	fun getAllText(): AnnotatedString = buildAnnotatedString {
-		lines.forEachIndexed { index, line ->
-			append(line)
-			if (index < lines.lastIndex) append('\n')
-		}
-	}
+	/**
+	 * The whole document as a single [AnnotatedString], lines joined with newlines.
+	 * Built on first read and reused until a revision changes the text; semantics
+	 * rebuilds read this per frame, so an unmemoized concatenation is O(document)
+	 * each time.
+	 */
+	fun getAllText(): AnnotatedString = allText.value
 
 	/**
 	 * Keeps the span index: the ranges are untouched by a text edit, so the lines they
 	 * start on are the same ones they started on before.
 	 */
 	internal fun withLines(lines: List<AnnotatedString>) =
-		DocumentSnapshot(lines, richSpans, spansByLine, lineStartsOf(lines))
+		DocumentSnapshot(lines, richSpans, spansByLine, lineStartsOf(lines), allTextOf(lines))
 
 	internal fun withRichSpans(richSpans: Set<RichSpan>) = DocumentSnapshot(
 		lines = lines,
 		richSpans = richSpans,
 		spansByLine = spansByLineOf(richSpans),
 		lineStarts = lineStarts,
+		allText = allText,
 	)
 }
+
+private fun allTextOf(lines: List<AnnotatedString>): Lazy<AnnotatedString> =
+	lazy(LazyThreadSafetyMode.PUBLICATION) {
+		buildAnnotatedString {
+			lines.forEachIndexed { index, line ->
+				append(line)
+				if (index < lines.lastIndex) append('\n')
+			}
+		}
+	}
 
 private fun spansByLineOf(richSpans: Set<RichSpan>): Lazy<Map<Int, List<RichSpan>>> =
 	lazy(LazyThreadSafetyMode.PUBLICATION) {

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/DocumentSnapshotAllTextTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/DocumentSnapshotAllTextTest.kt
@@ -1,0 +1,63 @@
+package state
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpan
+import com.darkrockstudios.texteditor.state.DocumentSnapshot
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+/**
+ * `getAllText` concatenates the whole document, and semantics rebuilds call it
+ * repeatedly. The snapshot memoizes it per text revision, so repeated reads and
+ * span-only revisions must not pay the O(document) build again.
+ */
+class DocumentSnapshotAllTextTest {
+
+	private fun snapshot(vararg lines: String) = DocumentSnapshot(
+		lines = lines.map { AnnotatedString(it) },
+		richSpans = emptySet(),
+	)
+
+	@Test
+	fun `joins lines with newlines`() {
+		assertEquals("alpha\nbravo\ncharlie", snapshot("alpha", "bravo", "charlie").getAllText().text)
+	}
+
+	@Test
+	fun `repeated reads return the same instance`() {
+		val doc = snapshot("alpha", "bravo")
+		assertSame(doc.getAllText(), doc.getAllText())
+	}
+
+	@Test
+	fun `a span-only revision shares the cached text`() {
+		val doc = snapshot("alpha", "bravo")
+		val text = doc.getAllText()
+
+		val span = RichSpan(
+			TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 4)),
+			BulletListSpanStyle,
+		)
+		val respanned = doc.withRichSpans(setOf(span))
+
+		// Same instance, not merely equal: a span revision leaves every line alone,
+		// so rebuilding the concatenation would be pure work for an identical result.
+		assertSame(text, respanned.getAllText())
+	}
+
+	@Test
+	fun `a text revision rebuilds the text`() {
+		val doc = snapshot("alpha", "bravo")
+		val text = doc.getAllText()
+
+		val rewritten = doc.withLines(listOf(AnnotatedString("edited"), AnnotatedString("bravo")))
+
+		assertNotSame(text, rewritten.getAllText())
+		assertEquals("edited\nbravo", rewritten.getAllText().text)
+	}
+}

--- a/docs/design/incremental-relayout.md
+++ b/docs/design/incremental-relayout.md
@@ -183,8 +183,10 @@ per-line query the layout pass runs costs the spans on that line, not the
 spans in the document. `SpanScanCostTest` pins a relayout to a constant number
 of flat span-set iterations.
 
-## 8. Deferred follow-ups (from issue #36)
+## 8. Semantics text
 
-- **Semantics versioning.** `BasicTextEditor` still rebuilds
-  `editableText = state.getAllText()` (an O(document) concatenation) whenever
-  semantics are rebuilt.
+`DocumentSnapshot.getAllText()` (the whole document as one string, read by the
+semantics block on every rebuild) is memoized per text revision: built on
+first read and shared across span-only revisions, the same pattern as the
+line-start and span indices. With this, every follow-up from issue #36 has
+landed.


### PR DESCRIPTION
Second of two stacked PRs for #84 (stacked on #85; merge that first, then retarget or this shows its commits).

The semantics block reads `editableText = state.getAllText()` on every semantics rebuild, an O(document) concatenation with no caching. `DocumentSnapshot` now memoizes the concatenation per text revision: built lazily on first read, shared across span-only revisions, discarded by text edits. Same `Lazy`-sharing pattern as the snapshot's line-start and span indices, and `DocumentSnapshotAllTextTest` pins the identity semantics (same instance across reads and span revisions, rebuilt on text revisions).

With this, every follow-up from #36 has landed; closes #84 once both PRs are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1M4nuYBhRwRnpiBEjt3GZ