### PR TITLE
Decouple input from specific actions: an action registry and an edit-behavior chain

### DIFF
--- a/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/input/ImeCursorSync.android.kt
+++ b/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/input/ImeCursorSync.android.kt
@@ -75,6 +75,36 @@ actual class ImeCursorSync actual constructor(
 				}
 		}
 
+		// Edits the IME cannot infer from text or caret movement: a behavior that
+		// claims a backspace by exiting a list changes neither, so the deduplication
+		// above would drop the correction and leave the keyboard's mirror a character
+		// ahead of the document. Clearing the last-sent values forces the next push.
+		scope.launch {
+			state.imeResyncRequests.collect {
+				if (state.platformExtensions.isInBatchEdit) return@collect
+				val view = state.platformExtensions.view ?: return@collect
+
+				lastSelStart = -1
+				lastSelEnd = -1
+				lastCompStart = -2
+				lastCompEnd = -2
+
+				val cursorIndex = state.getCharacterIndex(state.cursorPosition)
+				val selection = state.selector.selection
+				val selStart = selection?.let { state.getCharacterIndex(it.start) } ?: cursorIndex
+				val selEnd = selection?.let { state.getCharacterIndex(it.end) } ?: cursorIndex
+				val composing = state.composingRange
+				val compStart = composing?.let { state.getCharacterIndex(it.start) } ?: -1
+				val compEnd = composing?.let { state.getCharacterIndex(it.end) } ?: -1
+
+				lastSelStart = selStart
+				lastSelEnd = selEnd
+				lastCompStart = compStart
+				lastCompEnd = compEnd
+				updateImeSelection(view, selStart, selEnd, compStart, compEnd)
+			}
+		}
+
 		// Edit-driven updateExtractedText pushes for IMEs in monitor mode. Edits always
 		// emit on this flow, even if cursor/selection don't change (e.g. autocorrect that
 		// replaces text with a same-length variant).

--- a/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/input/ImeCursorSync.android.kt
+++ b/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/input/ImeCursorSync.android.kt
@@ -53,13 +53,10 @@ actual class ImeCursorSync actual constructor(
 				}
 		}
 
-		// Edits the IME cannot infer from what it can see. A behavior that claims a
-		// backspace by exiting a list leaves the text and the caret index exactly
-		// where they were, so there is nothing for `updateSelection` to carry: both
-		// this class and `InputMethodManager` drop a push whose indices match the
-		// last one. Only `restartInput` makes the keyboard discard its mirror and
-		// re-read the buffer, which is what it takes to undo the decrement it
-		// already applied when it issued the request.
+		// Edits the IME cannot infer from what it can see: a behavior that exits a
+		// list on backspace leaves text and caret indices unchanged, so a selection
+		// push would be dropped as a duplicate. Only restartInput makes the keyboard
+		// discard its mirror and re-read the buffer.
 		scope.launch {
 			state.imeResyncRequests.collect {
 				if (state.platformExtensions.isInBatchEdit) return@collect

--- a/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/input/ImeCursorSync.android.kt
+++ b/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/input/ImeCursorSync.android.kt
@@ -44,64 +44,31 @@ actual class ImeCursorSync actual constructor(
 					if (state.platformExtensions.isInBatchEdit) return@collect
 					val view = state.platformExtensions.view ?: return@collect
 
-					val selStart: Int
-					val selEnd: Int
-					if (selection != null) {
-						selStart = state.getCharacterIndex(selection.start)
-						selEnd = state.getCharacterIndex(selection.end)
-					} else {
-						val cursorIndex = state.getCharacterIndex(cursorPos)
-						selStart = cursorIndex
-						selEnd = cursorIndex
-					}
-
-					val composing = state.composingRange
-					val compStart = composing?.let { state.getCharacterIndex(it.start) } ?: -1
-					val compEnd = composing?.let { state.getCharacterIndex(it.end) } ?: -1
-
-					val changed = selStart != lastSelStart || selEnd != lastSelEnd ||
-							compStart != lastCompStart || compEnd != lastCompEnd
+					val indices = state.currentImeSelection(cursorPos, selection)
+					val changed = indices.selStart != lastSelStart || indices.selEnd != lastSelEnd ||
+							indices.compStart != lastCompStart || indices.compEnd != lastCompEnd
 					if (!changed) return@collect
 
-					lastSelStart = selStart
-					lastSelEnd = selEnd
-					lastCompStart = compStart
-					lastCompEnd = compEnd
-					updateImeSelection(view, selStart, selEnd, compStart, compEnd)
-
-					if (state.platformExtensions.cursorAnchorMonitoringEnabled) {
-						state.platformExtensions.sendCursorAnchorInfo()
-					}
+					pushSelection(view, indices)
 				}
 		}
 
-		// Edits the IME cannot infer from text or caret movement: a behavior that
-		// claims a backspace by exiting a list changes neither, so the deduplication
-		// above would drop the correction and leave the keyboard's mirror a character
-		// ahead of the document. Clearing the last-sent values forces the next push.
+		// Edits the IME cannot infer from what it can see. A behavior that claims a
+		// backspace by exiting a list leaves the text and the caret index exactly
+		// where they were, so there is nothing for `updateSelection` to carry: both
+		// this class and `InputMethodManager` drop a push whose indices match the
+		// last one. Only `restartInput` makes the keyboard discard its mirror and
+		// re-read the buffer, which is what it takes to undo the decrement it
+		// already applied when it issued the request.
 		scope.launch {
 			state.imeResyncRequests.collect {
 				if (state.platformExtensions.isInBatchEdit) return@collect
 				val view = state.platformExtensions.view ?: return@collect
+				val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE)
+						as? InputMethodManager ?: return@collect
 
-				lastSelStart = -1
-				lastSelEnd = -1
-				lastCompStart = -2
-				lastCompEnd = -2
-
-				val cursorIndex = state.getCharacterIndex(state.cursorPosition)
-				val selection = state.selector.selection
-				val selStart = selection?.let { state.getCharacterIndex(it.start) } ?: cursorIndex
-				val selEnd = selection?.let { state.getCharacterIndex(it.end) } ?: cursorIndex
-				val composing = state.composingRange
-				val compStart = composing?.let { state.getCharacterIndex(it.start) } ?: -1
-				val compEnd = composing?.let { state.getCharacterIndex(it.end) } ?: -1
-
-				lastSelStart = selStart
-				lastSelEnd = selEnd
-				lastCompStart = compStart
-				lastCompEnd = compEnd
-				updateImeSelection(view, selStart, selEnd, compStart, compEnd)
+				imm.restartInput(view)
+				pushSelection(view, state.currentImeSelection())
 			}
 		}
 
@@ -133,16 +100,48 @@ actual class ImeCursorSync actual constructor(
 		lastCompEnd = -2
 	}
 
-	private fun updateImeSelection(
-		view: View,
-		selStart: Int,
-		selEnd: Int,
-		compStart: Int,
-		compEnd: Int
-	) {
+	/** The selection and composing indices as the IME should currently see them. */
+	private class ImeSelection(
+		val selStart: Int,
+		val selEnd: Int,
+		val compStart: Int,
+		val compEnd: Int,
+	)
+
+	private fun TextEditorState.currentImeSelection(
+		cursorPos: CharLineOffset = cursorPosition,
+		selection: TextEditorRange? = selector.selection,
+	): ImeSelection {
+		val selStart: Int
+		val selEnd: Int
+		if (selection != null) {
+			selStart = getCharacterIndex(selection.start)
+			selEnd = getCharacterIndex(selection.end)
+		} else {
+			val cursorIndex = getCharacterIndex(cursorPos)
+			selStart = cursorIndex
+			selEnd = cursorIndex
+		}
+
+		val composing = composingRange
+		return ImeSelection(
+			selStart = selStart,
+			selEnd = selEnd,
+			compStart = composing?.let { getCharacterIndex(it.start) } ?: -1,
+			compEnd = composing?.let { getCharacterIndex(it.end) } ?: -1,
+		)
+	}
+
+	/** Records [indices] as last-sent and pushes them, with whatever else the IME is monitoring. */
+	private fun pushSelection(view: View, indices: ImeSelection) {
+		lastSelStart = indices.selStart
+		lastSelEnd = indices.selEnd
+		lastCompStart = indices.compStart
+		lastCompEnd = indices.compEnd
+
 		val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
 			?: return
-		imm.updateSelection(view, selStart, selEnd, compStart, compEnd)
+		imm.updateSelection(view, indices.selStart, indices.selEnd, indices.compStart, indices.compEnd)
 
 		if (state.platformExtensions.extractedTextMonitorEnabled) {
 			imm.updateExtractedText(
@@ -150,6 +149,10 @@ actual class ImeCursorSync actual constructor(
 				state.platformExtensions.extractedTextMonitorToken,
 				state.toExtractedText()
 			)
+		}
+
+		if (state.platformExtensions.cursorAnchorMonitoringEnabled) {
+			state.platformExtensions.sendCursorAnchorInfo()
 		}
 	}
 }

--- a/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.android.kt
+++ b/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.android.kt
@@ -1,3 +1,3 @@
 package com.darkrockstudios.texteditor.input
 
-internal actual fun platformKeyBindings(): KeyBindings = CtrlKeyBindings
+actual fun platformKeyBindings(): KeyBindings = CtrlKeyBindings

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
@@ -48,6 +48,7 @@ import com.darkrockstudios.texteditor.contextmenu.TextEditorContextMenuProvider
 import com.darkrockstudios.texteditor.contextmenu.TextEditorContextMenuState
 import com.darkrockstudios.texteditor.cursor.DrawCursor
 import com.darkrockstudios.texteditor.input.CaptureViewForIme
+import com.darkrockstudios.texteditor.input.KeyBindings
 import com.darkrockstudios.texteditor.input.LocalKeyBindings
 import com.darkrockstudios.texteditor.input.TextEditorInputModifierElement
 import com.darkrockstudios.texteditor.input.selectionAsTextRange
@@ -82,6 +83,9 @@ private const val CURSOR_BLINK_SPEED_MS = 500L
  *   see [RichSpanClickListener] for what the return value does (and does not do).
  * @param decorateLine Optional per-line decorator drawn behind each line, keyed by
  *   line index — useful for gutters, current-line highlights, or diff markers.
+ * @param keyBindings Chord-to-command mapping, defaulting to [LocalKeyBindings].
+ *   Bind chords to actions registered on [TextEditorState.actions] to add
+ *   shortcuts of your own.
  */
 @Composable
 fun BasicTextEditor(
@@ -95,6 +99,7 @@ fun BasicTextEditor(
 	contextMenuState: TextEditorContextMenuState? = null,
 	onRichSpanClick: RichSpanClickListener? = null,
 	decorateLine: LineDecorator? = null,
+	keyBindings: KeyBindings = LocalKeyBindings.current,
 ) {
 	// Capture platform view for IME cursor synchronization (Android only)
 	CaptureViewForIme(state)
@@ -104,8 +109,6 @@ fun BasicTextEditor(
 	val clipboard = LocalClipboard.current
 	val density = LocalDensity.current
 	val layoutDirection = LocalLayoutDirection.current
-
-	val keyBindings = LocalKeyBindings.current
 
 	val inputModifierElement = remember(state, clipboard, enabled, keyBindings) {
 		TextEditorInputModifierElement(state, clipboard, enabled, keyBindings)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
@@ -136,8 +136,8 @@ fun BasicTextEditor(
 	val internalContextMenuState = remember { TextEditorContextMenuState() }
 	val effectiveContextMenuState = contextMenuState ?: internalContextMenuState
 
-	val contextMenuActions = remember(state, clipboard) {
-		ContextMenuActions(state, clipboard, state.scope)
+	val contextMenuActions = remember(state, clipboard, enabled) {
+		ContextMenuActions(state, clipboard, state.scope, enabled)
 	}
 
 	LaunchedEffect(Unit) {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
@@ -70,7 +70,7 @@ fun RichTextView(
 			TextEditorInputModifierElement(state, clipboard, enabled = false, keyBindings = keyBindings)
 		}
 		val contextMenuActions = remember(state, clipboard) {
-			ContextMenuActions(state, clipboard, state.scope)
+			ContextMenuActions(state, clipboard, state.scope, enabled = false)
 		}
 
 		TextEditorContextMenuProvider(

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/TextEditor.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/TextEditor.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.darkrockstudios.texteditor.input.KeyBindings
+import com.darkrockstudios.texteditor.input.LocalKeyBindings
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.rememberTextEditorState
 
@@ -28,6 +30,9 @@ private val DefaultContentPadding = PaddingValues(16.dp)
  * @param onRichSpanClick Invoked when a rich span (link, list, blockquote, code
  *   block, …) is tapped or right-clicked; see [RichSpanClickListener] for what
  *   the return value does (and does not do).
+ * @param keyBindings Chord-to-command mapping, defaulting to [LocalKeyBindings].
+ *   Bind chords to actions registered on [TextEditorState.actions] to add
+ *   shortcuts of your own.
  */
 @Composable
 fun TextEditor(
@@ -38,6 +43,7 @@ fun TextEditor(
 	autoFocus: Boolean = false,
 	style: TextEditorStyle = rememberTextEditorStyle(),
 	onRichSpanClick: RichSpanClickListener? = null,
+	keyBindings: KeyBindings = LocalKeyBindings.current,
 ) {
 	Surface(modifier = modifier.focusBorder(state.isFocused && enabled, style)) {
 		BasicTextEditor(
@@ -48,6 +54,7 @@ fun TextEditor(
 			autoFocus = autoFocus,
 			style = style,
 			onRichSpanClick = onRichSpanClick,
+			keyBindings = keyBindings,
 		)
 	}
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/ContextMenuActions.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/ContextMenuActions.kt
@@ -1,105 +1,57 @@
 package com.darkrockstudios.texteditor.contextmenu
 
 import androidx.compose.ui.platform.Clipboard
-import com.darkrockstudios.texteditor.clipboard.ClipboardHelper
-import com.darkrockstudios.texteditor.clipboard.applyHtmlPasteBlocks
-import com.darkrockstudios.texteditor.clipboard.readHtmlPasteDocument
+import com.darkrockstudios.texteditor.input.EditorActionContext
+import com.darkrockstudios.texteditor.input.EditorCommand
+import com.darkrockstudios.texteditor.input.EditorCommand.Action
 import com.darkrockstudios.texteditor.state.TextEditorState
-import com.darkrockstudios.texteditor.state.applyStyleForEditAt
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
- * Encapsulates clipboard and selection operations for the context menu.
- * Reuses the same logic as TextEditorKeyCommandHandler.
+ * Resolves context menu items against the [EditorActionRegistry]
+ * [com.darkrockstudios.texteditor.input.EditorActionRegistry] on the state, so
+ * the menu runs the same implementations the keyboard does. Replacing a
+ * built-in, or registering an action of your own, changes both surfaces at once.
+ *
+ * The named methods cover the standard items; [canPerform] and [perform] drive
+ * any other registered action, including your own, from a
+ * [ContextMenuItem].
  */
 class ContextMenuActions(
 	private val state: TextEditorState,
 	private val clipboard: Clipboard,
 	private val scope: CoroutineScope,
 ) {
-	/**
-	 * Returns true if there is a selection that can be cut.
-	 */
-	fun canCut(): Boolean = state.selector.hasSelection()
+	private fun context() = EditorActionContext(state, clipboard, scope)
 
 	/**
-	 * Returns true if there is a selection that can be copied.
+	 * Whether [action] is registered and currently has work to do, which is what
+	 * decides if its menu item is shown. Unregistered actions report false, so
+	 * dropping one from the registry takes its item out of the menu.
 	 */
-	fun canCopy(): Boolean = state.selector.hasSelection()
+	fun canPerform(action: EditorCommand.Action): Boolean =
+		state.actions[action]?.isEnabled?.invoke(context()) == true
 
-	/**
-	 * Returns true if paste is available.
-	 * Note: We always return true since checking clipboard content is async.
-	 * The paste operation itself will handle empty clipboard gracefully.
-	 */
-	fun canPaste(): Boolean = true
-
-	/**
-	 * Cut the selected text to clipboard and delete it from the editor.
-	 */
-	fun cut() {
-		state.selector.selection?.let { selection ->
-			val selectedText = state.selector.getSelectedText()
-			val copyId = state.copyRichSpans(selection)
-			state.preserveCopiedRichSpansThroughNextEdit()
-			state.selector.deleteSelection()
-			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
-			}
-		}
+	/** Runs [action] if it is registered, otherwise does nothing. */
+	fun perform(action: EditorCommand.Action) {
+		state.actions[action]?.perform?.invoke(context())
 	}
 
-	/**
-	 * Copy the selected text to clipboard.
-	 */
-	fun copy() {
-		state.selector.selection?.let { selection ->
-			val selectedText = state.selector.getSelectedText()
-			val copyId = state.copyRichSpans(selection)
-			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
-			}
-		}
-	}
+	fun canCut(): Boolean = canPerform(Action.Cut)
+
+	fun canCopy(): Boolean = canPerform(Action.Copy)
 
 	/**
-	 * Paste text from clipboard at the current cursor position.
-	 * If there is a selection, it will be replaced with the pasted text.
+	 * True whenever paste is registered. Whether the clipboard actually holds
+	 * anything is not knowable synchronously; [paste] handles an empty one.
 	 */
-	fun paste() {
-		scope.launch {
-			ClipboardHelper.getText(clipboard, state.markdownConfiguration)?.let { text ->
-				val curSelection = state.selector.selection
-				val insertPosition = curSelection?.start ?: state.cursorPosition
-				// Read the clipboard's HTML before mutating: the text, the in-editor
-				// rich spans and the pasted block structure then land as one revision.
-				val htmlDocument = state.readHtmlPasteDocument(clipboard, text)
-				val clipboardCopyId = ClipboardHelper.readCopyId(clipboard)
-				state.preserveCopiedRichSpansThroughNextEdit()
-				state.withAtomicEdit {
-					if (curSelection != null) {
-						state.replace(curSelection, state.applyStyleForEditAt(curSelection.start, text))
-					} else {
-						state.insertStringAtCursor(text)
-					}
-					state.pasteRichSpans(
-						insertPosition,
-						text,
-						clipboardCopyId,
-						requireCopyIdMatch = ClipboardHelper.supportsCopyProvenance,
-					)
-					htmlDocument?.let { state.applyHtmlPasteBlocks(it, insertPosition, text) }
-				}
-				state.selector.clearSelection()
-			}
-		}
-	}
+	fun canPaste(): Boolean = canPerform(Action.Paste)
 
-	/**
-	 * Select all text in the editor.
-	 */
-	fun selectAll() {
-		state.selector.selectAll()
-	}
+	fun cut() = perform(Action.Cut)
+
+	fun copy() = perform(Action.Copy)
+
+	fun paste() = perform(Action.Paste)
+
+	fun selectAll() = perform(Action.SelectAll)
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/ContextMenuActions.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/ContextMenuActions.kt
@@ -11,12 +11,9 @@ import kotlinx.coroutines.CoroutineScope
 /**
  * Resolves context menu items against the [EditorActionRegistry]
  * [com.darkrockstudios.texteditor.input.EditorActionRegistry] on the state, so
- * the menu runs the same implementations the keyboard does. Replacing a
- * built-in, or registering an action of your own, changes both surfaces at once.
- *
- * The named methods cover the standard items; [canPerform] and [perform] drive
- * any other registered action, including your own, from a
- * [ContextMenuItem].
+ * the menu runs the same implementations the keyboard does. The named methods
+ * cover the standard items; [canPerform] and [perform] drive any registered
+ * action from a [ContextMenuItem].
  */
 class ContextMenuActions(
 	private val state: TextEditorState,
@@ -32,17 +29,15 @@ class ContextMenuActions(
 
 	/**
 	 * Whether [action] is registered, allowed in this editor, and currently has
-	 * work to do, which is what decides if its menu item is shown. Unregistered
-	 * actions report false, so dropping one from the registry takes its item out
-	 * of the menu, as does an editing action in a read-only editor.
+	 * work to do; false hides its menu item.
 	 */
 	fun canPerform(action: EditorCommand.Action): Boolean =
 		permitted(state.actions[action])?.isEnabled?.invoke(context()) == true
 
 	/**
-	 * Runs [action] if it is registered and allowed, otherwise does nothing. The
-	 * read-only check lives here rather than in the menu so a host item built on
-	 * this cannot mutate a disabled editor the keyboard already refuses to edit.
+	 * Runs [action] if it is registered and allowed. The read-only check lives
+	 * here, not in the menu, so a host item built on this cannot mutate a
+	 * disabled editor the keyboard already refuses to edit.
 	 */
 	fun perform(action: EditorCommand.Action) {
 		permitted(state.actions[action])?.perform?.invoke(context())

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/ContextMenuActions.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/ContextMenuActions.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.texteditor.contextmenu
 
 import androidx.compose.ui.platform.Clipboard
 import com.darkrockstudios.texteditor.input.EditorActionContext
+import com.darkrockstudios.texteditor.input.EditorActionSpec
 import com.darkrockstudios.texteditor.input.EditorCommand
 import com.darkrockstudios.texteditor.input.EditorCommand.Action
 import com.darkrockstudios.texteditor.state.TextEditorState
@@ -21,20 +22,30 @@ class ContextMenuActions(
 	private val state: TextEditorState,
 	private val clipboard: Clipboard,
 	private val scope: CoroutineScope,
+	private val enabled: Boolean = true,
 ) {
 	private fun context() = EditorActionContext(state, clipboard, scope)
 
+	/** Actions that mutate are refused outright while the editor is read-only. */
+	private fun permitted(spec: EditorActionSpec?): EditorActionSpec? =
+		spec?.takeUnless { it.editsDocument && !enabled }
+
 	/**
-	 * Whether [action] is registered and currently has work to do, which is what
-	 * decides if its menu item is shown. Unregistered actions report false, so
-	 * dropping one from the registry takes its item out of the menu.
+	 * Whether [action] is registered, allowed in this editor, and currently has
+	 * work to do, which is what decides if its menu item is shown. Unregistered
+	 * actions report false, so dropping one from the registry takes its item out
+	 * of the menu, as does an editing action in a read-only editor.
 	 */
 	fun canPerform(action: EditorCommand.Action): Boolean =
-		state.actions[action]?.isEnabled?.invoke(context()) == true
+		permitted(state.actions[action])?.isEnabled?.invoke(context()) == true
 
-	/** Runs [action] if it is registered, otherwise does nothing. */
+	/**
+	 * Runs [action] if it is registered and allowed, otherwise does nothing. The
+	 * read-only check lives here rather than in the menu so a host item built on
+	 * this cannot mutate a disabled editor the keyboard already refuses to edit.
+	 */
 	fun perform(action: EditorCommand.Action) {
-		state.actions[action]?.perform?.invoke(context())
+		permitted(state.actions[action])?.perform?.invoke(context())
 	}
 
 	fun canCut(): Boolean = canPerform(Action.Cut)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/TextEditorContextMenu.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/TextEditorContextMenu.kt
@@ -33,6 +33,18 @@ internal fun TextEditorContextMenu(
 	extraItems: List<ContextMenuItem> = emptyList(),
 	onDismiss: () -> Unit,
 ) {
+	val showCut = actions.canCut() && enabled
+	val showCopy = actions.canCopy()
+	val showPaste = enabled && actions.canPaste()
+	val showSelectAll = actions.canPerform(EditorCommand.Action.SelectAll)
+
+	// Every standard item is conditional, so a registry with them all dropped would
+	// otherwise pop an empty dropdown the user has to click away.
+	if (extraItems.isEmpty() && !showCut && !showCopy && !showPaste && !showSelectAll) {
+		onDismiss()
+		return
+	}
+
 	Box(modifier = Modifier.offset {
 		IntOffset(
 			position.x.roundToInt(),
@@ -60,8 +72,7 @@ internal fun TextEditorContextMenu(
 				HorizontalDivider()
 			}
 
-			// Cut - requires selection and enabled
-			if (actions.canCut() && enabled) {
+			if (showCut) {
 				DropdownMenuItem(
 					text = { Text(strings.cut) },
 					onClick = {
@@ -71,8 +82,7 @@ internal fun TextEditorContextMenu(
 				)
 			}
 
-			// Copy - requires selection
-			if (actions.canCopy()) {
+			if (showCopy) {
 				DropdownMenuItem(
 					text = { Text(strings.copy) },
 					onClick = {
@@ -82,8 +92,7 @@ internal fun TextEditorContextMenu(
 				)
 			}
 
-			// Paste - requires enabled
-			if (enabled && actions.canPaste()) {
+			if (showPaste) {
 				DropdownMenuItem(
 					text = { Text(strings.paste) },
 					onClick = {
@@ -93,7 +102,7 @@ internal fun TextEditorContextMenu(
 				)
 			}
 
-			if (actions.canPerform(EditorCommand.Action.SelectAll)) {
+			if (showSelectAll) {
 				DropdownMenuItem(
 					text = { Text(strings.selectAll) },
 					onClick = {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/TextEditorContextMenu.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/contextmenu/TextEditorContextMenu.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntOffset
+import com.darkrockstudios.texteditor.input.EditorCommand
 import kotlin.math.roundToInt
 
 /**
@@ -82,7 +83,7 @@ internal fun TextEditorContextMenu(
 			}
 
 			// Paste - requires enabled
-			if (enabled) {
+			if (enabled && actions.canPaste()) {
 				DropdownMenuItem(
 					text = { Text(strings.paste) },
 					onClick = {
@@ -92,14 +93,15 @@ internal fun TextEditorContextMenu(
 				)
 			}
 
-			// Select All - always available
-			DropdownMenuItem(
-				text = { Text(strings.selectAll) },
-				onClick = {
-					actions.selectAll()
-					onDismiss()
-				},
-			)
+			if (actions.canPerform(EditorCommand.Action.SelectAll)) {
+				DropdownMenuItem(
+					text = { Text(strings.selectAll) },
+					onClick = {
+						actions.selectAll()
+						onDismiss()
+					},
+				)
+			}
 		}
 	}
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/BuiltinEditorActions.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/BuiltinEditorActions.kt
@@ -1,0 +1,256 @@
+package com.darkrockstudios.texteditor.input
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.clipboard.ClipboardHelper
+import com.darkrockstudios.texteditor.clipboard.applyHtmlPasteBlocks
+import com.darkrockstudios.texteditor.clipboard.readHtmlPasteDocument
+import com.darkrockstudios.texteditor.input.EditorCommand.Action
+import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.state.applyStyleForEditAt
+import com.darkrockstudios.texteditor.state.moveToNextWord
+import com.darkrockstudios.texteditor.state.moveToPreviousWord
+import kotlinx.coroutines.launch
+
+/** One outdent level: a single hard tab, else up to this many spaces. */
+private const val TAB_SIZE = 4
+
+/**
+ * Registers the actions the editor ships with. Every one goes through the
+ * public [EditorActionRegistry.register], so the built-ins are exactly as
+ * replaceable as anything a host adds.
+ */
+internal fun EditorActionRegistry.registerBuiltinActions() {
+	register(EditorActionSpec(Action.SelectAll) { it.state.selector.selectAll() })
+
+	register(
+		EditorActionSpec(
+			action = Action.Copy,
+			isEnabled = { it.state.selector.hasSelection() },
+			perform = { it.copySelection() },
+		)
+	)
+	register(
+		EditorActionSpec(
+			action = Action.Cut,
+			isEnabled = { it.state.selector.hasSelection() },
+			perform = { it.cutSelection() },
+		)
+	)
+	register(EditorActionSpec(Action.Paste) { it.pasteClipboard() })
+
+	register(
+		EditorActionSpec(
+			action = Action.Undo,
+			isEnabled = { it.state.canUndo },
+			perform = { it.state.undo() },
+		)
+	)
+	register(
+		EditorActionSpec(
+			action = Action.Redo,
+			isEnabled = { it.state.canRedo },
+			perform = { it.state.redo() },
+		)
+	)
+
+	register(EditorActionSpec(Action.DeleteBackward) { it.state.handleBackspace() })
+	register(EditorActionSpec(Action.DeleteForward) { it.state.handleDelete() })
+	register(EditorActionSpec(Action.DeleteWordBackward) { ctx ->
+		ctx.state.deleteByMotion { ctx.state.moveToPreviousWord() }
+	})
+	register(EditorActionSpec(Action.DeleteWordForward) { ctx ->
+		ctx.state.deleteByMotion { ctx.state.moveToNextWord() }
+	})
+	register(EditorActionSpec(Action.DeleteToLineStart) { ctx ->
+		ctx.state.deleteByMotion { ctx.state.cursor.moveToLineStart() }
+	})
+
+	register(EditorActionSpec(Action.Indent) { it.state.handleIndent() })
+	register(EditorActionSpec(Action.Outdent) { it.state.handleOutdent() })
+	register(EditorActionSpec(Action.NewLine) { it.state.handleEnter() })
+}
+
+private fun EditorActionContext.copySelection() {
+	state.selector.selection?.let { selection ->
+		val selectedText = state.selector.getSelectedText()
+		val copyId = state.copyRichSpans(selection)
+		scope.launch {
+			ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
+		}
+	}
+}
+
+private fun EditorActionContext.cutSelection() {
+	state.selector.selection?.let { selection ->
+		val selectedText = state.selector.getSelectedText()
+		val copyId = state.copyRichSpans(selection)
+		state.preserveCopiedRichSpansThroughNextEdit()
+		state.selector.deleteSelection()
+		scope.launch {
+			ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
+		}
+	}
+}
+
+private fun EditorActionContext.pasteClipboard() {
+	scope.launch {
+		ClipboardHelper.getText(clipboard, state.markdownConfiguration)?.let { text ->
+			val curSelection = state.selector.selection
+			val insertPosition = curSelection?.start ?: state.cursorPosition
+			// Read the clipboard's HTML before mutating: the text, the in-editor
+			// rich spans and the pasted block structure then land as one revision.
+			val htmlDocument = state.readHtmlPasteDocument(clipboard, text)
+			val clipboardCopyId = ClipboardHelper.readCopyId(clipboard)
+			state.preserveCopiedRichSpansThroughNextEdit()
+			state.withAtomicEdit {
+				if (curSelection != null) {
+					state.replace(curSelection, state.applyStyleForEditAt(curSelection.start, text))
+				} else {
+					state.insertStringAtCursor(text)
+				}
+				state.pasteRichSpans(
+					insertPosition,
+					text,
+					clipboardCopyId,
+					requireCopyIdMatch = ClipboardHelper.supportsCopyProvenance,
+				)
+				htmlDocument?.let { state.applyHtmlPasteBlocks(it, insertPosition, text) }
+			}
+			state.selector.clearSelection()
+		}
+	}
+}
+
+private fun TextEditorState.handleDelete() {
+	if (selector.selection != null) {
+		selector.deleteSelection()
+	} else {
+		deleteAtCursor()
+	}
+}
+
+private fun TextEditorState.handleBackspace() {
+	if (selector.selection != null) {
+		selector.deleteSelection()
+	} else {
+		backspaceAtCursor()
+	}
+}
+
+/**
+ * Deletes between the caret and wherever [locateRangeEdge] moves it, or the selection when
+ * there is one. The caret the user had is handed to [TextEditorState.delete] explicitly:
+ * [locateRangeEdge] has already moved it off that position, and delete otherwise records
+ * wherever the caret currently sits as the position undo returns to.
+ */
+private fun TextEditorState.deleteByMotion(locateRangeEdge: () -> Unit) {
+	if (selector.selection != null) {
+		selector.deleteSelection()
+		return
+	}
+	val origin = cursorPosition
+	locateRangeEdge()
+	val edge = cursorPosition
+	if (edge == origin) return
+
+	val range = if (edge < origin) {
+		TextEditorRange(edge, origin)
+	} else {
+		TextEditorRange(origin, edge)
+	}
+	delete(range, cursorBefore = origin)
+}
+
+private fun TextEditorState.handleIndent() {
+	val selection = selector.selection
+	if (selection != null && selection.start.line != selection.end.line) {
+		indentLineRange(selection.start.line, selection.end.line)
+	} else {
+		if (selection != null) {
+			selector.deleteSelection()
+		}
+		insertStringAtCursor(" ".repeat(TAB_SIZE))
+	}
+}
+
+private fun TextEditorState.handleOutdent() {
+	val selection = selector.selection
+	if (selection != null) {
+		outdentLineRange(selection.start.line, selection.end.line)
+	} else {
+		outdentCurrentLine()
+	}
+}
+
+private fun TextEditorState.indentLineRange(startLine: Int, endLine: Int) {
+	val prefix = " ".repeat(TAB_SIZE)
+	val newText = buildAnnotatedString {
+		for (i in startLine..endLine) {
+			if (i > startLine) append('\n')
+			append(prefix)
+			append(textLines[i])
+		}
+	}
+	val range = TextEditorRange(
+		CharLineOffset(startLine, 0),
+		CharLineOffset(endLine, textLines[endLine].length)
+	)
+	replace(range, newText)
+	selector.updateSelection(
+		CharLineOffset(startLine, 0),
+		CharLineOffset(endLine, textLines[endLine].length)
+	)
+}
+
+private fun TextEditorState.outdentLineRange(startLine: Int, endLine: Int) {
+	var changed = false
+	val newText = buildAnnotatedString {
+		for (i in startLine..endLine) {
+			if (i > startLine) append('\n')
+			val line = textLines[i]
+			val remove = leadingOutdentWidth(line)
+			if (remove > 0) changed = true
+			append(line.subSequence(remove, line.length))
+		}
+	}
+	if (!changed) return
+
+	val range = TextEditorRange(
+		CharLineOffset(startLine, 0),
+		CharLineOffset(endLine, textLines[endLine].length)
+	)
+	replace(range, newText)
+	selector.updateSelection(
+		CharLineOffset(startLine, 0),
+		CharLineOffset(endLine, textLines[endLine].length)
+	)
+}
+
+private fun TextEditorState.outdentCurrentLine() {
+	val line = cursorPosition.line
+	val remove = leadingOutdentWidth(textLines[line])
+	if (remove == 0) return
+
+	val cursorChar = cursorPosition.char
+	delete(TextEditorRange(CharLineOffset(line, 0), CharLineOffset(line, remove)))
+	cursor.updatePosition(CharLineOffset(line, (cursorChar - remove).coerceAtLeast(0)))
+}
+
+/** Leading indentation to strip for one outdent level: a single hard tab, else up to [TAB_SIZE] spaces. */
+private fun leadingOutdentWidth(line: AnnotatedString): Int {
+	if (line.isEmpty()) return 0
+	if (line[0] == '\t') return 1
+	var count = 0
+	while (count < TAB_SIZE && count < line.length && line[count] == ' ') count++
+	return count
+}
+
+private fun TextEditorState.handleEnter() {
+	if (selector.selection != null) {
+		selector.deleteSelection()
+	}
+	insertNewlineAtCursor()
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorAction.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorAction.kt
@@ -28,7 +28,19 @@ class EditorActionSpec(
 	val action: EditorCommand.Action,
 	val isEnabled: (EditorActionContext) -> Boolean = { true },
 	val perform: (EditorActionContext) -> Unit,
-)
+) {
+	/**
+	 * Whether this mutates the document, which is what a read-only editor refuses.
+	 *
+	 * For a built-in id the answer comes from the built-in constant, not from
+	 * [action]. An [EditorCommand.Action] is identified by its id alone, so
+	 * replacing `editor.paste` with a spec built from `Action("editor.paste",
+	 * isEdit = false)` resolves as paste everywhere else; taking its word here
+	 * would let it run in an editor the app disabled.
+	 */
+	internal val editsDocument: Boolean
+		get() = EditorCommand.Action.builtinFor(action.id)?.isEdit ?: action.isEdit
+}
 
 /**
  * Everything this editor can do, keyed by [EditorCommand.Action.id]. Lives on

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorAction.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorAction.kt
@@ -1,0 +1,70 @@
+package com.darkrockstudios.texteditor.input
+
+import androidx.compose.ui.platform.Clipboard
+import com.darkrockstudios.texteditor.state.TextEditorState
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * What an action gets to work with. The clipboard and the scope belong to the
+ * composition rather than to the editor, so they arrive per invocation instead
+ * of being captured when the action is registered.
+ */
+class EditorActionContext(
+	val state: TextEditorState,
+	val clipboard: Clipboard,
+	val scope: CoroutineScope,
+)
+
+/**
+ * The implementation of one [EditorCommand.Action].
+ *
+ * [isEnabled] reports whether the action would currently do anything, for menus
+ * and toolbars that grey their items out. Key dispatch ignores it on purpose: a
+ * chord that resolves to a registered action must consume the key event whether
+ * or not the action has work to do, or Ctrl+C with an empty selection would
+ * fall through and type a literal `c`.
+ */
+class EditorActionSpec(
+	val action: EditorCommand.Action,
+	val isEnabled: (EditorActionContext) -> Boolean = { true },
+	val perform: (EditorActionContext) -> Unit,
+)
+
+/**
+ * Everything this editor can do, keyed by [EditorCommand.Action.id]. Lives on
+ * [TextEditorState] because that is the one object every input surface already
+ * shares: key chords reach it through [KeyBindings] and
+ * [TextEditorKeyCommandHandler], and the context menu resolves through it too,
+ * so an action is implemented once no matter how many ways it can be triggered.
+ *
+ * The built-ins register on construction through the same [register] a host
+ * calls, so there is no private door for library actions.
+ */
+class EditorActionRegistry {
+	private val specs = mutableMapOf<String, EditorActionSpec>()
+
+	init {
+		registerBuiltinActions()
+	}
+
+	/**
+	 * Registers [spec]. An id that is already registered is replaced, which is
+	 * how a host substitutes its own implementation of a built-in (binding
+	 * `editor.paste` to a paste that strips formatting, say).
+	 */
+	fun register(spec: EditorActionSpec) {
+		specs[spec.action.id] = spec
+	}
+
+	/** Drops [action], after which a chord bound to it types its character instead. */
+	fun unregister(action: EditorCommand.Action) {
+		specs.remove(action.id)
+	}
+
+	operator fun get(action: EditorCommand.Action): EditorActionSpec? = specs[action.id]
+
+	operator fun contains(action: EditorCommand.Action): Boolean = action.id in specs
+
+	/** The ids currently registered, for diagnostics and tests. */
+	val registeredIds: Set<String> get() = specs.keys.toSet()
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorAction.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorAction.kt
@@ -18,11 +18,9 @@ class EditorActionContext(
 /**
  * The implementation of one [EditorCommand.Action].
  *
- * [isEnabled] reports whether the action would currently do anything, for menus
- * and toolbars that grey their items out. Key dispatch ignores it on purpose: a
- * chord that resolves to a registered action must consume the key event whether
- * or not the action has work to do, or Ctrl+C with an empty selection would
- * fall through and type a literal `c`.
+ * [isEnabled] is for menus and toolbars that grey items out. Key dispatch
+ * ignores it: a bound chord must consume its event even with nothing to do,
+ * or Ctrl+C with an empty selection would type a literal `c`.
  */
 class EditorActionSpec(
 	val action: EditorCommand.Action,
@@ -31,12 +29,9 @@ class EditorActionSpec(
 ) {
 	/**
 	 * Whether this mutates the document, which is what a read-only editor refuses.
-	 *
-	 * For a built-in id the answer comes from the built-in constant, not from
-	 * [action]. An [EditorCommand.Action] is identified by its id alone, so
-	 * replacing `editor.paste` with a spec built from `Action("editor.paste",
-	 * isEdit = false)` resolves as paste everywhere else; taking its word here
-	 * would let it run in an editor the app disabled.
+	 * Built-in ids answer from the built-in constant, not [action]: identity is
+	 * the id alone, so `Action("editor.paste", isEdit = false)` must not get to
+	 * edit a disabled editor on its own say-so.
 	 */
 	internal val editsDocument: Boolean
 		get() = EditorCommand.Action.builtinFor(action.id)?.isEdit ?: action.isEdit
@@ -44,13 +39,9 @@ class EditorActionSpec(
 
 /**
  * Everything this editor can do, keyed by [EditorCommand.Action.id]. Lives on
- * [TextEditorState] because that is the one object every input surface already
- * shares: key chords reach it through [KeyBindings] and
- * [TextEditorKeyCommandHandler], and the context menu resolves through it too,
- * so an action is implemented once no matter how many ways it can be triggered.
- *
- * The built-ins register on construction through the same [register] a host
- * calls, so there is no private door for library actions.
+ * [TextEditorState] because that is the one object every input surface shares,
+ * so an action is implemented once no matter how it is triggered. The built-ins
+ * register on construction through the same [register] a host calls.
  */
 class EditorActionRegistry {
 	private val specs = mutableMapOf<String, EditorActionSpec>()
@@ -60,21 +51,17 @@ class EditorActionRegistry {
 	}
 
 	/**
-	 * Registers [spec]. An id that is already registered is replaced, which is
-	 * how a host substitutes its own implementation of a built-in (binding
-	 * `editor.paste` to a paste that strips formatting, say).
+	 * Registers [spec]. A previously registered id is replaced, which is how a
+	 * host substitutes its own implementation of a built-in.
 	 */
 	fun register(spec: EditorActionSpec) {
 		specs[spec.action.id] = spec
 	}
 
 	/**
-	 * Drops [action], after which the editor stops consuming any chord bound to it
-	 * and the event falls through to whatever would have seen it otherwise. What
-	 * that means depends on the chord: an unmodified printable key types its
-	 * character, a Ctrl or Cmd chord does nothing at all, and Tab reaches the
-	 * platform's focus traversal and moves focus out of the editor. Bind the chord
-	 * to an action of your own rather than unregistering if you need it inert.
+	 * Drops [action], leaving its chords unconsumed: a printable key types its
+	 * character, a Ctrl or Cmd chord goes dead, Tab moves focus out of the editor.
+	 * Bind the chord to a no-op action instead if you need it inert.
 	 */
 	fun unregister(action: EditorCommand.Action) {
 		specs.remove(action.id)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorAction.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorAction.kt
@@ -56,7 +56,14 @@ class EditorActionRegistry {
 		specs[spec.action.id] = spec
 	}
 
-	/** Drops [action], after which a chord bound to it types its character instead. */
+	/**
+	 * Drops [action], after which the editor stops consuming any chord bound to it
+	 * and the event falls through to whatever would have seen it otherwise. What
+	 * that means depends on the chord: an unmodified printable key types its
+	 * character, a Ctrl or Cmd chord does nothing at all, and Tab reaches the
+	 * platform's focus traversal and moves focus out of the editor. Bind the chord
+	 * to an action of your own rather than unregistering if you need it inert.
+	 */
 	fun unregister(action: EditorCommand.Action) {
 		specs.remove(action.id)
 	}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorCommand.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorCommand.kt
@@ -27,16 +27,12 @@ sealed interface EditorCommand {
 	}
 
 	/**
-	 * A named operation. Identified by [id] rather than being an enum member so a
-	 * host can introduce its own (`Action("myapp.toggleBold", isEdit = true)`) and
-	 * bind it from a custom [KeyBindings] exactly like a built-in.
-	 *
-	 * Ids are namespaced by convention: `editor.` for the built-ins below, then a
-	 * prefix of the owner's choosing. Equality is by [id] alone, so an action
-	 * rebuilt from its id matches the constant that named it. Two actions sharing
-	 * an id but disagreeing on [isEdit] are therefore the same action, and
-	 * whichever instance [KeyBindings] returns decides whether a disabled editor
-	 * runs it.
+	 * A named operation. Identified by [id] rather than enum membership so a host
+	 * can introduce its own (`Action("myapp.toggleBold", isEdit = true)`) and bind
+	 * it from a custom [KeyBindings] exactly like a built-in. Ids are namespaced
+	 * by convention (`editor.` is the built-ins'), and equality is by [id] alone,
+	 * so two actions sharing an id are the same action however they disagree on
+	 * [isEdit].
 	 */
 	class Action(val id: String, override val isEdit: Boolean) : EditorCommand {
 		override fun equals(other: Any?): Boolean = other is Action && other.id == id
@@ -60,9 +56,9 @@ sealed interface EditorCommand {
 			val NewLine = Action("editor.newLine", isEdit = true)
 
 			/**
-			 * The built-in carrying [id], or null for a host's own action. Lets the
-			 * editor take a built-in's [isEdit] from here rather than from whatever
-			 * instance a caller handed it, since identity is the id alone.
+			 * The built-in carrying [id], or null for a host's own action. Identity is
+			 * the id alone, so a built-in's [isEdit] is taken from here, never from
+			 * whatever instance a caller handed over.
 			 */
 			internal fun builtinFor(id: String): Action? = builtinsById[id]
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorCommand.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorCommand.kt
@@ -4,7 +4,7 @@ package com.darkrockstudios.texteditor.input
  * An editor operation, named by intent rather than by the keys that trigger it.
  * [KeyBindings] maps a platform's key chords onto these.
  */
-internal sealed interface EditorCommand {
+sealed interface EditorCommand {
 	/** Commands that change the document; they are ignored while the editor is disabled. */
 	val isEdit: Boolean
 
@@ -26,20 +26,56 @@ internal sealed interface EditorCommand {
 		override val isEdit: Boolean get() = false
 	}
 
-	enum class Action(override val isEdit: Boolean) : EditorCommand {
-		SelectAll(isEdit = false),
-		Copy(isEdit = false),
-		Cut(isEdit = true),
-		Paste(isEdit = true),
-		Undo(isEdit = true),
-		Redo(isEdit = true),
-		DeleteBackward(isEdit = true),
-		DeleteForward(isEdit = true),
-		DeleteWordBackward(isEdit = true),
-		DeleteWordForward(isEdit = true),
-		DeleteToLineStart(isEdit = true),
-		Indent(isEdit = true),
-		Outdent(isEdit = true),
-		NewLine(isEdit = true),
+	/**
+	 * A named operation. Identified by [id] rather than being an enum member so a
+	 * host can introduce its own (`Action("myapp.toggleBold", isEdit = true)`) and
+	 * bind it from a custom [KeyBindings] exactly like a built-in.
+	 *
+	 * Ids are namespaced by convention: `editor.` for the built-ins below, then a
+	 * prefix of the owner's choosing. Equality is by [id] alone, so an action
+	 * rebuilt from its id matches the constant that named it. Two actions sharing
+	 * an id but disagreeing on [isEdit] are therefore the same action, and
+	 * whichever instance [KeyBindings] returns decides whether a disabled editor
+	 * runs it.
+	 */
+	class Action(val id: String, override val isEdit: Boolean) : EditorCommand {
+		override fun equals(other: Any?): Boolean = other is Action && other.id == id
+		override fun hashCode(): Int = id.hashCode()
+		override fun toString(): String = "Action($id)"
+
+		companion object {
+			val SelectAll = Action("editor.selectAll", isEdit = false)
+			val Copy = Action("editor.copy", isEdit = false)
+			val Cut = Action("editor.cut", isEdit = true)
+			val Paste = Action("editor.paste", isEdit = true)
+			val Undo = Action("editor.undo", isEdit = true)
+			val Redo = Action("editor.redo", isEdit = true)
+			val DeleteBackward = Action("editor.deleteBackward", isEdit = true)
+			val DeleteForward = Action("editor.deleteForward", isEdit = true)
+			val DeleteWordBackward = Action("editor.deleteWordBackward", isEdit = true)
+			val DeleteWordForward = Action("editor.deleteWordForward", isEdit = true)
+			val DeleteToLineStart = Action("editor.deleteToLineStart", isEdit = true)
+			val Indent = Action("editor.indent", isEdit = true)
+			val Outdent = Action("editor.outdent", isEdit = true)
+			val NewLine = Action("editor.newLine", isEdit = true)
+
+			/** Every action the editor ships with. */
+			val Builtins: List<Action> = listOf(
+				SelectAll,
+				Copy,
+				Cut,
+				Paste,
+				Undo,
+				Redo,
+				DeleteBackward,
+				DeleteForward,
+				DeleteWordBackward,
+				DeleteWordForward,
+				DeleteToLineStart,
+				Indent,
+				Outdent,
+				NewLine,
+			)
+		}
 	}
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorCommand.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/EditorCommand.kt
@@ -59,6 +59,13 @@ sealed interface EditorCommand {
 			val Outdent = Action("editor.outdent", isEdit = true)
 			val NewLine = Action("editor.newLine", isEdit = true)
 
+			/**
+			 * The built-in carrying [id], or null for a host's own action. Lets the
+			 * editor take a built-in's [isEdit] from here rather than from whatever
+			 * instance a caller handed it, since identity is the id alone.
+			 */
+			internal fun builtinFor(id: String): Action? = builtinsById[id]
+
 			/** Every action the editor ships with. */
 			val Builtins: List<Action> = listOf(
 				SelectAll,
@@ -76,6 +83,8 @@ sealed interface EditorCommand {
 				Outdent,
 				NewLine,
 			)
+
+			private val builtinsById: Map<String, Action> = Builtins.associateBy { it.id }
 		}
 	}
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
@@ -30,7 +30,7 @@ internal fun TextEditorState.imeCommitText(text: String, newCursorPosition: Int)
 	// Restricted to the cursor-after-the-insert contract because a claimed newline
 	// may insert nothing at all, leaving no insert position to place a cursor from.
 	if (text == "\n" && newCursorPosition == 1 && composingRange == null) {
-		imePerformNewline()
+		asSemanticEdit { imePerformNewline() }
 		return
 	}
 
@@ -76,7 +76,7 @@ internal fun TextEditorState.imeDeleteSurroundingText(beforeLength: Int, afterLe
 	val cursorIndex = getCharacterIndex(cursorPosition)
 	val deleteStart = maxOf(0, cursorIndex - beforeLength)
 	val deleteEnd = minOf(getTextLength(), cursorIndex + afterLength)
-	deleteSurroundingRange(cursorIndex, deleteStart, deleteEnd)
+	deleteSurroundingRange(beforeLength, afterLength, cursorIndex, deleteStart, deleteEnd)
 }
 
 /** `deleteSurroundingTextInCodePoints`: same as [imeDeleteSurroundingText] but counted in code points. */
@@ -87,39 +87,67 @@ internal fun TextEditorState.imeDeleteSurroundingTextInCodePoints(beforeLength: 
 	val charsAfter = codePointsToChars(fullText, cursorIndex, afterLength, backwards = false)
 	val deleteStart = maxOf(0, cursorIndex - charsBefore)
 	val deleteEnd = minOf(getTextLength(), cursorIndex + charsAfter)
-	deleteSurroundingRange(cursorIndex, deleteStart, deleteEnd)
+	deleteSurroundingRange(charsBefore, charsAfter, cursorIndex, deleteStart, deleteEnd)
 }
 
 /**
- * Deletes [deleteStart]..[deleteEnd], as a backspace when that is exactly what the
- * range describes so an [EditBehavior][com.darkrockstudios.texteditor.state.EditBehavior]
- * can claim it, and as a plain range delete otherwise. Both produce the same text
- * and leave the cursor at the range start; only the behavior hook differs.
+ * Deletes [deleteStart]..[deleteEnd], routed through the semantic backspace or
+ * forward delete when that is exactly what was asked for so an
+ * [EditBehavior][com.darkrockstudios.texteditor.state.EditBehavior] can claim it,
+ * and as a plain range delete otherwise.
+ *
+ * Intent is read from [requestedBefore]/[requestedAfter], the widths the caller
+ * asked for, never from the clamped range. Near the edges of the document a
+ * request for several characters shrinks to one, and treating that as a
+ * single-character keystroke would misread a rewrite as a backspace.
  *
  * Thar be dragons: `deleteSurroundingText` is not unambiguously a keypress.
  * Autocorrect and prediction engines call it to rewrite what was already typed,
  * and treating one of those as a backspace would demote a line block in the
  * middle of a word correction. Requiring no composing region, no selection, and
- * exactly one character before the cursor excludes the rewrite shapes; widen
- * these conditions only with device evidence.
+ * a request for exactly one character on exactly one side excludes the rewrite
+ * shapes; widen these conditions only with device evidence.
  */
 private fun TextEditorState.deleteSurroundingRange(
+	requestedBefore: Int,
+	requestedAfter: Int,
 	cursorIndex: Int,
 	deleteStart: Int,
 	deleteEnd: Int,
 ) {
 	if (deleteStart >= deleteEnd) return
 
-	val isBackspace = deleteEnd == cursorIndex &&
-			cursorIndex - deleteStart == 1 &&
-			composingRange == null &&
-			!selector.hasSelection()
-	if (isBackspace) {
-		backspaceAtCursor()
-		return
-	}
+	val undisturbed = composingRange == null && !selector.hasSelection()
+	val available = deleteEnd - deleteStart
+	when {
+		undisturbed && requestedBefore == 1 && requestedAfter == 0 &&
+				available == 1 && deleteEnd == cursorIndex ->
+			asSemanticEdit { backspaceAtCursor() }
 
-	delete(TextEditorRange(getOffsetAtCharacter(deleteStart), getOffsetAtCharacter(deleteEnd)))
+		undisturbed && requestedBefore == 0 && requestedAfter == 1 &&
+				available == 1 && deleteStart == cursorIndex ->
+			asSemanticEdit { deleteAtCursor() }
+
+		else ->
+			delete(TextEditorRange(getOffsetAtCharacter(deleteStart), getOffsetAtCharacter(deleteEnd)))
+	}
+}
+
+/**
+ * Runs an IME request through a semantic edit that an
+ * [EditBehavior][com.darkrockstudios.texteditor.state.EditBehavior] may claim.
+ *
+ * A claiming behavior can satisfy the keystroke without touching text: exiting a
+ * list drops a gutter marker and leaves every character where it was. The IME has
+ * already advanced its own mirror of the buffer on the assumption that the edit it
+ * asked for happened, so leaving it uncorrected desyncs it by a character and its
+ * next request lands on the wrong text. Ask for a resync whenever the document
+ * length did not move.
+ */
+private inline fun TextEditorState.asSemanticEdit(edit: () -> Unit) {
+	val lengthBefore = getTextLength()
+	edit()
+	if (getTextLength() == lengthBefore) requestImeResync()
 }
 
 /** `setSelection`: collapse to a cursor when start == end, otherwise select; cursor goes to `end`. */

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
@@ -30,7 +30,7 @@ internal fun TextEditorState.imeCommitText(text: String, newCursorPosition: Int)
 	// Restricted to the cursor-after-the-insert contract because a claimed newline
 	// may insert nothing at all, leaving no insert position to place a cursor from.
 	if (text == "\n" && newCursorPosition == 1 && composingRange == null) {
-		asSemanticEdit { imePerformNewline() }
+		imePerformNewline()
 		return
 	}
 
@@ -76,7 +76,13 @@ internal fun TextEditorState.imeDeleteSurroundingText(beforeLength: Int, afterLe
 	val cursorIndex = getCharacterIndex(cursorPosition)
 	val deleteStart = maxOf(0, cursorIndex - beforeLength)
 	val deleteEnd = minOf(getTextLength(), cursorIndex + afterLength)
-	deleteSurroundingRange(beforeLength, afterLength, cursorIndex, deleteStart, deleteEnd)
+	deleteSurroundingRange(
+		singleCharBefore = beforeLength == 1 && afterLength == 0,
+		singleCharAfter = beforeLength == 0 && afterLength == 1,
+		cursorIndex = cursorIndex,
+		deleteStart = deleteStart,
+		deleteEnd = deleteEnd,
+	)
 }
 
 /** `deleteSurroundingTextInCodePoints`: same as [imeDeleteSurroundingText] but counted in code points. */
@@ -87,19 +93,33 @@ internal fun TextEditorState.imeDeleteSurroundingTextInCodePoints(beforeLength: 
 	val charsAfter = codePointsToChars(fullText, cursorIndex, afterLength, backwards = false)
 	val deleteStart = maxOf(0, cursorIndex - charsBefore)
 	val deleteEnd = minOf(getTextLength(), cursorIndex + charsAfter)
-	deleteSurroundingRange(charsBefore, charsAfter, cursorIndex, deleteStart, deleteEnd)
+	// charsBefore/charsAfter of 2 is one astral code point, which the semantic paths
+	// would split: they delete a single UTF-16 char. 0 is the document edge, where
+	// the request is still a keystroke even though there is nothing to remove.
+	deleteSurroundingRange(
+		singleCharBefore = beforeLength == 1 && afterLength == 0 && charsBefore <= 1,
+		singleCharAfter = beforeLength == 0 && afterLength == 1 && charsAfter <= 1,
+		cursorIndex = cursorIndex,
+		deleteStart = deleteStart,
+		deleteEnd = deleteEnd,
+	)
 }
 
 /**
  * Deletes [deleteStart]..[deleteEnd], routed through the semantic backspace or
- * forward delete when that is exactly what was asked for so an
+ * forward delete when that is what was asked for so an
  * [EditBehavior][com.darkrockstudios.texteditor.state.EditBehavior] can claim it,
  * and as a plain range delete otherwise.
  *
- * Intent is read from [requestedBefore]/[requestedAfter], the widths the caller
- * asked for, never from the clamped range. Near the edges of the document a
- * request for several characters shrinks to one, and treating that as a
- * single-character keystroke would misread a rewrite as a backspace.
+ * Intent comes from [singleCharBefore]/[singleCharAfter], derived from the widths
+ * the caller asked for, never from the clamped range. Near the edges of the
+ * document a request for several characters shrinks to one, and reading intent off
+ * the survivor would misclassify a rewrite as a backspace.
+ *
+ * The semantic routes run even when the clamped range is empty. A backspace at the
+ * very start of the document removes nothing but can still exit a line block, and
+ * the hardware key does exactly that, so bailing early here would leave the key
+ * dead on a soft keyboard for a block on the first line.
  *
  * Thar be dragons: `deleteSurroundingText` is not unambiguously a keypress.
  * Autocorrect and prediction engines call it to rewrite what was already typed,
@@ -109,45 +129,28 @@ internal fun TextEditorState.imeDeleteSurroundingTextInCodePoints(beforeLength: 
  * shapes; widen these conditions only with device evidence.
  */
 private fun TextEditorState.deleteSurroundingRange(
-	requestedBefore: Int,
-	requestedAfter: Int,
+	singleCharBefore: Boolean,
+	singleCharAfter: Boolean,
 	cursorIndex: Int,
 	deleteStart: Int,
 	deleteEnd: Int,
 ) {
-	if (deleteStart >= deleteEnd) return
-
 	val undisturbed = composingRange == null && !selector.hasSelection()
 	val available = deleteEnd - deleteStart
-	when {
-		undisturbed && requestedBefore == 1 && requestedAfter == 0 &&
-				available == 1 && deleteEnd == cursorIndex ->
-			asSemanticEdit { backspaceAtCursor() }
 
-		undisturbed && requestedBefore == 0 && requestedAfter == 1 &&
-				available == 1 && deleteStart == cursorIndex ->
-			asSemanticEdit { deleteAtCursor() }
-
-		else ->
-			delete(TextEditorRange(getOffsetAtCharacter(deleteStart), getOffsetAtCharacter(deleteEnd)))
+	if (undisturbed && available <= 1) {
+		if (singleCharBefore && deleteEnd <= cursorIndex) {
+			backspaceAtCursor()
+			return
+		}
+		if (singleCharAfter && deleteStart >= cursorIndex) {
+			deleteAtCursor()
+			return
+		}
 	}
-}
 
-/**
- * Runs an IME request through a semantic edit that an
- * [EditBehavior][com.darkrockstudios.texteditor.state.EditBehavior] may claim.
- *
- * A claiming behavior can satisfy the keystroke without touching text: exiting a
- * list drops a gutter marker and leaves every character where it was. The IME has
- * already advanced its own mirror of the buffer on the assumption that the edit it
- * asked for happened, so leaving it uncorrected desyncs it by a character and its
- * next request lands on the wrong text. Ask for a resync whenever the document
- * length did not move.
- */
-private inline fun TextEditorState.asSemanticEdit(edit: () -> Unit) {
-	val lengthBefore = getTextLength()
-	edit()
-	if (getTextLength() == lengthBefore) requestImeResync()
+	if (deleteStart >= deleteEnd) return
+	delete(TextEditorRange(getOffsetAtCharacter(deleteStart), getOffsetAtCharacter(deleteEnd)))
 }
 
 /** `setSelection`: collapse to a cursor when start == end, otherwise select; cursor goes to `end`. */

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
@@ -25,10 +25,10 @@ import com.darkrockstudios.texteditor.state.TextEditorState
  * `newCursorPosition` contract.
  */
 internal fun TextEditorState.imeCommitText(text: String, newCursorPosition: Int) {
-	// A committed bare newline is an Enter. An IME that commits "\n" as text never
-	// produces a key event, so routing here is the only way an EditBehavior sees it.
-	// Restricted to the cursor-after-the-insert contract because a claimed newline
-	// may insert nothing at all, leaving no insert position to place a cursor from.
+	// A committed bare newline is an Enter: an IME that commits "\n" never produces
+	// a key event, so routing here is the only way an EditBehavior sees it. Requires
+	// the cursor-after-the-insert contract because a claimed newline may insert
+	// nothing at all, leaving no insert position to place a cursor from.
 	if (text == "\n" && newCursorPosition == 1 && composingRange == null) {
 		imePerformNewline()
 		return
@@ -107,26 +107,20 @@ internal fun TextEditorState.imeDeleteSurroundingTextInCodePoints(beforeLength: 
 
 /**
  * Deletes [deleteStart]..[deleteEnd], routed through the semantic backspace or
- * forward delete when that is what was asked for so an
- * [EditBehavior][com.darkrockstudios.texteditor.state.EditBehavior] can claim it,
- * and as a plain range delete otherwise.
+ * forward delete when that is what was asked for, so an
+ * [EditBehavior][com.darkrockstudios.texteditor.state.EditBehavior] can claim it.
  *
- * Intent comes from [singleCharBefore]/[singleCharAfter], derived from the widths
- * the caller asked for, never from the clamped range. Near the edges of the
- * document a request for several characters shrinks to one, and reading intent off
- * the survivor would misclassify a rewrite as a backspace.
+ * Intent is [singleCharBefore]/[singleCharAfter], derived from the widths the
+ * caller asked for, never from the clamped range: near a document edge a
+ * multi-character rewrite shrinks to one and would read as a backspace. The
+ * semantic routes run even on an empty clamped range, because a backspace at the
+ * document start removes nothing yet can still exit a line block, as the
+ * hardware key does.
  *
- * The semantic routes run even when the clamped range is empty. A backspace at the
- * very start of the document removes nothing but can still exit a line block, and
- * the hardware key does exactly that, so bailing early here would leave the key
- * dead on a soft keyboard for a block on the first line.
- *
- * Thar be dragons: `deleteSurroundingText` is not unambiguously a keypress.
- * Autocorrect and prediction engines call it to rewrite what was already typed,
- * and treating one of those as a backspace would demote a line block in the
- * middle of a word correction. Requiring no composing region, no selection, and
- * a request for exactly one character on exactly one side excludes the rewrite
- * shapes; widen these conditions only with device evidence.
+ * Thar be dragons: autocorrect calls `deleteSurroundingText` to rewrite what was
+ * already typed, and reading one as a backspace demotes a line block mid-word.
+ * The no-composing-region / no-selection / exactly-one-character conditions
+ * exclude the rewrite shapes; widen them only with device evidence.
  */
 private fun TextEditorState.deleteSurroundingRange(
 	singleCharBefore: Boolean,

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/ImeEditLogic.kt
@@ -25,6 +25,15 @@ import com.darkrockstudios.texteditor.state.TextEditorState
  * `newCursorPosition` contract.
  */
 internal fun TextEditorState.imeCommitText(text: String, newCursorPosition: Int) {
+	// A committed bare newline is an Enter. An IME that commits "\n" as text never
+	// produces a key event, so routing here is the only way an EditBehavior sees it.
+	// Restricted to the cursor-after-the-insert contract because a claimed newline
+	// may insert nothing at all, leaving no insert position to place a cursor from.
+	if (text == "\n" && newCursorPosition == 1 && composingRange == null) {
+		imePerformNewline()
+		return
+	}
+
 	val insertStart = replaceComposingOrInsert(text)
 	val insertEnd = insertStart + text.length
 	// Commit semantics end the composition even when no mutation ran (empty text
@@ -67,9 +76,7 @@ internal fun TextEditorState.imeDeleteSurroundingText(beforeLength: Int, afterLe
 	val cursorIndex = getCharacterIndex(cursorPosition)
 	val deleteStart = maxOf(0, cursorIndex - beforeLength)
 	val deleteEnd = minOf(getTextLength(), cursorIndex + afterLength)
-	if (deleteStart < deleteEnd) {
-		delete(TextEditorRange(getOffsetAtCharacter(deleteStart), getOffsetAtCharacter(deleteEnd)))
-	}
+	deleteSurroundingRange(cursorIndex, deleteStart, deleteEnd)
 }
 
 /** `deleteSurroundingTextInCodePoints`: same as [imeDeleteSurroundingText] but counted in code points. */
@@ -80,9 +87,39 @@ internal fun TextEditorState.imeDeleteSurroundingTextInCodePoints(beforeLength: 
 	val charsAfter = codePointsToChars(fullText, cursorIndex, afterLength, backwards = false)
 	val deleteStart = maxOf(0, cursorIndex - charsBefore)
 	val deleteEnd = minOf(getTextLength(), cursorIndex + charsAfter)
-	if (deleteStart < deleteEnd) {
-		delete(TextEditorRange(getOffsetAtCharacter(deleteStart), getOffsetAtCharacter(deleteEnd)))
+	deleteSurroundingRange(cursorIndex, deleteStart, deleteEnd)
+}
+
+/**
+ * Deletes [deleteStart]..[deleteEnd], as a backspace when that is exactly what the
+ * range describes so an [EditBehavior][com.darkrockstudios.texteditor.state.EditBehavior]
+ * can claim it, and as a plain range delete otherwise. Both produce the same text
+ * and leave the cursor at the range start; only the behavior hook differs.
+ *
+ * Thar be dragons: `deleteSurroundingText` is not unambiguously a keypress.
+ * Autocorrect and prediction engines call it to rewrite what was already typed,
+ * and treating one of those as a backspace would demote a line block in the
+ * middle of a word correction. Requiring no composing region, no selection, and
+ * exactly one character before the cursor excludes the rewrite shapes; widen
+ * these conditions only with device evidence.
+ */
+private fun TextEditorState.deleteSurroundingRange(
+	cursorIndex: Int,
+	deleteStart: Int,
+	deleteEnd: Int,
+) {
+	if (deleteStart >= deleteEnd) return
+
+	val isBackspace = deleteEnd == cursorIndex &&
+			cursorIndex - deleteStart == 1 &&
+			composingRange == null &&
+			!selector.hasSelection()
+	if (isBackspace) {
+		backspaceAtCursor()
+		return
 	}
+
+	delete(TextEditorRange(getOffsetAtCharacter(deleteStart), getOffsetAtCharacter(deleteEnd)))
 }
 
 /** `setSelection`: collapse to a cursor when start == end, otherwise select; cursor goes to `end`. */

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
@@ -35,10 +35,9 @@ val KeyEvent.isCtrlShortcut: Boolean
  * }
  * ```
  *
- * A chord resolving to an action the registry does not know is not consumed, so
- * it falls through to whatever would have handled it otherwise: an unmodified
- * printable key types its character, a Ctrl or Cmd chord does nothing, and Tab
- * moves focus out of the editor. Register before you bind.
+ * A chord resolving to an unregistered action is not consumed: a printable key
+ * types its character, a Ctrl or Cmd chord goes dead, and Tab moves focus out
+ * of the editor. Register before you bind.
  */
 fun interface KeyBindings {
 	/** The command [event] triggers, or null when the chord is unbound. */

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
@@ -17,22 +17,44 @@ import com.darkrockstudios.texteditor.input.EditorCommand.Motion
  * chords that type a character (Hungarian AltGr+X is `#`, Polish AltGr+Z is `ż`).
  * Compose folds AltGraph into `isAltPressed`, and no Ctrl+Alt chord is bound.
  */
-internal val KeyEvent.isCtrlShortcut: Boolean
+val KeyEvent.isCtrlShortcut: Boolean
 	get() = isCtrlPressed && !isAltPressed
 
-/** Maps a platform's key chords onto the editor's [EditorCommand] vocabulary. */
-internal fun interface KeyBindings {
+/**
+ * Maps a platform's key chords onto the editor's [EditorCommand] vocabulary.
+ *
+ * Bind a chord to an [EditorCommand.Action] you registered on
+ * [TextEditorState.actions][com.darkrockstudios.texteditor.state.TextEditorState.actions]
+ * to add a shortcut. Delegate the chords you do not claim so the platform's
+ * conventions survive:
+ *
+ * ```kotlin
+ * val bindings = KeyBindings { event ->
+ *     if (event.key == Key.B && event.isCtrlShortcut) ToggleBold
+ *     else platformKeyBindings().commandFor(event)
+ * }
+ * ```
+ *
+ * An action the registry does not know is not consumed, so a chord bound to a
+ * forgotten registration types its character rather than becoming a dead key.
+ */
+fun interface KeyBindings {
 	/** The command [event] triggers, or null when the chord is unbound. */
 	fun commandFor(event: KeyEvent): EditorCommand?
 }
 
 /** The bindings of the host platform. */
-internal expect fun platformKeyBindings(): KeyBindings
+expect fun platformKeyBindings(): KeyBindings
 
-internal val LocalKeyBindings = staticCompositionLocalOf { platformKeyBindings() }
+/**
+ * The bindings every editor in the composition uses, defaulting to
+ * [platformKeyBindings]. Provide your own to change shortcuts app-wide, or pass
+ * them to a single editor through its `keyBindings` parameter.
+ */
+val LocalKeyBindings = staticCompositionLocalOf { platformKeyBindings() }
 
 /** Windows and Linux conventions: Ctrl for shortcuts, Ctrl+Arrow for word jumps, Home/End for line bounds. */
-internal object CtrlKeyBindings : KeyBindings {
+object CtrlKeyBindings : KeyBindings {
 	override fun commandFor(event: KeyEvent): EditorCommand? {
 		val ctrl = event.isCtrlShortcut
 		return when (event.key) {
@@ -69,7 +91,7 @@ internal object CtrlKeyBindings : KeyBindings {
  * may consume an Option event; everything else must fall through to
  * [TextEditorKeyCommandHandler.handleCharacterInput] to be typed as a literal character.
  */
-internal object MacKeyBindings : KeyBindings {
+object MacKeyBindings : KeyBindings {
 	override fun commandFor(event: KeyEvent): EditorCommand? {
 		val cmd = event.isMetaPressed
 		val option = event.isAltPressed

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.kt
@@ -35,8 +35,10 @@ val KeyEvent.isCtrlShortcut: Boolean
  * }
  * ```
  *
- * An action the registry does not know is not consumed, so a chord bound to a
- * forgotten registration types its character rather than becoming a dead key.
+ * A chord resolving to an action the registry does not know is not consumed, so
+ * it falls through to whatever would have handled it otherwise: an unmodified
+ * printable key types its character, a Ctrl or Cmd chord does nothing, and Tab
+ * moves focus out of the editor. Register before you bind.
  */
 fun interface KeyBindings {
 	/** The command [event] triggers, or null when the chord is unbound. */

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
@@ -80,6 +80,9 @@ internal class TextEditorKeyCommandHandler(
 			Action.Indent -> handleIndent(state)
 			Action.Outdent -> handleOutdent(state)
 			Action.NewLine -> handleEnter(state)
+			// An action nothing here implements must not swallow the keystroke, or a
+			// chord bound to it would eat the character instead of typing it.
+			else -> return false
 		}
 		return true
 	}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
@@ -60,12 +60,8 @@ internal class TextEditorKeyCommandHandler(
 				// An action nobody registered must not swallow the keystroke, so that a
 				// chord the host forgot to implement stays available to everything below.
 				val spec = state.actions[command] ?: return false
-				// Whether this edits comes from the registered spec, never from the
-				// Action the bindings handed us: identity is the id alone, so a host
-				// writing `Action("editor.paste", isEdit = false)` in its own bindings
-				// would otherwise resolve the real paste and mutate a disabled editor.
 				// Selection, copy and navigation stay available in a disabled editor.
-				if (spec.action.isEdit && !enabled) return false
+				if (spec.editsDocument && !enabled) return false
 				spec.perform(EditorActionContext(state, clipboard, scope))
 				true
 			}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
@@ -7,18 +7,9 @@ import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.utf16CodePoint
 import androidx.compose.ui.platform.Clipboard
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.buildAnnotatedString
-import com.darkrockstudios.texteditor.CharLineOffset
-import com.darkrockstudios.texteditor.TextEditorRange
-import com.darkrockstudios.texteditor.clipboard.ClipboardHelper
-import com.darkrockstudios.texteditor.clipboard.applyHtmlPasteBlocks
-import com.darkrockstudios.texteditor.clipboard.readHtmlPasteDocument
 import com.darkrockstudios.texteditor.input.EditorCommand.Action
 import com.darkrockstudios.texteditor.input.EditorCommand.Motion
-import com.darkrockstudios.texteditor.input.TextEditorKeyCommandHandler.Companion.TAB_SIZE
 import com.darkrockstudios.texteditor.state.TextEditorState
-import com.darkrockstudios.texteditor.state.applyStyleForEditAt
 import com.darkrockstudios.texteditor.state.moveCursorDown
 import com.darkrockstudios.texteditor.state.moveCursorPageDown
 import com.darkrockstudios.texteditor.state.moveCursorPageUp
@@ -29,22 +20,19 @@ import com.darkrockstudios.texteditor.state.moveToDocumentStart
 import com.darkrockstudios.texteditor.state.moveToNextWord
 import com.darkrockstudios.texteditor.state.moveToPreviousWord
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
  * Handles keyboard commands (shortcuts and navigation) for the text editor.
  * Also handles character input for desktop platforms via KEY_TYPED events.
  *
- * Which chord triggers which command is [keyBindings]' business; this class only
- * knows what the commands do.
+ * Pure translation, three ways: which chord means what is [keyBindings]'
+ * business, what an action does belongs to the [EditorActionRegistry] on the
+ * state, and only caret motion is implemented here, because a motion is not
+ * something a host can register.
  */
 internal class TextEditorKeyCommandHandler(
 	var keyBindings: KeyBindings,
 ) {
-
-	private companion object {
-		const val TAB_SIZE = 4
-	}
 
 	/**
 	 * Handle a key event and return true if it was consumed.
@@ -64,27 +52,20 @@ internal class TextEditorKeyCommandHandler(
 		// Selection, copy and navigation stay available in a disabled editor.
 		if (command.isEdit && !enabled) return false
 
-		when (command) {
-			is Motion -> moveCursor(command, state, extendSelection = keyEvent.isShiftPressed)
-			Action.SelectAll -> state.selector.selectAll()
-			Action.Copy -> handleCopy(state, clipboard, scope)
-			Action.Cut -> handleCut(state, clipboard, scope)
-			Action.Paste -> handlePaste(state, clipboard, scope)
-			Action.Undo -> state.undo()
-			Action.Redo -> state.redo()
-			Action.DeleteBackward -> handleBackspace(state)
-			Action.DeleteForward -> handleDelete(state)
-			Action.DeleteWordBackward -> handleDeletePreviousWord(state)
-			Action.DeleteWordForward -> handleDeleteNextWord(state)
-			Action.DeleteToLineStart -> handleDeleteToLineStart(state)
-			Action.Indent -> handleIndent(state)
-			Action.Outdent -> handleOutdent(state)
-			Action.NewLine -> handleEnter(state)
-			// An action nothing here implements must not swallow the keystroke, or a
-			// chord bound to it would eat the character instead of typing it.
-			else -> return false
+		return when (command) {
+			is Motion -> {
+				moveCursor(command, state, extendSelection = keyEvent.isShiftPressed)
+				true
+			}
+
+			is Action -> {
+				// An action nobody registered must not swallow the keystroke, or a
+				// chord bound to it would eat the character instead of typing it.
+				val spec = state.actions[command] ?: return false
+				spec.perform(EditorActionContext(state, clipboard, scope))
+				true
+			}
 		}
-		return true
 	}
 
 	/**
@@ -128,197 +109,6 @@ internal class TextEditorKeyCommandHandler(
 		state.insertStringAtCursor(character)
 
 		return true
-	}
-
-	private fun handleCopy(state: TextEditorState, clipboard: Clipboard, scope: CoroutineScope) {
-		state.selector.selection?.let { selection ->
-			val selectedText = state.selector.getSelectedText()
-			val copyId = state.copyRichSpans(selection)
-			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
-			}
-		}
-	}
-
-	private fun handleCut(state: TextEditorState, clipboard: Clipboard, scope: CoroutineScope) {
-		state.selector.selection?.let { selection ->
-			val selectedText = state.selector.getSelectedText()
-			val copyId = state.copyRichSpans(selection)
-			state.preserveCopiedRichSpansThroughNextEdit()
-			state.selector.deleteSelection()
-			scope.launch {
-				ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
-			}
-		}
-	}
-
-	private fun handlePaste(state: TextEditorState, clipboard: Clipboard, scope: CoroutineScope) {
-		scope.launch {
-			ClipboardHelper.getText(clipboard, state.markdownConfiguration)?.let { text ->
-				val curSelection = state.selector.selection
-				val insertPosition = curSelection?.start ?: state.cursorPosition
-				// Read the clipboard's HTML before mutating: the text, the in-editor
-				// rich spans and the pasted block structure then land as one revision.
-				val htmlDocument = state.readHtmlPasteDocument(clipboard, text)
-				val clipboardCopyId = ClipboardHelper.readCopyId(clipboard)
-				state.preserveCopiedRichSpansThroughNextEdit()
-				state.withAtomicEdit {
-					if (curSelection != null) {
-						state.replace(curSelection, state.applyStyleForEditAt(curSelection.start, text))
-					} else {
-						state.insertStringAtCursor(text)
-					}
-					state.pasteRichSpans(
-						insertPosition,
-						text,
-						clipboardCopyId,
-						requireCopyIdMatch = ClipboardHelper.supportsCopyProvenance,
-					)
-					htmlDocument?.let { state.applyHtmlPasteBlocks(it, insertPosition, text) }
-				}
-				state.selector.clearSelection()
-			}
-		}
-	}
-
-	private fun handleDelete(state: TextEditorState) {
-		if (state.selector.selection != null) {
-			state.selector.deleteSelection()
-		} else {
-			state.deleteAtCursor()
-		}
-	}
-
-	private fun handleBackspace(state: TextEditorState) {
-		if (state.selector.selection != null) {
-			state.selector.deleteSelection()
-		} else {
-			state.backspaceAtCursor()
-		}
-	}
-
-	private fun handleDeletePreviousWord(state: TextEditorState) =
-		deleteByMotion(state) { state.moveToPreviousWord() }
-
-	private fun handleDeleteNextWord(state: TextEditorState) =
-		deleteByMotion(state) { state.moveToNextWord() }
-
-	private fun handleDeleteToLineStart(state: TextEditorState) =
-		deleteByMotion(state) { state.cursor.moveToLineStart() }
-
-	/**
-	 * Deletes between the caret and wherever [locateRangeEdge] moves it, or the selection when
-	 * there is one. The caret the user had is handed to [TextEditorState.delete] explicitly:
-	 * [locateRangeEdge] has already moved it off that position, and delete otherwise records
-	 * wherever the caret currently sits as the position undo returns to.
-	 */
-	private fun deleteByMotion(state: TextEditorState, locateRangeEdge: () -> Unit) {
-		if (state.selector.selection != null) {
-			state.selector.deleteSelection()
-			return
-		}
-		val origin = state.cursorPosition
-		locateRangeEdge()
-		val edge = state.cursorPosition
-		if (edge == origin) return
-
-		val range = if (edge < origin) {
-			TextEditorRange(edge, origin)
-		} else {
-			TextEditorRange(origin, edge)
-		}
-		state.delete(range, cursorBefore = origin)
-	}
-
-	private fun handleIndent(state: TextEditorState) {
-		val selection = state.selector.selection
-		if (selection != null && selection.start.line != selection.end.line) {
-			indentLineRange(state, selection.start.line, selection.end.line)
-		} else {
-			if (selection != null) {
-				state.selector.deleteSelection()
-			}
-			state.insertStringAtCursor(" ".repeat(TAB_SIZE))
-		}
-	}
-
-	private fun handleOutdent(state: TextEditorState) {
-		val selection = state.selector.selection
-		if (selection != null) {
-			outdentLineRange(state, selection.start.line, selection.end.line)
-		} else {
-			outdentCurrentLine(state)
-		}
-	}
-
-	private fun indentLineRange(state: TextEditorState, startLine: Int, endLine: Int) {
-		val prefix = " ".repeat(TAB_SIZE)
-		val newText = buildAnnotatedString {
-			for (i in startLine..endLine) {
-				if (i > startLine) append('\n')
-				append(prefix)
-				append(state.textLines[i])
-			}
-		}
-		val range = TextEditorRange(
-			CharLineOffset(startLine, 0),
-			CharLineOffset(endLine, state.textLines[endLine].length)
-		)
-		state.replace(range, newText)
-		state.selector.updateSelection(
-			CharLineOffset(startLine, 0),
-			CharLineOffset(endLine, state.textLines[endLine].length)
-		)
-	}
-
-	private fun outdentLineRange(state: TextEditorState, startLine: Int, endLine: Int) {
-		var changed = false
-		val newText = buildAnnotatedString {
-			for (i in startLine..endLine) {
-				if (i > startLine) append('\n')
-				val line = state.textLines[i]
-				val remove = leadingOutdentWidth(line)
-				if (remove > 0) changed = true
-				append(line.subSequence(remove, line.length))
-			}
-		}
-		if (!changed) return
-
-		val range = TextEditorRange(
-			CharLineOffset(startLine, 0),
-			CharLineOffset(endLine, state.textLines[endLine].length)
-		)
-		state.replace(range, newText)
-		state.selector.updateSelection(
-			CharLineOffset(startLine, 0),
-			CharLineOffset(endLine, state.textLines[endLine].length)
-		)
-	}
-
-	private fun outdentCurrentLine(state: TextEditorState) {
-		val line = state.cursorPosition.line
-		val remove = leadingOutdentWidth(state.textLines[line])
-		if (remove == 0) return
-
-		val cursorChar = state.cursorPosition.char
-		state.delete(TextEditorRange(CharLineOffset(line, 0), CharLineOffset(line, remove)))
-		state.cursor.updatePosition(CharLineOffset(line, (cursorChar - remove).coerceAtLeast(0)))
-	}
-
-	/** Leading indentation to strip for one outdent level: a single hard tab, else up to [TAB_SIZE] spaces. */
-	private fun leadingOutdentWidth(line: AnnotatedString): Int {
-		if (line.isEmpty()) return 0
-		if (line[0] == '\t') return 1
-		var count = 0
-		while (count < TAB_SIZE && count < line.length && line[count] == ' ') count++
-		return count
-	}
-
-	private fun handleEnter(state: TextEditorState) {
-		if (state.selector.selection != null) {
-			state.selector.deleteSelection()
-		}
-		state.insertNewlineAtCursor()
 	}
 
 	private fun moveCursor(motion: Motion, state: TextEditorState, extendSelection: Boolean) {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/TextEditorKeyCommandHandler.kt
@@ -49,8 +49,6 @@ internal class TextEditorKeyCommandHandler(
 		if (keyEvent.type != KeyEventType.KeyDown) return false
 
 		val command = keyBindings.commandFor(keyEvent) ?: return false
-		// Selection, copy and navigation stay available in a disabled editor.
-		if (command.isEdit && !enabled) return false
 
 		return when (command) {
 			is Motion -> {
@@ -59,9 +57,15 @@ internal class TextEditorKeyCommandHandler(
 			}
 
 			is Action -> {
-				// An action nobody registered must not swallow the keystroke, or a
-				// chord bound to it would eat the character instead of typing it.
+				// An action nobody registered must not swallow the keystroke, so that a
+				// chord the host forgot to implement stays available to everything below.
 				val spec = state.actions[command] ?: return false
+				// Whether this edits comes from the registered spec, never from the
+				// Action the bindings handed us: identity is the id alone, so a host
+				// writing `Action("editor.paste", isEdit = false)` in its own bindings
+				// would otherwise resolve the real paste and mutate a disabled editor.
+				// Selection, copy and navigation stay available in a disabled editor.
+				if (spec.action.isEdit && !enabled) return false
 				spec.perform(EditorActionContext(state, clipboard, scope))
 				true
 			}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockEditBehavior.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockEditBehavior.kt
@@ -1,0 +1,62 @@
+package com.darkrockstudios.texteditor.richstyle
+
+import com.darkrockstudios.texteditor.state.EditBehavior
+import com.darkrockstudios.texteditor.state.TextEditorState
+
+/**
+ * Smart editing for lines carrying a [LineBlockStyle]: Enter on an empty item
+ * exits the block, backspace at its start demotes it, and a split keeps the
+ * gutter marker on both halves. See the "Smart editing" section of
+ * `docs/design/line-blocks.md`.
+ *
+ * Registered on every [TextEditorState] by default. Remove it from
+ * [TextEditorState.editBehaviors] for an editor that wants plain line breaks.
+ */
+object LineBlockEditBehavior : EditBehavior {
+
+	override fun onNewline(state: TextEditorState): Boolean {
+		val line = state.cursorPosition.line
+		val block = state.detectLineBlock(line) ?: return false
+
+		// Enter on an empty bullet/quote item exits the block: drop the gutter
+		// marker and indent, eat the keystroke. Matches Notion / Google Docs and
+		// gives a discoverable way to leave a list or quote without backspacing.
+		// Routed through the toggle so the demotion lands in undo history.
+		if (state.textLines.getOrNull(line)?.text.isNullOrEmpty()) {
+			state.editManager.toggleLineBlock(line..line, block)
+			return true
+		}
+
+		// The split and the block markers are one revision. Published separately, a
+		// reader between them sees the new half-line with its marker missing.
+		state.withAtomicEdit {
+			state.insertNewlineRaw()
+
+			// RichSpanManager's newline handling only keeps the span on one side when
+			// the cursor was at a span boundary, so apply to both lines so both halves
+			// of the split keep the gutter marker. applyLineBlock is idempotent.
+			state.applyLineBlock(line, block)
+			state.applyLineBlock(line + 1, block)
+		}
+		return true
+	}
+
+	override fun onBackspace(state: TextEditorState): Boolean {
+		// Backspace at column 0 of a line-block (blockquote, bullet) first demotes
+		// (removes the gutter marker and indent); a follow-up backspace then merges
+		// with the previous line. Matches Notion / Google Docs, a discoverable way
+		// to exit a block prefix without nuking the line content.
+		//
+		// Exception: if the previous line is the SAME line-block, fall through to
+		// merge directly. Otherwise demote-first turns "join two adjacent items"
+		// into a two-keystroke operation, which feels worse than Docs/Notion.
+		val position = state.cursorPosition
+		if (position.char != 0) return false
+		val activeBlock = state.detectLineBlock(position.line) ?: return false
+		if (state.detectLineBlock(position.line - 1) == activeBlock) return false
+
+		// Routed through the toggle so the demotion lands in undo history.
+		state.editManager.toggleLineBlock(position.line..position.line, activeBlock)
+		return true
+	}
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockEditBehavior.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/LineBlockEditBehavior.kt
@@ -18,10 +18,8 @@ object LineBlockEditBehavior : EditBehavior {
 		val line = state.cursorPosition.line
 		val block = state.detectLineBlock(line) ?: return false
 
-		// Enter on an empty bullet/quote item exits the block: drop the gutter
-		// marker and indent, eat the keystroke. Matches Notion / Google Docs and
-		// gives a discoverable way to leave a list or quote without backspacing.
-		// Routed through the toggle so the demotion lands in undo history.
+		// Enter on an empty item exits the block (matches Notion / Google Docs);
+		// routed through the toggle so the demotion lands in undo history.
 		if (state.textLines.getOrNull(line)?.text.isNullOrEmpty()) {
 			state.editManager.toggleLineBlock(line..line, block)
 			return true
@@ -32,9 +30,8 @@ object LineBlockEditBehavior : EditBehavior {
 		state.withAtomicEdit {
 			state.insertNewlineRaw()
 
-			// RichSpanManager's newline handling only keeps the span on one side when
-			// the cursor was at a span boundary, so apply to both lines so both halves
-			// of the split keep the gutter marker. applyLineBlock is idempotent.
+			// A split at a span boundary keeps the span on only one side, so apply
+			// to both halves; applyLineBlock is idempotent.
 			state.applyLineBlock(line, block)
 			state.applyLineBlock(line + 1, block)
 		}
@@ -42,14 +39,10 @@ object LineBlockEditBehavior : EditBehavior {
 	}
 
 	override fun onBackspace(state: TextEditorState): Boolean {
-		// Backspace at column 0 of a line-block (blockquote, bullet) first demotes
-		// (removes the gutter marker and indent); a follow-up backspace then merges
-		// with the previous line. Matches Notion / Google Docs, a discoverable way
-		// to exit a block prefix without nuking the line content.
-		//
-		// Exception: if the previous line is the SAME line-block, fall through to
-		// merge directly. Otherwise demote-first turns "join two adjacent items"
-		// into a two-keystroke operation, which feels worse than Docs/Notion.
+		// Backspace at column 0 of a block line first demotes; a second backspace
+		// then merges (matches Notion / Google Docs). Exception: when the previous
+		// line is the SAME block, fall through and merge directly, or joining two
+		// adjacent items becomes a two-keystroke operation.
 		val position = state.cursorPosition
 		if (position.char != 0) return false
 		val activeBlock = state.detectLineBlock(position.line) ?: return false

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/EditBehavior.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/EditBehavior.kt
@@ -1,24 +1,15 @@
 package com.darkrockstudios.texteditor.state
 
 /**
- * A hook consulted before the editor carries out one of its semantic edits, for
- * features that need to change what an edit *means* rather than what a key does.
+ * A hook consulted before one of the editor's semantic edits. Unlike an
+ * [EditorActionRegistry][com.darkrockstudios.texteditor.input.EditorActionRegistry]
+ * action, a behavior needs no trigger: a soft keyboard deletes and commits text
+ * without ever producing a key event, and the semantic edit is the only point
+ * every input path shares. See `docs/design/editor-actions.md`.
  *
- * This is the counterpart to
- * [EditorActionRegistry][com.darkrockstudios.texteditor.input.EditorActionRegistry],
- * and the two are not interchangeable. An action is invoked by name, so it
- * needs something to invoke it: a chord, a menu item, a toolbar button. A
- * behavior intercepts an edit that may have no such trigger at all, because a
- * soft keyboard can commit a newline or delete a character through
- * `InputConnection` without ever producing a key event. The edit itself is the
- * only point every input path shares.
- *
- * Returning true means "handled, do nothing else"; the primitive is skipped.
- * Returning false passes the edit along. The first behavior in
- * [TextEditorState.editBehaviors] to claim an edit wins.
- *
- * A behavior that mutates the document should route through the edit manager,
- * so its work lands in undo history as one revision like any other operation.
+ * Returning true means "handled, do nothing else"; the first behavior in
+ * [TextEditorState.editBehaviors] to claim an edit wins. A behavior that mutates
+ * should route through the edit manager so its work lands in undo history.
  */
 interface EditBehavior {
 	/** Called before a line break is inserted at the caret. */

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/EditBehavior.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/EditBehavior.kt
@@ -1,0 +1,32 @@
+package com.darkrockstudios.texteditor.state
+
+/**
+ * A hook consulted before the editor carries out one of its semantic edits, for
+ * features that need to change what an edit *means* rather than what a key does.
+ *
+ * This is the counterpart to
+ * [EditorActionRegistry][com.darkrockstudios.texteditor.input.EditorActionRegistry],
+ * and the two are not interchangeable. An action is invoked by name, so it
+ * needs something to invoke it: a chord, a menu item, a toolbar button. A
+ * behavior intercepts an edit that may have no such trigger at all, because a
+ * soft keyboard can commit a newline or delete a character through
+ * `InputConnection` without ever producing a key event. The edit itself is the
+ * only point every input path shares.
+ *
+ * Returning true means "handled, do nothing else"; the primitive is skipped.
+ * Returning false passes the edit along. The first behavior in
+ * [TextEditorState.editBehaviors] to claim an edit wins.
+ *
+ * A behavior that mutates the document should route through the edit manager,
+ * so its work lands in undo history as one revision like any other operation.
+ */
+interface EditBehavior {
+	/** Called before a line break is inserted at the caret. */
+	fun onNewline(state: TextEditorState): Boolean = false
+
+	/** Called before the character preceding the caret is deleted. */
+	fun onBackspace(state: TextEditorState): Boolean = false
+
+	/** Called before the character following the caret is deleted. */
+	fun onDeleteForward(state: TextEditorState): Boolean = false
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -33,12 +33,10 @@ import com.darkrockstudios.texteditor.input.EditorActionRegistry
 import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import com.darkrockstudios.texteditor.richstyle.BlockSpanStyle
 import com.darkrockstudios.texteditor.richstyle.CodeFenceSpanStyle
+import com.darkrockstudios.texteditor.richstyle.LineBlockEditBehavior
 import com.darkrockstudios.texteditor.richstyle.OrderedListSpanStyle
 import com.darkrockstudios.texteditor.richstyle.RichSpan
 import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
-import com.darkrockstudios.texteditor.richstyle.applyLineBlock
-import com.darkrockstudios.texteditor.richstyle.demoteLineBlock
-import com.darkrockstudios.texteditor.richstyle.detectLineBlock
 import com.darkrockstudios.texteditor.richstyle.normalizeLineBlocks
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -395,6 +393,17 @@ class TextEditorState(
 	/** Book-keeping for the document's [RichSpan] block decorations (lists, quotes, code fences, highlights). */
 	val richSpanManager = RichSpanManager(this)
 
+	/**
+	 * Behaviors consulted before [insertNewlineAtCursor], [backspaceAtCursor] and
+	 * [deleteAtCursor], in order; the first to claim an edit wins. Every input
+	 * path reaches these three, so a behavior applies to hardware keys and to an
+	 * IME alike.
+	 *
+	 * Pre-loaded with [LineBlockEditBehavior]. Add your own, reorder them, or
+	 * clear the list for an editor that wants the primitives untouched.
+	 */
+	val editBehaviors: MutableList<EditBehavior> = mutableListOf(LineBlockEditBehavior)
+
 	// In-editor rich-span clipboard. The system clipboard only carries the
 	// AnnotatedString (text + character-level spans), so line-anchored rich spans
 	// like ordered/bullet lists would be lost on a copy→paste round-trip. We
@@ -492,73 +501,35 @@ class TextEditorState(
 	}
 
 	/**
-	 * Inserts a line break at the cursor, splitting the current line. On an empty
-	 * list or blockquote item this instead exits the block (dropping its gutter
-	 * marker) and consumes the keystroke.
+	 * Inserts a line break at the cursor, splitting the current line, unless an
+	 * [EditBehavior] claims the edit first.
 	 */
 	fun insertNewlineAtCursor() {
-		val originalLine = cursorPosition.line
-		val activeBlock = detectLineBlock(originalLine)
-		val lineText = textLines.getOrNull(originalLine)?.text ?: ""
+		if (editBehaviors.any { it.onNewline(this) }) return
+		insertNewlineRaw()
+	}
 
-		// Enter on an empty bullet/quote item exits the block — drop the gutter
-		// marker and indent, eat the keystroke. Matches Notion / Google Docs and
-		// gives a discoverable way to leave a list or quote without backspacing.
-		// Routed through the toggle so the demotion lands in undo history.
-		if (lineText.isEmpty() && activeBlock != null) {
-			editManager.toggleLineBlock(originalLine..originalLine, activeBlock)
-			return
-		}
-
+	/**
+	 * Splits the line at the cursor with no [EditBehavior] consulted, for a
+	 * behavior that needs the plain split as part of the edit it is claiming.
+	 */
+	internal fun insertNewlineRaw() {
 		val operation = TextEditOperation.Insert(
 			position = cursorPosition,
 			text = cursor.applyCursorStyle("\n"),
 			cursorBefore = cursorPosition,
-			cursorAfter = CharLineOffset(originalLine + 1, 0)
+			cursorAfter = CharLineOffset(cursorPosition.line + 1, 0)
 		)
-		// The split and the block markers are one revision. Published separately, a
-		// reader between them sees the new half-line with its marker missing.
-		withAtomicEdit {
-			editManager.applyOperation(operation)
-
-			// RichSpanManager's newline handling only keeps the span on one side when
-			// the cursor was at a span boundary, so apply to both lines so both halves
-			// of the split keep the gutter marker. applyLineBlock is idempotent.
-			activeBlock?.let {
-				applyLineBlock(originalLine, it)
-				applyLineBlock(originalLine + 1, it)
-			}
-		}
+		editManager.applyOperation(operation)
 	}
 
 	/**
-	 * Deletes the character before the cursor, merging with the previous line when at
-	 * column 0. At the start of a list or blockquote item it first demotes the block
-	 * (removing its gutter marker) unless the previous line shares the same block.
+	 * Deletes the character before the cursor, merging with the previous line when
+	 * at column 0, unless an [EditBehavior] claims the edit first.
 	 */
 	fun backspaceAtCursor() {
-		// Backspace at column 0 of a line-block (blockquote, bullet) first demotes
-		// (removes the gutter marker and indent); a follow-up backspace then merges
-		// with the previous line. Matches Notion / Google Docs — discoverable way
-		// to exit a block prefix without nuking the line content.
-		//
-		// Exception: if the previous line is the SAME line-block, fall through to
-		// merge directly. Otherwise demote-first turns "join two adjacent items"
-		// into a two-keystroke operation, which feels worse than Docs/Notion.
-		if (cursorPosition.char == 0) {
-			val activeBlock = detectLineBlock(cursorPosition.line)
-			if (activeBlock != null) {
-				val prevBlock = detectLineBlock(cursorPosition.line - 1)
-				if (prevBlock != activeBlock) {
-					// Routed through the toggle so the demotion lands in undo history.
-					editManager.toggleLineBlock(
-						cursorPosition.line..cursorPosition.line,
-						activeBlock,
-					)
-					return
-				}
-			}
-		}
+		if (editBehaviors.any { it.onBackspace(this) }) return
+
 		if (cursorPosition.char > 0) {
 			val deleteRange = TextEditorRange(
 				CharLineOffset(cursorPosition.line, cursorPosition.char - 1),
@@ -589,9 +560,12 @@ class TextEditorState(
 
 	/**
 	 * Deletes the character after the cursor, merging the next line into the current
-	 * one when at end of line (forward delete).
+	 * one when at end of line (forward delete), unless an [EditBehavior] claims the
+	 * edit first.
 	 */
 	fun deleteAtCursor() {
+		if (editBehaviors.any { it.onDeleteForward(this) }) return
+
 		if (cursorPosition.char < textLines[cursorPosition.line].length) {
 			val deleteRange = TextEditorRange(
 				cursorPosition,

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -397,16 +397,12 @@ class TextEditorState(
 	/**
 	 * Behaviors consulted before [insertNewlineAtCursor], [backspaceAtCursor] and
 	 * [deleteAtCursor], in order; the first to claim an edit wins. Every input
-	 * path reaches these three, so a behavior applies to hardware keys and to an
-	 * IME alike.
+	 * path reaches these three, hardware keys and IME alike.
 	 *
-	 * Pre-loaded with [LineBlockEditBehavior], which sits at index 0 and claims
-	 * every newline and every column-0 backspace on a line carrying a block style
-	 * (header, blockquote, list, code fence). Appending with `add` therefore puts
-	 * your behavior *after* it, where it never sees those edits: an auto-indent
-	 * added that way would be dead inside a code fence, which is where it is most
-	 * wanted. Use `add(0, behavior)` to run first, or remove
-	 * [LineBlockEditBehavior] outright for an editor that wants plain line breaks.
+	 * Pre-loaded with [LineBlockEditBehavior] at index 0, which claims every
+	 * newline and column-0 backspace on a block line, so a behavior appended
+	 * after it never sees those edits. Use `add(0, behavior)` to run first, or
+	 * remove it outright for plain line breaks.
 	 */
 	val editBehaviors: MutableList<EditBehavior> = mutableListOf(LineBlockEditBehavior)
 
@@ -414,19 +410,14 @@ class TextEditorState(
 	private var behaviorDepth = 0
 
 	/**
-	 * Offers the edit to each behavior until one claims it.
+	 * Offers the edit to each behavior until one claims it. Iterates a snapshot
+	 * so a behavior may mutate the list mid-edit; nested calls skip the chain, so
+	 * a behavior can finish with an ordinary edit without being offered its own
+	 * edit again forever.
 	 *
-	 * Iterates a snapshot so a behavior may register or remove behaviors while
-	 * handling an edit. Nested calls skip the chain entirely, which is what lets a
-	 * behavior finish with the ordinary edit: an auto-indent that inserts its
-	 * whitespace and then calls [insertNewlineAtCursor] gets the plain split rather
-	 * than being offered its own edit again forever.
-	 *
-	 * A claim also asks the IME to resync. Once a behavior has answered the edit,
-	 * the keyboard's assumption about what its request did is unreliable in a way
-	 * no diff of the text can express: the edit may have changed only styling, or
-	 * inserted more than was asked for. The request is cheap and platforms without
-	 * an IME drop it.
+	 * A claim also asks the IME to resync: once a behavior answered the edit, the
+	 * keyboard's assumption about what its request did is wrong in a way no diff
+	 * of the text can express.
 	 */
 	private fun claimedByBehavior(hook: (EditBehavior) -> Boolean): Boolean {
 		if (behaviorDepth > 0) return false

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -40,6 +40,7 @@ import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
 import com.darkrockstudios.texteditor.richstyle.normalizeLineBlocks
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlin.concurrent.Volatile
 import kotlin.math.min
@@ -399,10 +400,23 @@ class TextEditorState(
 	 * path reaches these three, so a behavior applies to hardware keys and to an
 	 * IME alike.
 	 *
-	 * Pre-loaded with [LineBlockEditBehavior]. Add your own, reorder them, or
-	 * clear the list for an editor that wants the primitives untouched.
+	 * Pre-loaded with [LineBlockEditBehavior], which sits at index 0 and claims
+	 * every newline and every column-0 backspace on a line carrying a block style
+	 * (header, blockquote, list, code fence). Appending with `add` therefore puts
+	 * your behavior *after* it, where it never sees those edits: an auto-indent
+	 * added that way would be dead inside a code fence, which is where it is most
+	 * wanted. Use `add(0, behavior)` to run first, or remove
+	 * [LineBlockEditBehavior] outright for an editor that wants plain line breaks.
 	 */
 	val editBehaviors: MutableList<EditBehavior> = mutableListOf(LineBlockEditBehavior)
+
+	/**
+	 * Offers the edit to each behavior until one claims it. Iterates a snapshot so
+	 * that a behavior which registers or removes a behavior while handling an edit
+	 * does not fail the keystroke that triggered it.
+	 */
+	private inline fun claimedByBehavior(hook: (EditBehavior) -> Boolean): Boolean =
+		editBehaviors.toList().any(hook)
 
 	// In-editor rich-span clipboard. The system clipboard only carries the
 	// AnnotatedString (text + character-level spans), so line-anchored rich spans
@@ -500,12 +514,25 @@ class TextEditorState(
 		composingRange = null
 	}
 
+	private val _imeResyncRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+	/**
+	 * Fires when the editor answered an IME request in a way the IME cannot infer
+	 * from the text or the caret, so its mirror of the buffer has to be pushed
+	 * again rather than deduplicated away. Platforms without an IME ignore it.
+	 */
+	internal val imeResyncRequests: Flow<Unit> = _imeResyncRequests
+
+	internal fun requestImeResync() {
+		_imeResyncRequests.tryEmit(Unit)
+	}
+
 	/**
 	 * Inserts a line break at the cursor, splitting the current line, unless an
 	 * [EditBehavior] claims the edit first.
 	 */
 	fun insertNewlineAtCursor() {
-		if (editBehaviors.any { it.onNewline(this) }) return
+		if (claimedByBehavior { it.onNewline(this) }) return
 		insertNewlineRaw()
 	}
 
@@ -528,7 +555,7 @@ class TextEditorState(
 	 * at column 0, unless an [EditBehavior] claims the edit first.
 	 */
 	fun backspaceAtCursor() {
-		if (editBehaviors.any { it.onBackspace(this) }) return
+		if (claimedByBehavior { it.onBackspace(this) }) return
 
 		if (cursorPosition.char > 0) {
 			val deleteRange = TextEditorRange(
@@ -564,7 +591,7 @@ class TextEditorState(
 	 * edit first.
 	 */
 	fun deleteAtCursor() {
-		if (editBehaviors.any { it.onDeleteForward(this) }) return
+		if (claimedByBehavior { it.onDeleteForward(this) }) return
 
 		if (cursorPosition.char < textLines[cursorPosition.line].length) {
 			val deleteRange = TextEditorRange(

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -410,13 +410,37 @@ class TextEditorState(
 	 */
 	val editBehaviors: MutableList<EditBehavior> = mutableListOf(LineBlockEditBehavior)
 
+	/** Depth of the behavior chain currently dispatching, to break recursion. */
+	private var behaviorDepth = 0
+
 	/**
-	 * Offers the edit to each behavior until one claims it. Iterates a snapshot so
-	 * that a behavior which registers or removes a behavior while handling an edit
-	 * does not fail the keystroke that triggered it.
+	 * Offers the edit to each behavior until one claims it.
+	 *
+	 * Iterates a snapshot so a behavior may register or remove behaviors while
+	 * handling an edit. Nested calls skip the chain entirely, which is what lets a
+	 * behavior finish with the ordinary edit: an auto-indent that inserts its
+	 * whitespace and then calls [insertNewlineAtCursor] gets the plain split rather
+	 * than being offered its own edit again forever.
+	 *
+	 * A claim also asks the IME to resync. Once a behavior has answered the edit,
+	 * the keyboard's assumption about what its request did is unreliable in a way
+	 * no diff of the text can express: the edit may have changed only styling, or
+	 * inserted more than was asked for. The request is cheap and platforms without
+	 * an IME drop it.
 	 */
-	private inline fun claimedByBehavior(hook: (EditBehavior) -> Boolean): Boolean =
-		editBehaviors.toList().any(hook)
+	private fun claimedByBehavior(hook: (EditBehavior) -> Boolean): Boolean {
+		if (behaviorDepth > 0) return false
+
+		behaviorDepth++
+		val claimed = try {
+			editBehaviors.toList().any(hook)
+		} finally {
+			behaviorDepth--
+		}
+
+		if (claimed) requestImeResync()
+		return claimed
+	}
 
 	// In-editor rich-span clipboard. The system clipboard only carries the
 	// AnnotatedString (text + character-level spans), so line-anchored rich spans

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -29,6 +29,7 @@ import com.darkrockstudios.texteditor.coerceInto
 import com.darkrockstudios.texteditor.cursor.CursorMetrics
 import com.darkrockstudios.texteditor.cursor.getWrappedLineIndex
 import com.darkrockstudios.texteditor.effectiveHeight
+import com.darkrockstudios.texteditor.input.EditorActionRegistry
 import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import com.darkrockstudios.texteditor.richstyle.BlockSpanStyle
 import com.darkrockstudios.texteditor.richstyle.CodeFenceSpanStyle
@@ -427,6 +428,14 @@ class TextEditorState(
 	 * Collect this to observe the edit stream; decoration-only changes are excluded.
 	 */
 	val editOperations = editManager.editOperations
+
+	/**
+	 * Everything this editor can be asked to do, keyed by action id, pre-loaded
+	 * with the built-ins. Register here to add an action a custom
+	 * [KeyBindings][com.darkrockstudios.texteditor.input.KeyBindings] can bind or
+	 * a menu can invoke, or to replace a built-in with your own implementation.
+	 */
+	val actions: EditorActionRegistry = EditorActionRegistry()
 
 	/**
 	 * Replaces the entire document with [text], clearing rich spans and resetting

--- a/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.desktop.kt
+++ b/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.desktop.kt
@@ -8,5 +8,5 @@ internal fun keyBindingsForOs(osName: String): KeyBindings =
 		CtrlKeyBindings
 	}
 
-internal actual fun platformKeyBindings(): KeyBindings =
+actual fun platformKeyBindings(): KeyBindings =
 	keyBindingsForOs(System.getProperty("os.name").orEmpty())

--- a/ComposeTextEditor/src/desktopTest/kotlin/contextmenu/ContextMenuRegistryTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/contextmenu/ContextMenuRegistryTest.kt
@@ -99,6 +99,44 @@ class ContextMenuRegistryTest {
 		assertEquals(1, ran)
 	}
 
+	/**
+	 * The keyboard refuses editing actions in a read-only editor; a menu item built
+	 * on the same registry has to refuse them too, or it becomes the way around it.
+	 */
+	@Test
+	fun `a read-only editor refuses editing actions from the menu`() = runTest {
+		val state = editor()
+		val actions = ContextMenuActions(state, InMemoryClipboard(), this, enabled = false)
+		state.selector.updateSelection(CharLineOffset(0, 0), CharLineOffset(0, 5))
+
+		assertFalse(actions.canCut())
+		assertFalse(actions.canPaste())
+		assertTrue(actions.canCopy())
+		assertTrue(actions.canPerform(Action.SelectAll))
+
+		actions.cut()
+		assertEquals("hello world", state.getAllText().text)
+	}
+
+	/**
+	 * Action identity is the id alone, so replacing a built-in with a spec that
+	 * declares itself non-editing must not get that spec past the read-only gate.
+	 */
+	@Test
+	fun `a replaced builtin cannot declare itself non-editing`() = runTest {
+		val state = editor()
+		val actions = ContextMenuActions(state, InMemoryClipboard(), this, enabled = false)
+		var ran = 0
+		state.actions.register(
+			EditorActionSpec(Action("editor.paste", isEdit = false)) { ran++ }
+		)
+
+		assertFalse(actions.canPaste())
+		actions.paste()
+
+		assertEquals(0, ran)
+	}
+
 	@Test
 	fun `an unregistered action is inert rather than fatal`() = runTest {
 		val state = editor()

--- a/ComposeTextEditor/src/desktopTest/kotlin/contextmenu/ContextMenuRegistryTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/contextmenu/ContextMenuRegistryTest.kt
@@ -1,0 +1,113 @@
+package contextmenu
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.contextmenu.ContextMenuActions
+import com.darkrockstudios.texteditor.input.EditorActionSpec
+import com.darkrockstudios.texteditor.input.EditorCommand.Action
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import utils.InMemoryClipboard
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The context menu resolves through the action registry, so a host that replaces
+ * or drops a built-in changes the menu and the keyboard together.
+ */
+class ContextMenuRegistryTest {
+
+	private fun TestScope.editor(): TextEditorState = TextEditorState(
+		scope = this,
+		measurer = mockk(relaxed = true),
+		initialText = AnnotatedString("hello world"),
+	)
+
+	private fun TestScope.actionsFor(state: TextEditorState) =
+		ContextMenuActions(state, InMemoryClipboard(), this)
+
+	@Test
+	fun `menu items run the registered implementation`() = runTest {
+		val state = editor()
+		val actions = actionsFor(state)
+		val ran = mutableListOf<String>()
+		state.actions.register(EditorActionSpec(Action.Cut) { ran += "cut" })
+		state.actions.register(EditorActionSpec(Action.Copy) { ran += "copy" })
+		state.actions.register(EditorActionSpec(Action.Paste) { ran += "paste" })
+		state.actions.register(EditorActionSpec(Action.SelectAll) { ran += "selectAll" })
+
+		actions.cut()
+		actions.copy()
+		actions.paste()
+		actions.selectAll()
+
+		assertEquals(listOf("cut", "copy", "paste", "selectAll"), ran)
+	}
+
+	@Test
+	fun `cut and copy track the selection`() = runTest {
+		val state = editor()
+		val actions = actionsFor(state)
+
+		assertFalse(actions.canCut())
+		assertFalse(actions.canCopy())
+
+		state.selector.updateSelection(CharLineOffset(0, 0), CharLineOffset(0, 5))
+
+		assertTrue(actions.canCut())
+		assertTrue(actions.canCopy())
+	}
+
+	@Test
+	fun `paste is offered whenever it is registered`() = runTest {
+		val state = editor()
+		val actions = actionsFor(state)
+
+		assertTrue(actions.canPaste())
+
+		state.actions.unregister(Action.Paste)
+
+		assertFalse(actions.canPaste())
+	}
+
+	@Test
+	fun `a host action can drive its own menu item`() = runTest {
+		val state = editor()
+		val actions = actionsFor(state)
+		val custom = Action("myapp.shout", isEdit = true)
+		var ran = 0
+
+		assertFalse(actions.canPerform(custom))
+
+		state.actions.register(
+			EditorActionSpec(
+				action = custom,
+				isEnabled = { it.state.selector.hasSelection() },
+				perform = { ran++ },
+			)
+		)
+
+		assertFalse(actions.canPerform(custom))
+		state.selector.updateSelection(CharLineOffset(0, 0), CharLineOffset(0, 5))
+		assertTrue(actions.canPerform(custom))
+
+		actions.perform(custom)
+		assertEquals(1, ran)
+	}
+
+	@Test
+	fun `an unregistered action is inert rather than fatal`() = runTest {
+		val state = editor()
+		val actions = actionsFor(state)
+		state.actions.unregister(Action.SelectAll)
+
+		actions.selectAll()
+
+		assertFalse(actions.canPerform(Action.SelectAll))
+		assertFalse(state.selector.hasSelection())
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/CustomShortcutE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/CustomShortcutE2eTest.kt
@@ -1,0 +1,70 @@
+package e2e
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.input.CtrlKeyBindings
+import com.darkrockstudios.texteditor.input.EditorActionSpec
+import com.darkrockstudios.texteditor.input.EditorCommand
+import com.darkrockstudios.texteditor.input.KeyBindings
+import com.darkrockstudios.texteditor.input.isCtrlShortcut
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The whole point of the action registry, exercised the way a host app uses it:
+ * a chord nothing in the library knows about, bound to an action nothing in the
+ * library implements, reaching the document through the composed editor.
+ */
+class CustomShortcutE2eTest {
+
+	private val shout = EditorCommand.Action("test.shout", isEdit = true)
+
+	private val bindings = KeyBindings { event ->
+		if (event.key == Key.B && event.isCtrlShortcut) shout
+		else CtrlKeyBindings.commandFor(event)
+	}
+
+	@Test
+	fun `a host chord runs a host action`() = editorUiTest(
+		initialText = AnnotatedString("hello"),
+		keyBindings = bindings,
+	) {
+		state.actions.register(EditorActionSpec(shout) { it.state.insertStringAtCursor("!") })
+
+		press(Key.B, ctrl = true)
+		waitForIdle()
+
+		assertEquals("!hello", state.getAllText().text)
+	}
+
+	/** Delegating the unclaimed chords is what keeps the built-ins alive. */
+	@Test
+	fun `the delegated chords still work`() = editorUiTest(
+		initialText = AnnotatedString("hello"),
+		keyBindings = bindings,
+	) {
+		state.actions.register(EditorActionSpec(shout) { it.state.insertStringAtCursor("!") })
+
+		press(Key.A, ctrl = true)
+		waitForIdle()
+
+		assertEquals("hello", state.selector.getSelectedText().text)
+	}
+
+	/**
+	 * Rule 5: an action with no registration must not consume the chord. Nothing
+	 * happens here rather than the editor swallowing the keystroke silently.
+	 */
+	@Test
+	fun `an unregistered action leaves the document alone`() = editorUiTest(
+		initialText = AnnotatedString("hello"),
+		keyBindings = bindings,
+	) {
+		press(Key.B, ctrl = true)
+		waitForIdle()
+
+		assertEquals("hello", state.getAllText().text)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/EditorActionRegistryTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/EditorActionRegistryTest.kt
@@ -1,0 +1,161 @@
+package input
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.input.EditorActionContext
+import com.darkrockstudios.texteditor.input.EditorActionSpec
+import com.darkrockstudios.texteditor.input.EditorCommand
+import com.darkrockstudios.texteditor.input.EditorCommand.Action
+import com.darkrockstudios.texteditor.input.KeyBindings
+import com.darkrockstudios.texteditor.input.TextEditorKeyCommandHandler
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import utils.InMemoryClipboard
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(InternalComposeUiApi::class)
+private fun keyDown(key: Key, ctrl: Boolean = false) = KeyEvent(
+	key = key,
+	type = KeyEventType.KeyDown,
+	isCtrlPressed = ctrl,
+)
+
+/** Binds exactly one chord, so a test can drive one action through the real handler. */
+private class SingleChordBindings(
+	private val key: Key,
+	private val command: EditorCommand,
+) : KeyBindings {
+	override fun commandFor(event: KeyEvent): EditorCommand? =
+		if (event.key == key) command else null
+}
+
+class EditorActionRegistryTest {
+
+	private lateinit var state: TextEditorState
+	private lateinit var clipboard: InMemoryClipboard
+	private lateinit var scope: TestScope
+
+	@BeforeTest
+	fun setup() {
+		scope = TestScope()
+		clipboard = InMemoryClipboard()
+		state = TextEditorState(
+			scope = scope,
+			measurer = mockk(relaxed = true),
+			initialText = AnnotatedString("hello world"),
+		)
+	}
+
+	private fun context() = EditorActionContext(state, clipboard, scope)
+
+	private fun dispatch(event: KeyEvent, command: EditorCommand): Boolean =
+		TextEditorKeyCommandHandler(SingleChordBindings(event.key, command))
+			.handleKeyEvent(event, state, clipboard, scope, enabled = true)
+
+	@Test
+	fun `every builtin action is registered on a fresh state`() {
+		for (action in Action.Builtins) {
+			assertNotNull(state.actions[action], "${action.id} must be registered")
+		}
+		assertEquals(Action.Builtins.map { it.id }.toSet(), state.actions.registeredIds)
+	}
+
+	@Test
+	fun `a host action can be registered and invoked`() {
+		val custom = Action("myapp.shout", isEdit = true)
+		var ran = 0
+		state.actions.register(EditorActionSpec(custom) { ran++ })
+
+		assertTrue(custom in state.actions)
+		state.actions[custom]!!.perform(context())
+		assertEquals(1, ran)
+	}
+
+	@Test
+	fun `registering over a builtin id replaces it`() {
+		var ran = 0
+		state.actions.register(EditorActionSpec(Action.Paste) { ran++ })
+
+		state.actions[Action.Paste]!!.perform(context())
+		assertEquals(1, ran)
+		assertEquals(Action.Builtins.size, state.actions.registeredIds.size)
+	}
+
+	@Test
+	fun `unregister removes the action`() {
+		state.actions.unregister(Action.Paste)
+		assertNull(state.actions[Action.Paste])
+		assertFalse(Action.Paste in state.actions)
+	}
+
+	@Test
+	fun `isEnabled tracks whether the action has anything to do`() {
+		assertFalse(state.actions[Action.Copy]!!.isEnabled(context()))
+		state.selector.updateSelection(CharLineOffset(0, 0), CharLineOffset(0, 5))
+		assertTrue(state.actions[Action.Copy]!!.isEnabled(context()))
+	}
+
+	@Test
+	fun `a bound chord runs its registered action and consumes the event`() {
+		val custom = Action("myapp.shout", isEdit = true)
+		var ran = 0
+		state.actions.register(EditorActionSpec(custom) { ran++ })
+
+		assertTrue(dispatch(keyDown(Key.B, ctrl = true), custom))
+		assertEquals(1, ran)
+	}
+
+	/**
+	 * Rule 5 of the design: an action with no handler must leave the event alone.
+	 * Consuming it would turn a host's forgotten registration into a dead key that
+	 * silently swallows the character instead of typing it.
+	 */
+	@Test
+	fun `a chord bound to an unregistered action is not consumed`() {
+		val unregistered = Action("myapp.neverRegistered", isEdit = true)
+		assertFalse(dispatch(keyDown(Key.B, ctrl = true), unregistered))
+	}
+
+	@Test
+	fun `an unregistered builtin stops being consumed too`() {
+		state.actions.unregister(Action.Paste)
+		assertFalse(dispatch(keyDown(Key.V, ctrl = true), Action.Paste))
+	}
+
+	/**
+	 * Key dispatch deliberately ignores isEnabled: Ctrl+C with nothing selected
+	 * must still consume the chord rather than fall through and type a `c`.
+	 */
+	@Test
+	fun `a disabled action still consumes its chord`() {
+		assertFalse(state.actions[Action.Copy]!!.isEnabled(context()))
+		assertTrue(dispatch(keyDown(Key.C, ctrl = true), Action.Copy))
+	}
+
+	@Test
+	fun `an edit action is refused while the editor is disabled`() {
+		var ran = 0
+		val custom = Action("myapp.edits", isEdit = true)
+		state.actions.register(EditorActionSpec(custom) { ran++ })
+
+		val handler = TextEditorKeyCommandHandler(SingleChordBindings(Key.B, custom))
+		val consumed = handler.handleKeyEvent(
+			keyDown(Key.B, ctrl = true), state, clipboard, scope, enabled = false,
+		)
+
+		assertFalse(consumed)
+		assertEquals(0, ran)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/EditorActionRegistryTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/EditorActionRegistryTest.kt
@@ -144,6 +144,26 @@ class EditorActionRegistryTest {
 		assertTrue(dispatch(keyDown(Key.C, ctrl = true), Action.Copy))
 	}
 
+	/**
+	 * Action identity is the id alone, so a host writing its own bindings can hand
+	 * back a built-in id carrying the wrong metadata. The read-only gate has to
+	 * read isEdit off the registered spec or that forges its way past.
+	 */
+	@Test
+	fun `a forged isEdit cannot mutate a disabled editor`() {
+		val forged = Action("editor.paste", isEdit = false)
+		var ran = 0
+		state.actions.register(EditorActionSpec(Action.Paste) { ran++ })
+
+		val handler = TextEditorKeyCommandHandler(SingleChordBindings(Key.V, forged))
+		val consumed = handler.handleKeyEvent(
+			keyDown(Key.V, ctrl = true), state, clipboard, scope, enabled = false,
+		)
+
+		assertFalse(consumed)
+		assertEquals(0, ran)
+	}
+
 	@Test
 	fun `an edit action is refused while the editor is disabled`() {
 		var ran = 0

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/EditorActionRegistryTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/EditorActionRegistryTest.kt
@@ -164,6 +164,23 @@ class EditorActionRegistryTest {
 		assertEquals(0, ran)
 	}
 
+	/** The same forgery through the documented "replace a built-in" path. */
+	@Test
+	fun `a replaced builtin cannot forge isEdit either`() {
+		var ran = 0
+		state.actions.register(
+			EditorActionSpec(Action("editor.paste", isEdit = false)) { ran++ }
+		)
+
+		val handler = TextEditorKeyCommandHandler(SingleChordBindings(Key.V, Action.Paste))
+		val consumed = handler.handleKeyEvent(
+			keyDown(Key.V, ctrl = true), state, clipboard, scope, enabled = false,
+		)
+
+		assertFalse(consumed)
+		assertEquals(0, ran)
+	}
+
 	@Test
 	fun `an edit action is refused while the editor is disabled`() {
 		var ran = 0

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/EditorCommandTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/EditorCommandTest.kt
@@ -1,0 +1,59 @@
+package input
+
+import com.darkrockstudios.texteditor.input.EditorCommand.Action
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class EditorCommandTest {
+
+	@Test
+	fun `actions are equal by id alone`() {
+		assertEquals(Action.Copy, Action("editor.copy", isEdit = false))
+		assertEquals(Action.Copy.hashCode(), Action("editor.copy", isEdit = false).hashCode())
+		assertNotEquals(Action.Copy, Action.Cut)
+	}
+
+	@Test
+	fun `a host action is distinct from every builtin`() {
+		val custom = Action("myapp.toggleBold", isEdit = true)
+		assertFalse(custom in Action.Builtins)
+	}
+
+	@Test
+	fun `builtin ids are unique`() {
+		val ids = Action.Builtins.map { it.id }
+		assertEquals(ids.size, ids.toSet().size, "duplicate id in Action.Builtins: $ids")
+	}
+
+	@Test
+	fun `builtin ids are namespaced`() {
+		for (action in Action.Builtins) {
+			assertTrue(
+				action.id.startsWith("editor."),
+				"${action.id} must carry the editor. prefix",
+			)
+		}
+	}
+
+	/**
+	 * `Builtins` is hand-maintained and the action registry will drive itself from
+	 * it, so a constant left out of the list would register no handler and silently
+	 * do nothing. Reflection over the companion's getters is what makes forgetting
+	 * one a red test instead of a dead shortcut.
+	 */
+	@Test
+	fun `every declared action constant is in Builtins`() {
+		val declared = Action.Companion::class.java.declaredMethods
+			.filter { it.parameterCount == 0 && it.returnType == Action::class.java }
+			.map { it.invoke(Action.Companion) as Action }
+
+		assertTrue(declared.isNotEmpty(), "reflection found no Action constants to check")
+		assertEquals(
+			declared.map { it.id }.toSet(),
+			Action.Builtins.map { it.id }.toSet(),
+		)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/ImeLineBlockParityTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/ImeLineBlockParityTest.kt
@@ -286,6 +286,32 @@ class ImeLineBlockParityTest {
 		assertEquals("a", state.getAllText().text)
 	}
 
+	/**
+	 * Clamping leaves nothing to delete, but the keystroke still means "exit the
+	 * block", which is what the hardware key does here.
+	 */
+	@Test
+	fun `backspace at the document start still demotes`() = runTest {
+		val state = editorWith("- item")
+		state.cursor.updatePosition(CharLineOffset(0, 0))
+
+		state.imeDeleteSurroundingText(1, 0)
+
+		assertEquals("item", state.getAllText().text)
+		assertTrue(state.bulletLines().isEmpty())
+	}
+
+	@Test
+	fun `hardware backspace at the document start demotes the same way`() = runTest {
+		val state = editorWith("- item")
+		state.cursor.updatePosition(CharLineOffset(0, 0))
+
+		runAction(state, Action.DeleteBackward)
+
+		assertEquals("item", state.getAllText().text)
+		assertTrue(state.bulletLines().isEmpty())
+	}
+
 	// --- the IME has to be told when its request was answered without an edit ---
 
 	@Test

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/ImeLineBlockParityTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/ImeLineBlockParityTest.kt
@@ -12,9 +12,12 @@ import com.darkrockstudios.texteditor.input.imeSetComposingRegion
 import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
 import com.darkrockstudios.texteditor.markdown.MarkdownExtension
 import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.state.EditBehavior
 import com.darkrockstudios.texteditor.state.TextEditorState
 import io.mockk.mockk
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import utils.InMemoryClipboard
 import kotlin.test.Test
@@ -221,6 +224,114 @@ class ImeLineBlockParityTest {
 		state.imeCommitText("\n", newCursorPosition = 1)
 
 		assertEquals("one\n\n", state.getAllText().text)
+	}
+
+	/**
+	 * Near the start of the document a multi-character request clamps down to the
+	 * one character that exists. Intent has to come from what was asked for, or an
+	 * autocorrect rewrite at the top of the document reads as a backspace and the
+	 * behavior claims it, deleting nothing and demoting the block.
+	 */
+	@Test
+	fun `a clamped multi-character delete is not a backspace`() = runTest {
+		val state = TextEditorState(
+			scope = this,
+			measurer = mockk(relaxed = true),
+			initialText = AnnotatedString("\nitem"),
+		)
+		MarkdownExtension(state, MarkdownConfiguration.DEFAULT).toggleBulletList(1..1)
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.imeDeleteSurroundingText(3, 0)
+
+		assertEquals("item", state.getAllText().text)
+		assertEquals(1, state.textLines.size)
+	}
+
+	// --- forward delete reaches the chain too ---
+
+	@Test
+	fun `a forward delete is offered to the behaviors`() = runTest {
+		val state = editorWith("plain\n- item")
+		var claimed = 0
+		state.editBehaviors.add(0, object : EditBehavior {
+			override fun onDeleteForward(state: TextEditorState): Boolean {
+				claimed++
+				return true
+			}
+		})
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.imeDeleteSurroundingText(0, 1)
+
+		assertEquals(1, claimed)
+		assertEquals("plain\nitem", state.getAllText().text)
+	}
+
+	@Test
+	fun `a clamped multi-character forward delete is not a forward keystroke`() = runTest {
+		val state = editorWith("ab")
+		var claimed = 0
+		state.editBehaviors.add(0, object : EditBehavior {
+			override fun onDeleteForward(state: TextEditorState): Boolean {
+				claimed++
+				return true
+			}
+		})
+		state.cursor.updatePosition(CharLineOffset(0, 1))
+
+		state.imeDeleteSurroundingText(0, 5)
+
+		assertEquals(0, claimed)
+		assertEquals("a", state.getAllText().text)
+	}
+
+	// --- the IME has to be told when its request was answered without an edit ---
+
+	@Test
+	fun `a behavior-claimed backspace asks the IME to resync`() = runTest {
+		val state = editorWith("plain\n- item")
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+		var resyncs = 0
+		val job = launch { state.imeResyncRequests.collect { resyncs++ } }
+		runCurrent()
+
+		state.imeDeleteSurroundingText(1, 0)
+		runCurrent()
+
+		assertEquals(1, resyncs)
+		job.cancel()
+	}
+
+	@Test
+	fun `a behavior-claimed newline asks the IME to resync`() = runTest {
+		val state = editorWith("- one\n- ")
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+		var resyncs = 0
+		val job = launch { state.imeResyncRequests.collect { resyncs++ } }
+		runCurrent()
+
+		state.imeCommitText("\n", newCursorPosition = 1)
+		runCurrent()
+
+		assertEquals(1, resyncs)
+		job.cancel()
+	}
+
+	/** A delete that really removed text needs no correction; the caret move carries it. */
+	@Test
+	fun `an ordinary backspace does not ask for a resync`() = runTest {
+		val state = editorWith("hello")
+		state.cursor.updatePosition(CharLineOffset(0, 5))
+		var resyncs = 0
+		val job = launch { state.imeResyncRequests.collect { resyncs++ } }
+		runCurrent()
+
+		state.imeDeleteSurroundingText(1, 0)
+		runCurrent()
+
+		assertEquals(0, resyncs)
+		job.cancel()
 	}
 
 	// --- the non-block case must be untouched by the routing ---

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/ImeLineBlockParityTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/ImeLineBlockParityTest.kt
@@ -1,0 +1,260 @@
+package input
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.input.EditorActionContext
+import com.darkrockstudios.texteditor.input.EditorCommand.Action
+import com.darkrockstudios.texteditor.input.imeCommitText
+import com.darkrockstudios.texteditor.input.imeDeleteSurroundingText
+import com.darkrockstudios.texteditor.input.imeDeleteSurroundingTextInCodePoints
+import com.darkrockstudios.texteditor.input.imePerformNewline
+import com.darkrockstudios.texteditor.input.imeSetComposingRegion
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import utils.InMemoryClipboard
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Line-block smart editing has to reach the document the same way no matter which
+ * path the edit arrived on. A soft keyboard picks among several `InputConnection`
+ * methods for what the user experiences as one keystroke, so each of them is
+ * checked here against the hardware-key result.
+ */
+class ImeLineBlockParityTest {
+
+	private fun TestScope.editorWith(markdown: String): TextEditorState {
+		val state = TextEditorState(
+			scope = this,
+			measurer = mockk(relaxed = true),
+			initialText = null as AnnotatedString?,
+		)
+		MarkdownExtension(state, MarkdownConfiguration.DEFAULT).importMarkdown(markdown)
+		return state
+	}
+
+	private fun TextEditorState.bulletLines(): List<Int> =
+		richSpanManager.getAllRichSpans()
+			.filter { it.style === BulletListSpanStyle }
+			.map { it.range.start.line }
+			.sorted()
+
+	private fun TestScope.runAction(state: TextEditorState, action: Action) {
+		state.actions[action]!!.perform(EditorActionContext(state, InMemoryClipboard(), this))
+	}
+
+	// --- backspace at the start of a bullet: demote, do not merge ---
+
+	/** The reference result every other path is compared against. */
+	@Test
+	fun `hardware backspace demotes`() = runTest {
+		val state = editorWith("plain\n- item")
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		runAction(state, Action.DeleteBackward)
+
+		assertEquals("plain\nitem", state.getAllText().text)
+		assertFalse(1 in state.bulletLines())
+	}
+
+	@Test
+	fun `deleteSurroundingText backspace demotes`() = runTest {
+		val state = editorWith("plain\n- item")
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.imeDeleteSurroundingText(1, 0)
+
+		assertEquals("plain\nitem", state.getAllText().text)
+		assertFalse(1 in state.bulletLines())
+	}
+
+	@Test
+	fun `deleteSurroundingTextInCodePoints backspace demotes`() = runTest {
+		val state = editorWith("plain\n- item")
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.imeDeleteSurroundingTextInCodePoints(1, 0)
+
+		assertEquals("plain\nitem", state.getAllText().text)
+		assertFalse(1 in state.bulletLines())
+	}
+
+	// --- enter on an empty bullet: exit the block ---
+
+	@Test
+	fun `hardware enter exits the block`() = runTest {
+		val state = editorWith("- one\n- ")
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		runAction(state, Action.NewLine)
+
+		assertEquals(2, state.textLines.size)
+		assertEquals(listOf(0), state.bulletLines())
+	}
+
+	@Test
+	fun `commitText newline exits the block`() = runTest {
+		val state = editorWith("- one\n- ")
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.imeCommitText("\n", newCursorPosition = 1)
+
+		assertEquals(2, state.textLines.size)
+		assertEquals(listOf(0), state.bulletLines())
+	}
+
+	@Test
+	fun `performEditorAction newline exits the block`() = runTest {
+		val state = editorWith("- one\n- ")
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.imePerformNewline()
+
+		assertEquals(2, state.textLines.size)
+		assertEquals(listOf(0), state.bulletLines())
+	}
+
+	// --- shapes that must NOT be mistaken for a keystroke ---
+
+	/**
+	 * The autocorrect shape: a composing region means the IME is rewriting text it
+	 * is tracking, not relaying a backspace.
+	 */
+	@Test
+	fun `a delete inside a composing region stays a range delete`() = runTest {
+		val state = editorWith("plain\n- item")
+		state.cursor.updatePosition(CharLineOffset(1, 4))
+		state.imeSetComposingRegion(6, 10)
+
+		state.imeDeleteSurroundingText(1, 0)
+
+		assertEquals("plain\nite", state.getAllText().text)
+		assertTrue(1 in state.bulletLines())
+	}
+
+	/**
+	 * With a selection live the IME is replacing a range, so the caret sitting at
+	 * the start of a bullet is incidental and must not trigger the demote.
+	 */
+	@Test
+	fun `a delete replacing a selection stays a range delete`() = runTest {
+		val state = editorWith("plain\n- item")
+		state.selector.updateSelection(CharLineOffset(1, 0), CharLineOffset(1, 2))
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.imeDeleteSurroundingText(1, 0)
+
+		assertEquals("plainitem", state.getAllText().text)
+	}
+
+	@Test
+	fun `a multi-character delete stays a range delete`() = runTest {
+		val state = editorWith("plain\n- item")
+		state.cursor.updatePosition(CharLineOffset(1, 4))
+
+		state.imeDeleteSurroundingText(3, 0)
+
+		assertEquals("plain\ni", state.getAllText().text)
+		assertTrue(1 in state.bulletLines())
+	}
+
+	@Test
+	fun `a forward delete stays a range delete`() = runTest {
+		val state = editorWith("plain\n- item")
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.imeDeleteSurroundingText(0, 1)
+
+		assertEquals("plain\ntem", state.getAllText().text)
+		assertTrue(1 in state.bulletLines())
+	}
+
+	@Test
+	fun `a delete spanning both sides stays a range delete`() = runTest {
+		val state = editorWith("plain\n- item")
+		state.cursor.updatePosition(CharLineOffset(1, 2))
+
+		state.imeDeleteSurroundingText(1, 1)
+
+		assertEquals("plain\nim", state.getAllText().text)
+		assertTrue(1 in state.bulletLines())
+	}
+
+	/**
+	 * One code point but two chars, so the backspace path (which deletes a single
+	 * char) would split the pair.
+	 */
+	@Test
+	fun `a surrogate pair delete stays a range delete`() = runTest {
+		val state = editorWith("- a😀")
+		state.cursor.updatePosition(CharLineOffset(0, 3))
+
+		state.imeDeleteSurroundingTextInCodePoints(1, 0)
+
+		assertEquals("a", state.getAllText().text)
+	}
+
+	@Test
+	fun `committed text that merely contains a newline is not an enter`() = runTest {
+		val state = editorWith("- one\n- ")
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.imeCommitText("hi\n", newCursorPosition = 1)
+
+		assertEquals(3, state.textLines.size)
+		assertEquals("one\nhi\n", state.getAllText().text)
+	}
+
+	@Test
+	fun `a newline committed over a composing region is not an enter`() = runTest {
+		val state = editorWith("- one\n- ab")
+		state.cursor.updatePosition(CharLineOffset(1, 2))
+		state.imeSetComposingRegion(4, 6)
+
+		state.imeCommitText("\n", newCursorPosition = 1)
+
+		assertEquals("one\n\n", state.getAllText().text)
+	}
+
+	// --- the non-block case must be untouched by the routing ---
+
+	@Test
+	fun `backspace on plain text is unchanged`() = runTest {
+		val state = editorWith("hello")
+		state.cursor.updatePosition(CharLineOffset(0, 5))
+
+		state.imeDeleteSurroundingText(1, 0)
+
+		assertEquals("hell", state.getAllText().text)
+		assertEquals(4, state.getCharacterIndex(state.cursorPosition))
+	}
+
+	@Test
+	fun `backspace merging two plain lines is unchanged`() = runTest {
+		val state = editorWith("one\n\ntwo")
+		state.cursor.updatePosition(CharLineOffset(2, 0))
+
+		state.imeDeleteSurroundingText(1, 0)
+
+		assertEquals("one\ntwo", state.getAllText().text)
+		assertEquals(4, state.getCharacterIndex(state.cursorPosition))
+	}
+
+	@Test
+	fun `commitText newline on plain text splits the line`() = runTest {
+		val state = editorWith("hello")
+		state.cursor.updatePosition(CharLineOffset(0, 2))
+
+		state.imeCommitText("\n", newCursorPosition = 1)
+
+		assertEquals("he\nllo", state.getAllText().text)
+		assertEquals(3, state.getCharacterIndex(state.cursorPosition))
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/input/KeyBindingsTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/input/KeyBindingsTest.kt
@@ -251,7 +251,7 @@ class KeyBindingsTest {
 		for (command in readOnly) {
 			assertEquals(false, command.isEdit, "$command must be allowed in a disabled editor")
 		}
-		for (command in Action.entries - Action.SelectAll - Action.Copy) {
+		for (command in Action.Builtins - Action.SelectAll - Action.Copy) {
 			assertEquals(true, command.isEdit, "$command changes the document")
 		}
 	}

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/EditBehaviorTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/EditBehaviorTest.kt
@@ -1,0 +1,181 @@
+package state
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.richstyle.LineBlockEditBehavior
+import com.darkrockstudios.texteditor.state.EditBehavior
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The chain itself: what a behavior can claim, what falls through, and that the
+ * line-block semantics are now a removable behavior rather than something welded
+ * into the primitives.
+ */
+class EditBehaviorTest {
+
+	private fun TestScope.editor(text: String = "hello") = TextEditorState(
+		scope = this,
+		measurer = mockk(relaxed = true),
+		initialText = AnnotatedString(text),
+	)
+
+	private fun TestScope.bulletedEditor(markdown: String): MarkdownExtension {
+		val state = TextEditorState(
+			scope = this,
+			measurer = mockk(relaxed = true),
+			initialText = null as AnnotatedString?,
+		)
+		val extension = MarkdownExtension(state, MarkdownConfiguration.DEFAULT)
+		extension.importMarkdown(markdown)
+		return extension
+	}
+
+	private fun TextEditorState.bulletLines(): List<Int> =
+		richSpanManager.getAllRichSpans()
+			.filter { it.style === BulletListSpanStyle }
+			.map { it.range.start.line }
+			.sorted()
+
+	/** Claims whatever it is asked about and counts the asks. */
+	private class ClaimAll : EditBehavior {
+		var newlines = 0
+		var backspaces = 0
+		var deletes = 0
+		override fun onNewline(state: TextEditorState): Boolean { newlines++; return true }
+		override fun onBackspace(state: TextEditorState): Boolean { backspaces++; return true }
+		override fun onDeleteForward(state: TextEditorState): Boolean { deletes++; return true }
+	}
+
+	@Test
+	fun `line blocks are a behavior on every state by default`() = runTest {
+		val state = editor()
+		assertEquals(listOf<EditBehavior>(LineBlockEditBehavior), state.editBehaviors.toList())
+	}
+
+	@Test
+	fun `a claiming behavior suppresses all three primitives`() = runTest {
+		val state = editor()
+		val behavior = ClaimAll()
+		state.editBehaviors.add(0, behavior)
+		state.cursor.updatePosition(CharLineOffset(0, 3))
+
+		state.insertNewlineAtCursor()
+		state.backspaceAtCursor()
+		state.deleteAtCursor()
+
+		assertEquals(1, behavior.newlines)
+		assertEquals(1, behavior.backspaces)
+		assertEquals(1, behavior.deletes)
+		assertEquals("hello", state.getAllText().text)
+	}
+
+	@Test
+	fun `a behavior that declines lets the primitive run`() = runTest {
+		val state = editor()
+		var asked = 0
+		state.editBehaviors.add(0, object : EditBehavior {
+			override fun onNewline(state: TextEditorState): Boolean {
+				asked++
+				return false
+			}
+		})
+		state.cursor.updatePosition(CharLineOffset(0, 2))
+
+		state.insertNewlineAtCursor()
+
+		assertEquals(1, asked)
+		assertEquals("he\nllo", state.getAllText().text)
+	}
+
+	@Test
+	fun `the first behavior to claim wins`() = runTest {
+		val state = editor()
+		val first = ClaimAll()
+		val second = ClaimAll()
+		state.editBehaviors.add(0, second)
+		state.editBehaviors.add(0, first)
+
+		state.insertNewlineAtCursor()
+
+		assertEquals(1, first.newlines)
+		assertEquals(0, second.newlines)
+	}
+
+	@Test
+	fun `enter on an empty bullet exits the block`() = runTest {
+		val extension = bulletedEditor("- one\n- ")
+		val state = extension.editorState
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.insertNewlineAtCursor()
+
+		assertEquals(listOf(0), state.bulletLines())
+		assertEquals(2, state.textLines.size)
+	}
+
+	/**
+	 * The same keystroke with the behavior removed: no block exit, just a split.
+	 * The split half also loses its gutter marker, which is the span-boundary gap
+	 * the behavior covers by applying the block to both halves.
+	 */
+	@Test
+	fun `removing the behavior gives a plain split on an empty bullet`() = runTest {
+		val extension = bulletedEditor("- one\n- ")
+		val state = extension.editorState
+		assertTrue(state.editBehaviors.remove(LineBlockEditBehavior))
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.insertNewlineAtCursor()
+
+		assertEquals(3, state.textLines.size)
+		assertFalse(1 in state.bulletLines())
+	}
+
+	@Test
+	fun `a split inside a bullet keeps the marker on both halves`() = runTest {
+		val extension = bulletedEditor("- hello")
+		val state = extension.editorState
+		state.cursor.updatePosition(CharLineOffset(0, 2))
+
+		state.insertNewlineAtCursor()
+
+		assertEquals(listOf(0, 1), state.bulletLines())
+		assertEquals("he\nllo", state.getAllText().text)
+	}
+
+	@Test
+	fun `backspace at the start of a bullet demotes before merging`() = runTest {
+		val extension = bulletedEditor("plain\n- item")
+		val state = extension.editorState
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.backspaceAtCursor()
+
+		assertFalse(1 in state.bulletLines())
+		assertEquals("plain\nitem", state.getAllText().text)
+
+		state.backspaceAtCursor()
+		assertEquals("plainitem", state.getAllText().text)
+	}
+
+	@Test
+	fun `backspace merges directly when the previous line is the same block`() = runTest {
+		val extension = bulletedEditor("- one\n- two")
+		val state = extension.editorState
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+
+		state.backspaceAtCursor()
+
+		assertEquals("onetwo", state.getAllText().text)
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/EditBehaviorTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/EditBehaviorTest.kt
@@ -9,7 +9,9 @@ import com.darkrockstudios.texteditor.richstyle.LineBlockEditBehavior
 import com.darkrockstudios.texteditor.state.EditBehavior
 import com.darkrockstudios.texteditor.state.TextEditorState
 import io.mockk.mockk
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -130,6 +132,58 @@ class EditBehaviorTest {
 
 		state.insertNewlineAtCursor()
 		assertEquals("\nhello", state.getAllText().text)
+	}
+
+	/**
+	 * "Do my thing, then the ordinary edit" is the natural way to write a behavior,
+	 * and the only primitive a host can reach is the public one that runs the chain.
+	 * A nested call has to skip the chain or it recurses until the stack goes.
+	 */
+	@Test
+	fun `a behavior may finish by calling the edit it claimed`() = runTest {
+		val state = editor()
+		state.editBehaviors.add(0, object : EditBehavior {
+			override fun onNewline(state: TextEditorState): Boolean {
+				state.insertStringAtCursor(">")
+				state.insertNewlineAtCursor()
+				return true
+			}
+		})
+		state.cursor.updatePosition(CharLineOffset(0, 2))
+
+		state.insertNewlineAtCursor()
+
+		assertEquals("he>\nllo", state.getAllText().text)
+	}
+
+	@Test
+	fun `a claimed edit asks the IME to resync`() = runTest {
+		val extension = bulletedEditor("- one\n- ")
+		val state = extension.editorState
+		state.cursor.updatePosition(CharLineOffset(1, 0))
+		var resyncs = 0
+		val job = launch { state.imeResyncRequests.collect { resyncs++ } }
+		runCurrent()
+
+		state.insertNewlineAtCursor()
+		runCurrent()
+
+		assertEquals(1, resyncs)
+		job.cancel()
+	}
+
+	@Test
+	fun `an unclaimed edit does not ask for a resync`() = runTest {
+		val state = editor()
+		var resyncs = 0
+		val job = launch { state.imeResyncRequests.collect { resyncs++ } }
+		runCurrent()
+
+		state.insertNewlineAtCursor()
+		runCurrent()
+
+		assertEquals(0, resyncs)
+		job.cancel()
 	}
 
 	@Test

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/EditBehaviorTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/EditBehaviorTest.kt
@@ -111,6 +111,27 @@ class EditBehaviorTest {
 		assertEquals(0, second.newlines)
 	}
 
+	/** A mode-switching behavior that retires itself must not fail the keystroke. */
+	@Test
+	fun `a behavior may edit the chain while claiming an edit`() = runTest {
+		val state = editor()
+		val oneShot = object : EditBehavior {
+			override fun onNewline(state: TextEditorState): Boolean {
+				state.editBehaviors.remove(this)
+				return true
+			}
+		}
+		state.editBehaviors.add(0, oneShot)
+
+		state.insertNewlineAtCursor()
+
+		assertEquals(listOf<EditBehavior>(LineBlockEditBehavior), state.editBehaviors.toList())
+		assertEquals("hello", state.getAllText().text)
+
+		state.insertNewlineAtCursor()
+		assertEquals("\nhello", state.getAllText().text)
+	}
+
 	@Test
 	fun `enter on an empty bullet exits the block`() = runTest {
 		val extension = bulletedEditor("- one\n- ")

--- a/ComposeTextEditor/src/iosMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.ios.kt
+++ b/ComposeTextEditor/src/iosMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.ios.kt
@@ -1,4 +1,4 @@
 package com.darkrockstudios.texteditor.input
 
 /** Hardware keyboards on iPadOS follow the macOS conventions. */
-internal actual fun platformKeyBindings(): KeyBindings = MacKeyBindings
+actual fun platformKeyBindings(): KeyBindings = MacKeyBindings

--- a/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.wasmJs.kt
+++ b/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/input/KeyBindings.wasmJs.kt
@@ -8,5 +8,5 @@ package com.darkrockstudios.texteditor.input
 private fun isMacHost(): Boolean =
 	js("/Mac|iPhone|iPad|iPod/.test((navigator.platform || '') + ' ' + (navigator.userAgent || ''))")
 
-internal actual fun platformKeyBindings(): KeyBindings =
+actual fun platformKeyBindings(): KeyBindings =
 	if (isMacHost()) MacKeyBindings else CtrlKeyBindings

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckingTextEditor.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckingTextEditor.kt
@@ -179,11 +179,9 @@ fun SpellCheckingTextEditor(
 					currentSpellCheckItem = spellCheckItem
 
 					// A right-click always offers a menu, falling back to the standard
-					// one when the span has nothing to correct. A tap only opens one when
-					// there is a correction to offer: tapping a correctly spelled word
-					// means "put the caret here", and answering that with a menu is not
-					// what was asked for. Declining leaves the tap unconsumed, so it
-					// still focuses the editor and raises the keyboard.
+					// one. A tap only opens one with a correction to offer: tapping a
+					// correctly spelled word means "put the caret here", so declining
+					// leaves the tap to focus the editor and raise the keyboard.
 					if (type == SpanClickType.SECONDARY_CLICK || spellCheckItem != null) {
 						showContextMenu(offset, spellCheckItem)
 						true
@@ -233,11 +231,9 @@ private fun computeAffectedRanges(
 }
 
 /**
- * Overlapping, or butting up against each other end to start.
- *
- * A typed word arrives as one insert per character, each range starting exactly where the
- * last ended. [TextEditorRange.intersects] is exclusive at the ends and reports those as
- * disjoint, which would re-check the same word once per character typed.
+ * Overlapping, or butting up end to start. A typed word arrives as one insert per
+ * character, each range starting where the last ended; [TextEditorRange.intersects]
+ * is exclusive at the ends and would re-check the same word once per keystroke.
  */
 private fun TextEditorRange.adjoins(other: TextEditorRange): Boolean =
 	intersects(other) || end == other.start || other.end == start

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,11 +156,13 @@ translation paths:
 
 - **Commands.** `KeyBindings` maps the platform's key chords onto the
   `EditorCommand` vocabulary: motions and actions named by intent
-  (`WordLeft`, `DeleteWordBackward`, `Paste`), not by keys.
-  `TextEditorKeyCommandHandler` is the single executor. The split is strict:
-  bindings know which chord means what, the handler knows what commands do,
-  and nothing else knows either. Windows/Linux and macOS conventions ship as
-  two `KeyBindings` values; hosts can substitute their own.
+  (`WordLeft`, `DeleteWordBackward`, `Paste`), not by keys. The split is
+  three ways: bindings know which chord means what, the
+  `EditorActionRegistry` on the state knows what an action *does*, and
+  `TextEditorKeyCommandHandler` implements only caret motion, because a
+  motion is not something a host can register. Windows/Linux and macOS
+  conventions ship as two `KeyBindings` values; hosts can substitute their
+  own and register actions for their own chords to bind.
 - **Typed characters.** Printable typing that arrives as raw key events
   (desktop `KEY_TYPED`, hardware keyboards on Android, browser keydown on
   wasm) inserts through the same handler, gated by a per-platform predicate
@@ -173,6 +175,16 @@ translation paths:
 All of this converges on one modifier node, `TextEditorInputModifierNode`,
 which also owns the session lifecycle: gaining focus launches the platform
 input session, losing focus (or disabling the editor) cancels it.
+
+Two extension points hang off this, and they are not interchangeable. An
+**action** is invoked by name, so it needs something to invoke it: a chord, a
+menu item, a toolbar button. An **edit behavior** intercepts one of the
+semantic edits (newline, backspace, forward delete) and may have no trigger at
+all, because an IME can commit a newline or delete a character without ever
+producing a key event. Line-block smart editing is the first behavior, which is
+what makes it reach every input path rather than only the ones that go through
+key handling. Both, and the reasoning for keeping them separate:
+[design/editor-actions.md](design/editor-actions.md).
 
 The IME contract runs in two directions. Commands flow in, and each one lands
 in a single shared implementation (`ImeEditLogic` in commonMain) so that

--- a/docs/design/editor-actions.md
+++ b/docs/design/editor-actions.md
@@ -145,10 +145,14 @@ class EditorActionRegistry {
 enablement predicate the menu can be built from a list of action ids and stop
 knowing what any of them mean.
 
-The core registers its fourteen built-ins when the state is constructed.
-`MarkdownExtension` registers `markdown.toggleBold`, `markdown.toggleBulletList`
-and the rest from its `init`, which is the same place it already reaches into
-`editorState`.
+The core registers its fourteen built-ins when the state is constructed. The
+obvious follow-up is for `MarkdownExtension` to register `markdown.toggleBold`,
+`markdown.toggleBulletList` and the rest from its `init`, which is the same
+place it already reaches into `editorState`, making every toolbar function
+bindable. That is *not* implemented: nothing outside `BuiltinEditorActions`
+registers an action, and `MarkdownExtension` is unchanged by this work. A host
+wanting a markdown chord today registers the action itself, as
+`sampleApp/BoldShortcut.kt` does.
 
 ### Resolution and consumption
 
@@ -156,12 +160,25 @@ and the rest from its `init`, which is the same place it already reaches into
 
 1. `keyBindings.commandFor(event)` or return false.
 2. `Motion`: move the caret, extending on shift. Unchanged.
-3. `Action`: return false if `isEdit && !enabled`. Look it up; **return false
-   if unregistered** (rule 5). Otherwise `perform(context)` and return true.
+3. `Action`: look it up; **return false if unregistered** (rule 5). Then return
+   false if the *registered spec's* `isEdit` and the editor is disabled.
+   Otherwise `perform(context)` and return true.
 
-Returning false for an unregistered action matters more than it looks: a host
-that binds a chord and forgets to register the handler gets the character
-typed, not a dead key.
+The gate reads `isEdit` off the spec rather than off the `EditorCommand.Action`
+the bindings returned, because `Action` identity is its id alone. A host writing
+its own bindings can hand back `Action("editor.paste", isEdit = false)`, which
+resolves the real built-in paste; taking the caller's word for it would let that
+mutate a read-only editor.
+
+Returning false for an unregistered action leaves the event to whatever would
+have handled it otherwise. It is worth being precise about what that means,
+because an earlier draft of this document claimed it always "gets the character
+typed, not a dead key", and that is only true for unmodified printable keys.
+`handleCharacterInput` refuses control characters and refuses any Ctrl or Cmd
+chord, so an unregistered `editor.paste` makes Ctrl+V inert, and an unregistered
+`editor.indent` lets Tab reach the platform's focus traversal and move focus out
+of the editor entirely. A host that wants a chord to do nothing should bind it
+to a registered no-op action rather than unregister the built-in.
 
 ## Edit behaviors
 

--- a/docs/design/editor-actions.md
+++ b/docs/design/editor-actions.md
@@ -28,22 +28,23 @@ line-block concern lives inside the two functions every input source shares.
 That inverts the intended layering (core reaching into `richstyle`), and it
 leaves no seam for any other feature that wants the same kind of hook.
 
-The second symptom is already a bug. Because the behavior sits in the
+The second symptom was already a bug. Because the behavior sat in the
 primitives rather than at a point every input path agrees on, whether the user
-gets it depends on which method their IME happens to call:
+got it depended on which method their IME happened to call:
 
-| Path | Reaches block exit / demote |
-| --- | --- |
-| Hardware key, `TextEditorKeyCommandHandler` | yes |
-| Android `sendKeyEvent(KEYCODE_DEL)`, re-dispatched to the key handler | yes |
-| Android `deleteSurroundingText(1, 0)` to `imeDeleteSurroundingText` | no |
-| `commitText("\n")` to `imeCommitText` to `insertStringAtCursor` | no |
-| `performEditorAction` to `imePerformNewline` | yes |
+| Path | Before | After |
+| --- | --- | --- |
+| Hardware key, `TextEditorKeyCommandHandler` | yes | yes |
+| Android `sendKeyEvent(KEYCODE_DEL)`, re-dispatched to the key handler | yes | yes |
+| Android `deleteSurroundingText(1, 0)` to `imeDeleteSurroundingText` | no | yes |
+| `commitText("\n")` to `imeCommitText` to `insertStringAtCursor` | no | yes |
+| `performEditorAction` to `imePerformNewline` | yes | yes |
 
-So on a soft keyboard, backspace at the start of a bullet demotes or merges
+So on a soft keyboard, backspace at the start of a bullet demoted or merged
 depending on the IME's choice of `InputConnection` method, and Enter on an
-empty bullet exits the list or does not depending on whether the IME commits
-the newline as text.
+empty bullet exited the list or did not depending on whether the IME committed
+the newline as text. Every row is checked by `ImeLineBlockParityTest`, with the
+hardware-key result as the reference the others are compared against.
 
 ## Design rules
 
@@ -210,10 +211,27 @@ The semantics documented under "Smart editing" in
 Moving code that keeps running by default and behaves identically is worth
 stating plainly, because it is fair to ask what was gained:
 
-- `TextEditorState` stops importing `richstyle`. The dependency inverts.
+- The dependency narrows. `TextEditorState` drops `applyLineBlock` and
+  `detectLineBlock` and names `LineBlockEditBehavior` instead. It does not stop
+  importing `richstyle`: `normalizeLineBlocks` and the block span styles are
+  still used by layout, measurement and content normalization, which have
+  nothing to do with edit behaviors. An earlier draft of this document claimed
+  the dependency inverts outright, which was wrong.
 - Every input path gets the behavior, which fixes the divergence table above.
 - A code-editor host can add auto-indent or bracket-closing without forking.
-- It can be turned off, which today requires editing the library.
+- It can be turned off, which previously required editing the library.
+
+The newline case does not fit a plain "handled / not handled" return. Enter on
+an empty item is a clean claim, but a split *inside* an item needs the block
+captured before the split and re-applied to both halves after, in one revision,
+because detection after the split is unreliable. Rather than add a second hook
+and thread state between the two, `TextEditorState.insertNewlineRaw()` is
+`internal` and the behavior performs the split itself inside its own
+`withAtomicEdit`. The interface stays a single boolean.
+
+That double apply is load-bearing rather than defensive: with the behavior
+removed, splitting an item leaves the new half without its gutter marker, which
+`EditBehaviorTest` pins.
 
 ## Making every input path agree
 
@@ -234,9 +252,54 @@ no selection) exclude the autocorrect case as far as static reading can tell,
 but this needs verification on a device against at least Gboard and one
 third-party keyboard, not just the `androidHostTest` suite.
 
+As implemented, the guard is written on the computed character range rather
+than the caller's arguments: exactly one character ending at the caret, no
+composing region, no selection. Writing it that way lets
+`deleteSurroundingTextInCodePoints` share it without a one-code-point delete of
+an astral character reaching `backspaceAtCursor`, which deletes a single UTF-16
+char and would split the surrogate pair.
+
+### Device verification still owed
+
+Everything below is covered only by desktop JVM tests against the shared
+`ImeEditLogic`. The guards are a static reading of what an autocorrect rewrite
+looks like versus what a relayed keypress looks like, and no soft keyboard was
+run against them. Do not treat this as release-ready until it has been checked
+on hardware against Gboard and at least one third-party keyboard (SwiftKey or
+Samsung Keyboard are the usual second targets).
+
+What to check, in a document with a bullet list:
+
+1. *Backspace at the start of a bullet item* should demote the item, and a
+   second press should merge it into the previous line. Check with the caret at
+   column 0 of an item whose predecessor is a different block, and again where
+   the predecessor is the same block (which must merge directly, no demote).
+2. *Enter on an empty bullet item* should exit the list rather than adding
+   another empty item.
+3. *Autocorrect must not demote.* Type a word at the start of a bullet item,
+   let the keyboard offer a correction, and accept it. The bullet must survive.
+   This is the failure mode the guard exists to prevent and the one most likely
+   to be wrong, because it depends on whether the keyboard keeps a composing
+   region while it rewrites.
+4. *Predictive replacement of a whole word* at the start of an item, same
+   expectation.
+5. *Swipe / glide typing* into and over an item boundary, which tends to use
+   `commitText` with multi-character strings and larger `deleteSurroundingText`
+   spans than the guard admits. Nothing should demote.
+6. *Emoji and other astral characters* deleted with one backspace at the end of
+   an item: the whole glyph goes, never half a surrogate pair.
+7. *Voice input* committing text that contains newlines, which must not be read
+   as an Enter.
+
+If any of these misbehave, the fix is to narrow the guard in
+`deleteSurroundingRange` / `imeCommitText`, not to widen it. The pre-existing
+behavior is the safe fallback: a plain range delete is always correct for the
+text, it just misses the block semantics.
+
 ## Landing order
 
-Each step compiles, passes, and is independently revertible.
+Each step compiles, passes, and is independently revertible. All six have
+landed.
 
 1. `EditorCommand` public; `Action` becomes an open class with companion
    constants. Pure mechanical change, no behavior difference.
@@ -246,22 +309,61 @@ Each step compiles, passes, and is independently revertible.
 3. `ContextMenuActions` collapses onto the registry. Deletes the duplicated
    cut/copy/paste bodies.
 4. `EditBehavior` chain; `LineBlockEditBehavior` extracted and registered by
-   default. `TextEditorState` loses its line-block imports.
+   default. `TextEditorState` loses its line-block editing imports.
 5. IME backspace and newline routed through the semantic paths. Tests for each
    row of the divergence table.
 6. Registration surfaced on `BasicTextEditor` / `TextEditor`, `LocalKeyBindings`
    made public, docs updated, sample app binds Ctrl+B to bold as the worked
    example.
 
+## Extending the editor
+
+Three seams, in the order you are likely to reach for them.
+
+*Add a shortcut.* Register an action, then bind a chord to it. Delegate the
+chords you do not claim or you lose every built-in:
+
+```kotlin
+val ToggleBold = EditorCommand.Action("myapp.toggleBold", isEdit = true)
+
+state.actions.register(EditorActionSpec(ToggleBold) { it.state.toggleBold() })
+
+val bindings = KeyBindings { event ->
+    if (event.key == Key.B && event.isCtrlShortcut) ToggleBold
+    else platformKeyBindings().commandFor(event)
+}
+
+TextEditor(state = state, keyBindings = bindings)
+```
+
+Use `isCtrlShortcut` rather than `isCtrlPressed`: Windows synthesizes AltGr as
+left-Ctrl plus right-Alt, so a bare Ctrl test steals the layout chords that type
+a character. `sampleApp/BoldShortcut.kt` is this worked out, including picking
+the modifier per platform.
+
+*Replace a built-in.* Register over its id. `editor.paste` bound to a paste that
+strips formatting changes the chord, the context menu and anything else that
+invokes it, because they all resolve through the same registry.
+
+*Intercept an edit.* Implement `EditBehavior` and add it to
+`state.editBehaviors`. Use this, not an action, when the thing you are reacting
+to has no chord: an IME commits a newline without ever producing a key event.
+Note that `withAtomicEdit` and the raw primitives are `internal`, so an
+out-of-module behavior builds on the public edit API (`insertStringAtCursor`,
+`delete`, `replace`) and cannot wrap a primitive in its own transaction.
+
 ## Known limitations and follow-ups
 
 - `Action.Indent` / `Action.Outdent` insert and strip literal spaces against a
-  hard-coded `TAB_SIZE = 4` in `TextEditorKeyCommandHandler`. Once actions are
-  open these become overridable, so a list-aware Tab or a code-editor indent is
-  a host concern rather than a library change. Not addressed here.
+  hard-coded `TAB_SIZE = 4`, now in `BuiltinEditorActions`. Because actions are
+  open these are overridable, so a list-aware Tab or a code-editor indent is a
+  host concern rather than a library change. Not addressed here.
 - Behaviors are consulted for newline, backspace and forward delete only.
   Typed-character interception (auto-pairing quotes and brackets) is the
   obvious next hook and is deliberately out of scope until something needs it.
-- The registry has no ordering control beyond insertion order. If two behaviors
-  ever contend for the same edit, priority becomes a real design question;
-  until then, first-registered-wins is enough.
+- `EditBehavior` is public but the transactional primitives it would want are
+  not. An out-of-module behavior can claim an edit and can mutate through the
+  public API, but cannot compose several mutations into one revision. Widen this
+  when a host asks for it, rather than guessing at the shape now.
+- The IME routing is unverified on real hardware. See "Device verification still
+  owed" above; that list should be worked through before a release ships this.

--- a/docs/design/editor-actions.md
+++ b/docs/design/editor-actions.md
@@ -1,50 +1,9 @@
 # Editor actions and edit behaviors
 
-The design reference for how input reaches editor behavior: which shortcuts
-exist, what they invoke, and how a feature attaches behavior to a primitive
-edit without the primitive knowing the feature exists. It replaces the closed
-`EditorCommand.Action` enum and the hard-wired line-block branches in
-`TextEditorState`. Motivating issue: #37.
-
-## The problem
-
-Two symptoms, one cause.
-
-*Actions are a closed set.* `EditorCommand.Action` is an `internal` enum with
-fourteen members. `KeyBindings` maps chords onto it and
-`TextEditorKeyCommandHandler` executes it, which is a clean split as far as it
-goes, but a host cannot add a member. `MarkdownExtension` already exposes
-`toggleBlockquote`, `toggleBulletList`, `toggleOrderedList`, `toggleCodeFence`
-and `toggleHeader`, and the sample app drives all of them from toolbar buttons.
-Not one of them can be bound to a key without forking the library. Because
-there is also no way to *invoke* an action by name, every input surface
-re-implements the ones that do exist: `ContextMenuActions.paste` and
-`TextEditorKeyCommandHandler.handlePaste` are the same twenty-five lines of
-clipboard, rich-span provenance and HTML-block logic, written twice.
-
-*Behavior is welded into primitives.* `insertNewlineAtCursor` and
-`backspaceAtCursor` call `detectLineBlock` and branch on the result, so a
-line-block concern lives inside the two functions every input source shares.
-That inverts the intended layering (core reaching into `richstyle`), and it
-leaves no seam for any other feature that wants the same kind of hook.
-
-The second symptom was already a bug. Because the behavior sat in the
-primitives rather than at a point every input path agrees on, whether the user
-got it depended on which method their IME happened to call:
-
-| Path | Before | After |
-| --- | --- | --- |
-| Hardware key, `TextEditorKeyCommandHandler` | yes | yes |
-| Android `sendKeyEvent(KEYCODE_DEL)`, re-dispatched to the key handler | yes | yes |
-| Android `deleteSurroundingText(1, 0)` to `imeDeleteSurroundingText` | no | yes |
-| `commitText("\n")` to `imeCommitText` to `insertStringAtCursor` | no | yes |
-| `performEditorAction` to `imePerformNewline` | yes | yes |
-
-So on a soft keyboard, backspace at the start of a bullet demoted or merged
-depending on the IME's choice of `InputConnection` method, and Enter on an
-empty bullet exited the list or did not depending on whether the IME committed
-the newline as text. Every row is checked by `ImeLineBlockParityTest`, with the
-hardware-key result as the reference the others are compared against.
+How input reaches editor behavior: which shortcuts exist, what they invoke,
+and how a feature attaches behavior to a primitive edit without the primitive
+knowing the feature exists. Covers the `EditorCommand` vocabulary, the
+`EditorActionRegistry`, and the `EditBehavior` chain. Motivating issue: #37.
 
 ## Design rules
 
@@ -76,17 +35,17 @@ like an action bound to Backspace. It is not, because the IME never produces a
 key event. A soft-keyboard backspace arrives as `deleteSurroundingText(1, 0)`,
 an autocorrect replacement arrives as `commitText`, and neither carries a chord
 to bind. The interception point has to be the semantic edit primitive, not the
-chord, which is precisely why the current code ended up inside
-`backspaceAtCursor` in the first place. The fix is not to move it somewhere
-chord-shaped; it is to make that interception point explicit and registrable.
+chord. This is also why the line-block logic could never live in key handling:
+a behavior attached to a chord reaches only the input paths that produce key
+events, and the soft-keyboard paths silently lose it.
 
 ## Actions
 
 ### The vocabulary
 
-`EditorCommand` becomes public. `Motion` stays an enum: motions are a genuinely
-closed vocabulary, nothing about a caret movement is extensible, and keeping it
-closed preserves the exhaustive `when` in the handler. `Action` becomes an open
+`EditorCommand` is public. `Motion` is an enum: motions are a genuinely closed
+vocabulary, nothing about a caret movement is extensible, and keeping it
+closed preserves the exhaustive `when` in the handler. `Action` is an open
 class keyed by a string id:
 
 ```kotlin
@@ -98,20 +57,19 @@ sealed interface EditorCommand {
             val SelectAll = Action("editor.selectAll", isEdit = false)
             val Copy = Action("editor.copy", isEdit = false)
             val Paste = Action("editor.paste", isEdit = true)
-            // … the current fourteen
+            // … the built-in set
         }
     }
 }
 ```
 
-Existing `KeyBindings` implementations are untouched by this: `Action.Copy`
-still resolves through the companion. A host writes
-`Action("myapp.toggleBold", isEdit = true)` and binds it from its own
-`KeyBindings`. Ids are namespaced by convention (`editor.`, `markdown.`,
-`myapp.`) and the registry is keyed by id string, not object identity, so a
-duplicate id is a detectable collision rather than a silent second entry.
+A host writes `Action("myapp.toggleBold", isEdit = true)` and binds it from
+its own `KeyBindings`. Ids are namespaced by convention (`editor.`,
+`markdown.`, `myapp.`) and the registry is keyed by id string, not object
+identity, so a duplicate id is a detectable collision rather than a silent
+second entry.
 
-`isEdit` stays on the action because the disabled-editor gate needs it before
+`isEdit` sits on the action because the disabled-editor gate needs it before
 dispatch, without having to resolve a handler first.
 
 ### The registry
@@ -140,26 +98,23 @@ class EditorActionRegistry {
 }
 ```
 
-`isEnabled` exists for the context menu, which today asks `canCut()` /
-`canCopy()` / `canPaste()` through bespoke methods. Once actions carry their own
-enablement predicate the menu can be built from a list of action ids and stop
-knowing what any of them mean.
+`isEnabled` exists for the context menu, which builds its items from a list of
+action ids and asks each spec whether it currently applies, instead of knowing
+what any of them mean.
 
-The core registers its fourteen built-ins when the state is constructed. The
-obvious follow-up is for `MarkdownExtension` to register `markdown.toggleBold`,
-`markdown.toggleBulletList` and the rest from its `init`, which is the same
-place it already reaches into `editorState`, making every toolbar function
-bindable. That is *not* implemented: nothing outside `BuiltinEditorActions`
-registers an action, and `MarkdownExtension` is unchanged by this work. A host
-wanting a markdown chord today registers the action itself, as
-`sampleApp/BoldShortcut.kt` does.
+The core registers its built-ins (`BuiltinEditorActions`) when the state is
+constructed. Nothing else in the library registers an action:
+`MarkdownExtension` still exposes its toggles as plain functions, and a host
+that wants a markdown chord registers the action itself, as
+`sampleApp/BoldShortcut.kt` does. Having the extension register
+`markdown.toggleBold` and friends from its `init` is the obvious follow-up.
 
 ### Resolution and consumption
 
-`TextEditorKeyCommandHandler.handleKeyEvent` becomes:
+`TextEditorKeyCommandHandler.handleKeyEvent` resolves in three steps:
 
 1. `keyBindings.commandFor(event)` or return false.
-2. `Motion`: move the caret, extending on shift. Unchanged.
+2. `Motion`: move the caret, extending on shift.
 3. `Action`: look it up; **return false if unregistered** (rule 5). Then return
    false if the *registered spec's* `isEdit` and the editor is disabled.
    Otherwise `perform(context)` and return true.
@@ -171,14 +126,13 @@ resolves the real built-in paste; taking the caller's word for it would let that
 mutate a read-only editor.
 
 Returning false for an unregistered action leaves the event to whatever would
-have handled it otherwise. It is worth being precise about what that means,
-because an earlier draft of this document claimed it always "gets the character
-typed, not a dead key", and that is only true for unmodified printable keys.
-`handleCharacterInput` refuses control characters and refuses any Ctrl or Cmd
-chord, so an unregistered `editor.paste` makes Ctrl+V inert, and an unregistered
-`editor.indent` lets Tab reach the platform's focus traversal and move focus out
-of the editor entirely. A host that wants a chord to do nothing should bind it
-to a registered no-op action rather than unregister the built-in.
+have handled it otherwise, but only unmodified printable keys have a useful
+fallback. `handleCharacterInput` refuses control characters and refuses any
+Ctrl or Cmd chord, so an unregistered `editor.paste` makes Ctrl+V inert, and an
+unregistered `editor.indent` lets Tab reach the platform's focus traversal and
+move focus out of the editor entirely. A host that wants a chord to do nothing
+should bind it to a registered no-op action rather than unregister the
+built-in.
 
 ## Edit behaviors
 
@@ -195,12 +149,11 @@ interface EditBehavior {
 Returning true means "I handled it, do nothing else". Behaviors are an ordered
 list on `TextEditorState`; the first to claim the edit wins. A behavior that
 mutates must route through the edit manager, so its work lands in undo history
-like any other operation (the current line-block code already does this
-deliberately, going through `toggleLineBlock` rather than mutating spans
-directly).
+like any other operation (`LineBlockEditBehavior` does this by going through
+`toggleLineBlock` rather than mutating spans directly).
 
-The chain is consulted inside the existing public functions, which keep both
-their names and their current behavior:
+The chain is consulted inside the public semantic functions, so every caller
+gets it:
 
 ```kotlin
 fun backspaceAtCursor() {
@@ -209,40 +162,36 @@ fun backspaceAtCursor() {
 }
 ```
 
-The alternative was a new semantic layer (`performBackspace` running the chain,
-`backspaceAtCursor` staying primitive). Rejected for this pass: it changes what
-`backspaceAtCursor` does for existing callers, and there is no caller that wants
-the primitive without the behavior. The raw form stays internal until something
-needs it.
+A separate semantic layer (`performBackspace` running the chain over a
+primitive `backspaceAtCursor`) was considered and rejected: no caller wants
+the primitive without the behavior, so the raw form stays `internal` until
+something needs it.
 
 ### Line blocks as the first behavior
 
 Line blocks are not a markdown feature. They are a core capability that
-markdown happens to serialize, so the behavior stays in the library and
-`MarkdownExtension` remains a consumer. It moves out of `TextEditorState` and
-into a `LineBlockEditBehavior` in `richstyle`, registered by default, carrying
-the logic currently at `TextEditorState.kt:490-502` and `:530-552` verbatim.
-The semantics documented under "Smart editing" in
-[line-blocks.md](line-blocks.md) do not change.
+markdown happens to serialize, so the behavior lives in the library
+(`LineBlockEditBehavior` in `richstyle`) and is registered by default;
+`MarkdownExtension` remains a consumer. The semantics documented under
+"Smart editing" in [line-blocks.md](line-blocks.md) are unchanged by where the
+code sits.
 
-Moving code that keeps running by default and behaves identically is worth
-stating plainly, because it is fair to ask what was gained:
+What the seam buys over branching inside the primitives:
 
-- The dependency narrows. `TextEditorState` drops `applyLineBlock` and
-  `detectLineBlock` and names `LineBlockEditBehavior` instead. It does not stop
-  importing `richstyle`: `normalizeLineBlocks` and the block span styles are
-  still used by layout, measurement and content normalization, which have
-  nothing to do with edit behaviors. An earlier draft of this document claimed
-  the dependency inverts outright, which was wrong.
-- Every input path gets the behavior, which fixes the divergence table above.
+- The dependency narrows. `TextEditorState` names `LineBlockEditBehavior` but
+  no longer calls `applyLineBlock` or `detectLineBlock` itself. It still
+  imports `richstyle`: `normalizeLineBlocks` and the block span styles are
+  used by layout, measurement and content normalization, which have nothing to
+  do with edit behaviors.
+- Every input path gets the behavior. See "Input-path parity" below.
 - A code-editor host can add auto-indent or bracket-closing without forking.
 - It can be turned off, which previously required editing the library.
 
 The newline case does not fit a plain "handled / not handled" return. Enter on
 an empty item is a clean claim, but a split *inside* an item needs the block
 captured before the split and re-applied to both halves after, in one revision,
-because detection after the split is unreliable. Rather than add a second hook
-and thread state between the two, `TextEditorState.insertNewlineRaw()` is
+because detection after the split is unreliable. Rather than a second hook with
+state threaded between the two, `TextEditorState.insertNewlineRaw()` is
 `internal` and the behavior performs the split itself inside its own
 `withAtomicEdit`. The interface stays a single boolean.
 
@@ -250,50 +199,52 @@ That double apply is load-bearing rather than defensive: with the behavior
 removed, splitting an item leaves the new half without its gutter marker, which
 `EditBehaviorTest` pins.
 
-## Making every input path agree
+## Input-path parity
 
-With the chain in place, the IME paths route to the semantic functions:
+Five paths deliver a backspace or a newline, and all five must land on the
+same semantic function so the chain sees them:
 
-- `imeDeleteSurroundingText(before = 1, after = 0)` with no composing region
-  and no selection is a backspace. Route it to `backspaceAtCursor()`. Every
-  other shape stays a range delete.
-- `imeCommitText("\n", …)` with no composing region is an Enter. Route it to
-  the newline path.
+- Hardware key events, through `TextEditorKeyCommandHandler`.
+- Android `sendKeyEvent(KEYCODE_DEL)`, re-dispatched to the key handler.
+- Android `deleteSurroundingText(1, 0)`, routed to `backspaceAtCursor()`.
+- `commitText("\n")`, routed to the newline path.
+- `performEditorAction`, through `imePerformNewline`.
 
-This is the risky part of the whole design and should land last, on its own,
-with tests. `deleteSurroundingText(1, 0)` is not unambiguously a keypress:
-autocorrect and prediction engines use the same call to rewrite what the user
-typed, and treating one of those as a backspace would demote a bullet in the
-middle of a word correction. The guard conditions above (no composing region,
-no selection) exclude the autocorrect case as far as static reading can tell,
-but this needs verification on a device against at least Gboard and one
-third-party keyboard, not just the `androidHostTest` suite.
+Each path is checked by `ImeLineBlockParityTest`, with the hardware-key result
+as the reference the others are compared against. Before the IME routing
+existed, whether a soft-keyboard backspace demoted a bullet depended on which
+`InputConnection` method the IME happened to call.
 
-As implemented, the guard reads intent from the widths the caller asked for, not
-from the range that survives clamping: a request for exactly one character on
-exactly one side, no composing region, no selection. The distinction matters at
-the edges of the document, where a request for several characters shrinks to
-one; reading the survivor would let an autocorrect rewrite at the top of the
-document pass as a backspace.
+The IME routing is the risky part of the design, because
+`deleteSurroundingText(1, 0)` is not unambiguously a keypress: autocorrect and
+prediction engines use the same call to rewrite what the user typed, and
+treating one of those as a backspace would demote a bullet in the middle of a
+word correction. The guards:
 
-The code-point variant additionally requires that its request resolved to at
-most one UTF-16 char, so a one-code-point delete of an astral character never
-reaches `backspaceAtCursor`, which deletes a single char and would split the
-surrogate pair.
-
-Both semantic routes also run when clamping leaves an empty range. A backspace
-at the very start of the document removes nothing but can still exit a line
-block, which is what the hardware key does; bailing on the empty range would
-leave the key dead on a soft keyboard for a block on the first line.
+- Intent is read from the widths the caller asked for, not from the range that
+  survives clamping: exactly one character on exactly one side, no composing
+  region, no selection. The distinction matters at the edges of the document,
+  where a request for several characters shrinks to one; reading the survivor
+  would let an autocorrect rewrite at the top of the document pass as a
+  backspace.
+- The code-point variant additionally requires that its request resolved to at
+  most one UTF-16 char, so a one-code-point delete of an astral character never
+  reaches `backspaceAtCursor`, which deletes a single char and would split the
+  surrogate pair.
+- Both semantic routes also run when clamping leaves an empty range. A
+  backspace at the very start of the document removes nothing but can still
+  exit a line block, which is what the hardware key does; bailing on the empty
+  range would leave the key dead on a soft keyboard for a block on the first
+  line.
 
 ### Device verification still owed
 
-Everything below is covered only by desktop JVM tests against the shared
-`ImeEditLogic`. The guards are a static reading of what an autocorrect rewrite
-looks like versus what a relayed keypress looks like, and no soft keyboard was
-run against them. Do not treat this as release-ready until it has been checked
-on hardware against Gboard and at least one third-party keyboard (SwiftKey or
-Samsung Keyboard are the usual second targets).
+The guards are a static reading of what an autocorrect rewrite looks like
+versus what a relayed keypress looks like, covered only by desktop JVM tests
+against the shared `ImeEditLogic`; no soft keyboard has been run against them.
+Do not treat this as release-ready until it has been checked on hardware
+against Gboard and at least one third-party keyboard (SwiftKey or Samsung
+Keyboard are the usual second targets).
 
 What to check, in a document with a bullet list:
 
@@ -319,29 +270,8 @@ What to check, in a document with a bullet list:
    as an Enter.
 
 If any of these misbehave, the fix is to narrow the guard in
-`deleteSurroundingRange` / `imeCommitText`, not to widen it. The pre-existing
-behavior is the safe fallback: a plain range delete is always correct for the
-text, it just misses the block semantics.
-
-## Landing order
-
-Each step compiles, passes, and is independently revertible. All six have
-landed.
-
-1. `EditorCommand` public; `Action` becomes an open class with companion
-   constants. Pure mechanical change, no behavior difference.
-2. `EditorActionRegistry` on `TextEditorState`. Built-in action bodies move out
-   of `TextEditorKeyCommandHandler` into registered specs; the handler resolves
-   through the registry.
-3. `ContextMenuActions` collapses onto the registry. Deletes the duplicated
-   cut/copy/paste bodies.
-4. `EditBehavior` chain; `LineBlockEditBehavior` extracted and registered by
-   default. `TextEditorState` loses its line-block editing imports.
-5. IME backspace and newline routed through the semantic paths. Tests for each
-   row of the divergence table.
-6. Registration surfaced on `BasicTextEditor` / `TextEditor`, `LocalKeyBindings`
-   made public, docs updated, sample app binds Ctrl+B to bold as the worked
-   example.
+`deleteSurroundingRange` / `imeCommitText`, not to widen it. A plain range
+delete is always correct for the text, it just misses the block semantics.
 
 ## Extending the editor
 
@@ -382,15 +312,16 @@ out-of-module behavior builds on the public edit API (`insertStringAtCursor`,
 ## Known limitations and follow-ups
 
 - `Action.Indent` / `Action.Outdent` insert and strip literal spaces against a
-  hard-coded `TAB_SIZE = 4`, now in `BuiltinEditorActions`. Because actions are
+  hard-coded `TAB_SIZE = 4` in `BuiltinEditorActions`. Because actions are
   open these are overridable, so a list-aware Tab or a code-editor indent is a
-  host concern rather than a library change. Not addressed here.
+  host concern rather than a library change.
 - Behaviors are consulted for newline, backspace and forward delete only.
   Typed-character interception (auto-pairing quotes and brackets) is the
   obvious next hook and is deliberately out of scope until something needs it.
 - `EditBehavior` is public but the transactional primitives it would want are
   not. An out-of-module behavior can claim an edit and can mutate through the
-  public API, but cannot compose several mutations into one revision. Widen this
-  when a host asks for it, rather than guessing at the shape now.
-- The IME routing is unverified on real hardware. See "Device verification still
-  owed" above; that list should be worked through before a release ships this.
+  public API, but cannot compose several mutations into one revision. Widen
+  this when a host asks for it, rather than guessing at the shape now.
+- The IME routing is unverified on real hardware. See "Device verification
+  still owed" above; that list should be worked through before a release ships
+  this.

--- a/docs/design/editor-actions.md
+++ b/docs/design/editor-actions.md
@@ -1,0 +1,267 @@
+# Editor actions and edit behaviors
+
+The design reference for how input reaches editor behavior: which shortcuts
+exist, what they invoke, and how a feature attaches behavior to a primitive
+edit without the primitive knowing the feature exists. It replaces the closed
+`EditorCommand.Action` enum and the hard-wired line-block branches in
+`TextEditorState`. Motivating issue: #37.
+
+## The problem
+
+Two symptoms, one cause.
+
+*Actions are a closed set.* `EditorCommand.Action` is an `internal` enum with
+fourteen members. `KeyBindings` maps chords onto it and
+`TextEditorKeyCommandHandler` executes it, which is a clean split as far as it
+goes, but a host cannot add a member. `MarkdownExtension` already exposes
+`toggleBlockquote`, `toggleBulletList`, `toggleOrderedList`, `toggleCodeFence`
+and `toggleHeader`, and the sample app drives all of them from toolbar buttons.
+Not one of them can be bound to a key without forking the library. Because
+there is also no way to *invoke* an action by name, every input surface
+re-implements the ones that do exist: `ContextMenuActions.paste` and
+`TextEditorKeyCommandHandler.handlePaste` are the same twenty-five lines of
+clipboard, rich-span provenance and HTML-block logic, written twice.
+
+*Behavior is welded into primitives.* `insertNewlineAtCursor` and
+`backspaceAtCursor` call `detectLineBlock` and branch on the result, so a
+line-block concern lives inside the two functions every input source shares.
+That inverts the intended layering (core reaching into `richstyle`), and it
+leaves no seam for any other feature that wants the same kind of hook.
+
+The second symptom is already a bug. Because the behavior sits in the
+primitives rather than at a point every input path agrees on, whether the user
+gets it depends on which method their IME happens to call:
+
+| Path | Reaches block exit / demote |
+| --- | --- |
+| Hardware key, `TextEditorKeyCommandHandler` | yes |
+| Android `sendKeyEvent(KEYCODE_DEL)`, re-dispatched to the key handler | yes |
+| Android `deleteSurroundingText(1, 0)` to `imeDeleteSurroundingText` | no |
+| `commitText("\n")` to `imeCommitText` to `insertStringAtCursor` | no |
+| `performEditorAction` to `imePerformNewline` | yes |
+
+So on a soft keyboard, backspace at the start of a bullet demotes or merges
+depending on the IME's choice of `InputConnection` method, and Enter on an
+empty bullet exits the list or does not depending on whether the IME commits
+the newline as text.
+
+## Design rules
+
+1. **Input translates, it never decides.** Key handling, pointer handling and
+   the IME all resolve to the same named action or the same semantic edit.
+   No input path may carry behavior another input path lacks.
+2. **The chord and the behavior are separate registries.** `KeyBindings`
+   answers "which action does this chord name". The action registry answers
+   "what does that action do". Neither may absorb the other.
+3. **Built-ins register through the public mechanism.** Line blocks, clipboard
+   actions and everything else the library ships use the same registration API
+   a host would. If a built-in needs a private door, the door is the design
+   defect.
+4. **Primitives stay permissive.** `insertNewlineAtCursor` and friends do one
+   mechanical thing. Anything smart is a registered behavior consulted above
+   them.
+5. **Unclaimed input falls through.** An action id with no registered handler
+   must not consume the key event, or an unbound chord swallows a keystroke
+   that should have been typed.
+
+## Why two mechanisms and not one
+
+An action is invoked by name, from anywhere: a chord, a menu item, a toolbar
+button, host code. A behavior intercepts a semantic edit that has no name and
+no chord of its own.
+
+It is tempting to collapse them, since "backspace demotes the bullet" looks
+like an action bound to Backspace. It is not, because the IME never produces a
+key event. A soft-keyboard backspace arrives as `deleteSurroundingText(1, 0)`,
+an autocorrect replacement arrives as `commitText`, and neither carries a chord
+to bind. The interception point has to be the semantic edit primitive, not the
+chord, which is precisely why the current code ended up inside
+`backspaceAtCursor` in the first place. The fix is not to move it somewhere
+chord-shaped; it is to make that interception point explicit and registrable.
+
+## Actions
+
+### The vocabulary
+
+`EditorCommand` becomes public. `Motion` stays an enum: motions are a genuinely
+closed vocabulary, nothing about a caret movement is extensible, and keeping it
+closed preserves the exhaustive `when` in the handler. `Action` becomes an open
+class keyed by a string id:
+
+```kotlin
+sealed interface EditorCommand {
+    enum class Motion : EditorCommand { Left, Right, /* … */ }
+
+    class Action(val id: String, val isEdit: Boolean) : EditorCommand {
+        companion object {
+            val SelectAll = Action("editor.selectAll", isEdit = false)
+            val Copy = Action("editor.copy", isEdit = false)
+            val Paste = Action("editor.paste", isEdit = true)
+            // … the current fourteen
+        }
+    }
+}
+```
+
+Existing `KeyBindings` implementations are untouched by this: `Action.Copy`
+still resolves through the companion. A host writes
+`Action("myapp.toggleBold", isEdit = true)` and binds it from its own
+`KeyBindings`. Ids are namespaced by convention (`editor.`, `markdown.`,
+`myapp.`) and the registry is keyed by id string, not object identity, so a
+duplicate id is a detectable collision rather than a silent second entry.
+
+`isEdit` stays on the action because the disabled-editor gate needs it before
+dispatch, without having to resolve a handler first.
+
+### The registry
+
+Lives on `TextEditorState`, because that is the one object the key handler, the
+context menu and the IME already share. Clipboard and coroutine scope are not
+available at registration time, so they arrive per invocation:
+
+```kotlin
+class EditorActionContext(
+    val state: TextEditorState,
+    val clipboard: Clipboard,
+    val scope: CoroutineScope,
+)
+
+class EditorActionSpec(
+    val action: EditorCommand.Action,
+    val isEnabled: (EditorActionContext) -> Boolean = { true },
+    val perform: (EditorActionContext) -> Unit,
+)
+
+class EditorActionRegistry {
+    fun register(spec: EditorActionSpec)
+    fun unregister(action: EditorCommand.Action)
+    operator fun get(action: EditorCommand.Action): EditorActionSpec?
+}
+```
+
+`isEnabled` exists for the context menu, which today asks `canCut()` /
+`canCopy()` / `canPaste()` through bespoke methods. Once actions carry their own
+enablement predicate the menu can be built from a list of action ids and stop
+knowing what any of them mean.
+
+The core registers its fourteen built-ins when the state is constructed.
+`MarkdownExtension` registers `markdown.toggleBold`, `markdown.toggleBulletList`
+and the rest from its `init`, which is the same place it already reaches into
+`editorState`.
+
+### Resolution and consumption
+
+`TextEditorKeyCommandHandler.handleKeyEvent` becomes:
+
+1. `keyBindings.commandFor(event)` or return false.
+2. `Motion`: move the caret, extending on shift. Unchanged.
+3. `Action`: return false if `isEdit && !enabled`. Look it up; **return false
+   if unregistered** (rule 5). Otherwise `perform(context)` and return true.
+
+Returning false for an unregistered action matters more than it looks: a host
+that binds a chord and forgets to register the handler gets the character
+typed, not a dead key.
+
+## Edit behaviors
+
+### The chain
+
+```kotlin
+interface EditBehavior {
+    fun onNewline(state: TextEditorState): Boolean = false
+    fun onBackspace(state: TextEditorState): Boolean = false
+    fun onDeleteForward(state: TextEditorState): Boolean = false
+}
+```
+
+Returning true means "I handled it, do nothing else". Behaviors are an ordered
+list on `TextEditorState`; the first to claim the edit wins. A behavior that
+mutates must route through the edit manager, so its work lands in undo history
+like any other operation (the current line-block code already does this
+deliberately, going through `toggleLineBlock` rather than mutating spans
+directly).
+
+The chain is consulted inside the existing public functions, which keep both
+their names and their current behavior:
+
+```kotlin
+fun backspaceAtCursor() {
+    if (editBehaviors.any { it.onBackspace(this) }) return
+    backspaceAtCursorRaw()
+}
+```
+
+The alternative was a new semantic layer (`performBackspace` running the chain,
+`backspaceAtCursor` staying primitive). Rejected for this pass: it changes what
+`backspaceAtCursor` does for existing callers, and there is no caller that wants
+the primitive without the behavior. The raw form stays internal until something
+needs it.
+
+### Line blocks as the first behavior
+
+Line blocks are not a markdown feature. They are a core capability that
+markdown happens to serialize, so the behavior stays in the library and
+`MarkdownExtension` remains a consumer. It moves out of `TextEditorState` and
+into a `LineBlockEditBehavior` in `richstyle`, registered by default, carrying
+the logic currently at `TextEditorState.kt:490-502` and `:530-552` verbatim.
+The semantics documented under "Smart editing" in
+[line-blocks.md](line-blocks.md) do not change.
+
+Moving code that keeps running by default and behaves identically is worth
+stating plainly, because it is fair to ask what was gained:
+
+- `TextEditorState` stops importing `richstyle`. The dependency inverts.
+- Every input path gets the behavior, which fixes the divergence table above.
+- A code-editor host can add auto-indent or bracket-closing without forking.
+- It can be turned off, which today requires editing the library.
+
+## Making every input path agree
+
+With the chain in place, the IME paths route to the semantic functions:
+
+- `imeDeleteSurroundingText(before = 1, after = 0)` with no composing region
+  and no selection is a backspace. Route it to `backspaceAtCursor()`. Every
+  other shape stays a range delete.
+- `imeCommitText("\n", …)` with no composing region is an Enter. Route it to
+  the newline path.
+
+This is the risky part of the whole design and should land last, on its own,
+with tests. `deleteSurroundingText(1, 0)` is not unambiguously a keypress:
+autocorrect and prediction engines use the same call to rewrite what the user
+typed, and treating one of those as a backspace would demote a bullet in the
+middle of a word correction. The guard conditions above (no composing region,
+no selection) exclude the autocorrect case as far as static reading can tell,
+but this needs verification on a device against at least Gboard and one
+third-party keyboard, not just the `androidHostTest` suite.
+
+## Landing order
+
+Each step compiles, passes, and is independently revertible.
+
+1. `EditorCommand` public; `Action` becomes an open class with companion
+   constants. Pure mechanical change, no behavior difference.
+2. `EditorActionRegistry` on `TextEditorState`. Built-in action bodies move out
+   of `TextEditorKeyCommandHandler` into registered specs; the handler resolves
+   through the registry.
+3. `ContextMenuActions` collapses onto the registry. Deletes the duplicated
+   cut/copy/paste bodies.
+4. `EditBehavior` chain; `LineBlockEditBehavior` extracted and registered by
+   default. `TextEditorState` loses its line-block imports.
+5. IME backspace and newline routed through the semantic paths. Tests for each
+   row of the divergence table.
+6. Registration surfaced on `BasicTextEditor` / `TextEditor`, `LocalKeyBindings`
+   made public, docs updated, sample app binds Ctrl+B to bold as the worked
+   example.
+
+## Known limitations and follow-ups
+
+- `Action.Indent` / `Action.Outdent` insert and strip literal spaces against a
+  hard-coded `TAB_SIZE = 4` in `TextEditorKeyCommandHandler`. Once actions are
+  open these become overridable, so a list-aware Tab or a code-editor indent is
+  a host concern rather than a library change. Not addressed here.
+- Behaviors are consulted for newline, backspace and forward delete only.
+  Typed-character interception (auto-pairing quotes and brackets) is the
+  obvious next hook and is deliberately out of scope until something needs it.
+- The registry has no ordering control beyond insertion order. If two behaviors
+  ever contend for the same edit, priority becomes a real design question;
+  until then, first-registered-wins is enough.

--- a/docs/design/editor-actions.md
+++ b/docs/design/editor-actions.md
@@ -269,12 +269,22 @@ no selection) exclude the autocorrect case as far as static reading can tell,
 but this needs verification on a device against at least Gboard and one
 third-party keyboard, not just the `androidHostTest` suite.
 
-As implemented, the guard is written on the computed character range rather
-than the caller's arguments: exactly one character ending at the caret, no
-composing region, no selection. Writing it that way lets
-`deleteSurroundingTextInCodePoints` share it without a one-code-point delete of
-an astral character reaching `backspaceAtCursor`, which deletes a single UTF-16
-char and would split the surrogate pair.
+As implemented, the guard reads intent from the widths the caller asked for, not
+from the range that survives clamping: a request for exactly one character on
+exactly one side, no composing region, no selection. The distinction matters at
+the edges of the document, where a request for several characters shrinks to
+one; reading the survivor would let an autocorrect rewrite at the top of the
+document pass as a backspace.
+
+The code-point variant additionally requires that its request resolved to at
+most one UTF-16 char, so a one-code-point delete of an astral character never
+reaches `backspaceAtCursor`, which deletes a single char and would split the
+surrogate pair.
+
+Both semantic routes also run when clamping leaves an empty range. A backspace
+at the very start of the document removes nothing but can still exit a line
+block, which is what the hardware key does; bailing on the empty range would
+leave the key dead on a soft keyboard for a block on the first line.
 
 ### Device verification still owed
 

--- a/sampleApp/src/commonMain/kotlin/BoldShortcut.kt
+++ b/sampleApp/src/commonMain/kotlin/BoldShortcut.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.texteditor.sample
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.isMetaPressed
@@ -28,22 +29,32 @@ val ToggleBold = EditorCommand.Action("sample.toggleBold", isEdit = true)
  * do not claim is what keeps copy, paste, undo and every motion working.
  */
 @Composable
-fun rememberBoldShortcut(markdown: MarkdownExtension): KeyBindings = remember(markdown) {
-	markdown.editorState.actions.register(
-		EditorActionSpec(ToggleBold) { it.state.toggleBold(markdown) }
-	)
+fun rememberBoldShortcut(markdown: MarkdownExtension): KeyBindings {
+	DisposableEffect(markdown) {
+		val actions = markdown.editorState.actions
+		actions.register(EditorActionSpec(ToggleBold) { it.state.toggleBold(markdown) })
+		// The spec captures this MarkdownExtension, so leaving it registered would
+		// keep a stale closure alive on a state that outlives this screen.
+		onDispose { actions.unregister(ToggleBold) }
+	}
 
-	val platform = platformKeyBindings()
-	// macOS puts shortcuts on Cmd and reserves Ctrl for its Emacs-style bindings,
-	// so which modifier means "shortcut" is the platform's call, not ours.
-	val isMac = platform === MacKeyBindings
-	KeyBindings { event ->
-		val shortcut = if (isMac) event.isMetaPressed else event.isCtrlShortcut
-		if (event.key == Key.B && shortcut) ToggleBold else platform.commandFor(event)
+	return remember {
+		val platform = platformKeyBindings()
+		// macOS puts shortcuts on Cmd and reserves Ctrl for its Emacs-style bindings,
+		// so which modifier means "shortcut" is the platform's call, not ours.
+		val isMac = platform === MacKeyBindings
+		KeyBindings { event ->
+			val shortcut = if (isMac) event.isMetaPressed else event.isCtrlShortcut
+			if (event.key == Key.B && shortcut) ToggleBold else platform.commandFor(event)
+		}
 	}
 }
 
-private fun TextEditorState.toggleBold(markdown: MarkdownExtension) {
+/**
+ * The one bold implementation. The toolbar button calls this too, so the chord
+ * and the button cannot drift apart.
+ */
+fun TextEditorState.toggleBold(markdown: MarkdownExtension) {
 	val bold = markdown.markdownStyles.BOLD
 	val selection = selector.selection
 	if (selection == null) {

--- a/sampleApp/src/commonMain/kotlin/BoldShortcut.kt
+++ b/sampleApp/src/commonMain/kotlin/BoldShortcut.kt
@@ -1,0 +1,56 @@
+package com.darkrockstudios.texteditor.sample
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.key
+import com.darkrockstudios.texteditor.input.EditorActionSpec
+import com.darkrockstudios.texteditor.input.EditorCommand
+import com.darkrockstudios.texteditor.input.KeyBindings
+import com.darkrockstudios.texteditor.input.MacKeyBindings
+import com.darkrockstudios.texteditor.input.isCtrlShortcut
+import com.darkrockstudios.texteditor.input.platformKeyBindings
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.state.getSpanStylesInRange
+
+/**
+ * Bold as an editor action rather than a toolbar-only function, which is what
+ * lets a key chord reach it. Any id works as long as it does not collide with
+ * the `editor.` namespace the built-ins use.
+ */
+val ToggleBold = EditorCommand.Action("sample.toggleBold", isEdit = true)
+
+/**
+ * Registers [ToggleBold] on [markdown]'s state and returns bindings that add
+ * Ctrl+B (Cmd+B on macOS) on top of the platform's own. Delegating the chords we
+ * do not claim is what keeps copy, paste, undo and every motion working.
+ */
+@Composable
+fun rememberBoldShortcut(markdown: MarkdownExtension): KeyBindings = remember(markdown) {
+	markdown.editorState.actions.register(
+		EditorActionSpec(ToggleBold) { it.state.toggleBold(markdown) }
+	)
+
+	val platform = platformKeyBindings()
+	// macOS puts shortcuts on Cmd and reserves Ctrl for its Emacs-style bindings,
+	// so which modifier means "shortcut" is the platform's call, not ours.
+	val isMac = platform === MacKeyBindings
+	KeyBindings { event ->
+		val shortcut = if (isMac) event.isMetaPressed else event.isCtrlShortcut
+		if (event.key == Key.B && shortcut) ToggleBold else platform.commandFor(event)
+	}
+}
+
+private fun TextEditorState.toggleBold(markdown: MarkdownExtension) {
+	val bold = markdown.markdownStyles.BOLD
+	val selection = selector.selection
+	if (selection == null) {
+		cursor.toggleStyle(bold)
+	} else if (getSpanStylesInRange(selection).contains(bold)) {
+		removeStyleSpan(selection, bold)
+	} else {
+		addStyleSpan(selection, bold)
+	}
+}

--- a/sampleApp/src/commonMain/kotlin/TextEditorDemoUi.kt
+++ b/sampleApp/src/commonMain/kotlin/TextEditorDemoUi.kt
@@ -114,6 +114,7 @@ fun TextEditorDemoUi(
 				.padding(8.dp)
 				.fillMaxSize(),
 			style = style,
+			keyBindings = rememberBoldShortcut(markdownExtension),
 			onRichSpanClick = { span, clickType, _ ->
 				when (clickType) {
 					SpanClickType.TAP -> println("Touch tap on span: $span")

--- a/sampleApp/src/commonMain/kotlin/TextEditorToolbarUi.kt
+++ b/sampleApp/src/commonMain/kotlin/TextEditorToolbarUi.kt
@@ -116,9 +116,7 @@ fun TextEditorToolbar(
 			// Formatting Controls Group
 			Row {
 				FormatButton(
-					onClick = {
-						toggleStyle(state, isBoldActive, mardkown.markdownStyles.BOLD)
-					},
+					onClick = { state.toggleBold(mardkown) },
 					icon = Icons.Default.FormatBold,
 					contentDescription = "Bold",
 					isActive = isBoldActive,


### PR DESCRIPTION
Closes #37.

Formatting-specific code lived inside the input paths, and the action vocabulary was a closed `internal` enum. This adds a registry for actions and a chain for edit behaviors, moves the built-ins onto them, and makes the whole thing public so a host can add a shortcut without forking.

The layering fix also closed a real behavioral bug, which was not the original expectation.

## The bug that fell out of it

Line-block smart editing (Enter on an empty bullet exits the list, backspace at the start of an item demotes it) lived in `insertNewlineAtCursor` / `backspaceAtCursor`. Those are not a point every input path shares, so on a soft keyboard whether the user got the behavior depended on which `InputConnection` method their IME happened to call:

| Path | Before | After |
| --- | --- | --- |
| Hardware key | yes | yes |
| `sendKeyEvent(KEYCODE_DEL)` | yes | yes |
| `deleteSurroundingText(1, 0)` | **no** | yes |
| `commitText("\n")` | **no** | yes |
| `performEditorAction` | yes | yes |

Every row is covered by `ImeLineBlockParityTest`, with the hardware-key result as the reference the others are asserted against rather than a separately-written expectation.

## Two mechanisms, deliberately not one

An **action** is invoked by name, so it needs something to invoke it: a chord, a menu item, a toolbar button. A **behavior** intercepts a semantic edit that may have no trigger at all, because an IME commits a newline without ever producing a key event. Collapsing them into one mechanism would mean the IME could never reach it.

- `EditorActionRegistry` on `TextEditorState`, keyed by action id. The 14 built-ins register through the same public `register()` a host calls, so re-registering an id replaces a built-in.
- `EditBehavior` chain consulted by `insertNewlineAtCursor`, `backspaceAtCursor` and `deleteAtCursor`, first claim wins. `LineBlockEditBehavior` is registered by default and removable.

## Adding a shortcut

```kotlin
val ToggleBold = EditorCommand.Action("myapp.toggleBold", isEdit = true)
state.actions.register(EditorActionSpec(ToggleBold) { it.state.toggleBold() })

val bindings = KeyBindings { event ->
    if (event.key == Key.B && event.isCtrlShortcut) ToggleBold
    else platformKeyBindings().commandFor(event)
}

TextEditor(state = state, keyBindings = bindings)
```

`sampleApp/BoldShortcut.kt` is this worked out, including picking the modifier per platform.

## Notable decisions

**Line blocks stayed in core.** They are not a markdown feature, they are a capability markdown happens to serialize, so `LineBlockEditBehavior` lives in `richstyle` and `MarkdownExtension` remains a consumer.

**`isEnabled` is menu metadata, not a dispatch gate.** Key dispatch ignores it on purpose: Ctrl+C with an empty selection has to consume the chord rather than fall through and type a literal `c`.

**An unregistered action does not consume its chord**, so the event falls through to whatever would have handled it. Note this does *not* universally mean "the character gets typed": that holds for unmodified printable keys, but a Ctrl chord does nothing and Tab reaches focus traversal. Documented on `unregister`.

**`isCtrlShortcut` became public**, which was not in the plan. Writing the sample surfaced it: Windows synthesizes AltGr as left-Ctrl + right-Alt, so a host testing `isCtrlPressed` steals the layout chords that type a character (Hungarian AltGr+X is `#`). The library already had the guard and was keeping it `internal`.

**A behavior claim triggers an IME resync.** Once a behavior has answered an edit, the keyboard's assumption about what its own request did is unreliable in a way no diff of the text can express: the edit may have changed only styling, or inserted more than was asked for. On Android that resync is `restartInput`, because `InputMethodManager` drops an `updateSelection` whose indices match its cache — which is exactly this case.

## Review history

Two rounds of high-effort multi-agent review, 20 findings fixed across `4434001` and `edb615b`. The ones worth knowing about:

- The IME backspace guard read intent from the **clamped** range, so a multi-character autocorrect delete near the document start was misread as a keystroke and demoted a block while deleting nothing. Intent now comes from the requested widths.
- The first version of the resync fix was a **no-op** — it defeated only its own dedup, not `InputMethodManager`'s — and was keyed off "document length unchanged", which missed `imePerformNewline` and any behavior inserting a different amount than requested. Both replaced by the claim-triggered `restartInput` above.
- Backspace at the **very start of the document** never reached the semantic path, so a block on line 1 could not be exited from a soft keyboard while the hardware key worked.
- `isEdit` for the read-only gate was forgeable, first via `KeyBindings` and then via the documented "replace a built-in" registry path. It now comes from the built-in constant for built-in ids.
- `ContextMenuActions.perform()` had no read-only gate, so a host menu item could mutate an editor the keyboard refuses to edit. It takes `enabled` now.
- The behavior chain had no reentrancy guard, so a behavior finishing with `insertNewlineAtCursor()` recursed to a `StackOverflowError`. Nested calls now skip the chain, which makes "do X, then the ordinary edit" the natural pattern.

## Testing

1011 desktop + 6 Android host tests, zero failures. `:ComposeTextEditor:check` green on desktop, Android, iOS and wasm; sample app builds.

The signal that matters most is the pre-existing suites passing unchanged while their implementations moved files: 63 line-block tests, and the two `ContextMenuClipboardTest` cases that assert bullets survive a context-menu copy/paste round trip.

### Manual QA

Desktop sample, hardware keyboard: line-block smart editing (block exit, demote, split keeping markers on both halves, undo of a demote), the new Ctrl+B, delegated chords (copy/paste/cut/undo/redo/select-all/Tab indent), context menu, and the read-only `RichTextView` refusing Cut and Paste — all pass.

Not covered by that pass, and **still owed before release**: the Android section. `docs/design/editor-actions.md` has a checklist under "Device verification still owed". The cases most likely to fail are accepting an autocorrect suggestion at the start of a list item, and continuing to type immediately after a demote (the mirror-desync path, whose symptoms appear on the *next* edit rather than the demote itself). If any of them misbehave the fix is to narrow the guard, not widen it: a plain range delete is always correct for the text and only misses the block semantics.

Two pre-existing issues surfaced during QA that are **not** from this branch and are not addressed here: an empty line-block line renders its gutter marker slightly left until a character is typed, and Android pointer handling pops the soft keyboard on pan and treats a mouse click as a long press. Neither touches any file in this diff.

## Commits

Each step compiles, passes and is independently revertible.

| | |
| --- | --- |
| `3416c5c` | `Action` becomes id-keyed |
| `8577313` | design doc |
| `7d49c68` | action registry |
| `efa97ca` | context menu onto the registry, deleting the duplicated cut/copy/paste bodies |
| `63682ae` | `EditBehavior` chain |
| `68bb94d` | IME routing |
| `b5078e9` | public API, sample, docs |
| `4434001` | first review round |
| `edb615b` | second review round |
