### PR TITLE
Don't raise the soft keyboard on a pan or a span-claimed tap

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
@@ -100,6 +100,7 @@ fun BasicTextEditor(
 	CaptureViewForIme(state)
 
 	val focusRequester = remember { FocusRequester() }
+	val spanTapGate = remember { SpanTapGate() }
 	val interactionSource = remember { MutableInteractionSource() }
 	val clipboard = LocalClipboard.current
 	val density = LocalDensity.current
@@ -207,7 +208,7 @@ fun BasicTextEditor(
 				modifier = editorModifier
 					.padding(horizontalPadding)
 					.focusRequester(focusRequester)
-					.requestFocusOnPress(focusRequester)
+					.requestFocusOnPress(focusRequester, spanTapGate)
 					.then(inputModifierElement)
 					.focusable(enabled = true, interactionSource = interactionSource)
 					// Publish text-editing semantics so the node is recognized as an editable
@@ -263,7 +264,7 @@ fun BasicTextEditor(
 							state = state,
 							onSpanClick = onRichSpanClick,
 							onContextMenuRequest = { offset -> effectiveContextMenuState.showMenu(offset) },
-							onRequestFocus = { focusRequester.requestFocus() },
+						spanTapGate = spanTapGate,
 						)
 						// Capture the canvas position so the desktop IME can place the
 						// composition/candidate window relative to the cursor.
@@ -300,23 +301,47 @@ fun BasicTextEditor(
 }
 
 /**
- * Focuses the editor for a press that lands on the container but never reaches the
- * text canvas, such as the empty space below a short document.
+ * Focuses the editor when the user actually points at it.
  *
- * Anything over the text is `textEditorPointerInputHandling`'s to decide, because
- * that is where a gesture is classified as a tap, a pan, a long press or a span
- * click. It consumes the release of every gesture it handles, so a consumed
- * release here means focus has already been settled and must not be second-guessed.
+ * A mouse press is unambiguous, so it focuses immediately. A finger press is not:
+ * it may still turn into a scroll, and on Android focusing raises the soft
+ * keyboard, so focusing on the down event pops the keyboard over the text every
+ * time the user tries to pan. A finger therefore has to lift roughly where it
+ * landed before this counts as a tap, which matches how the editor already
+ * decides caret placement: mouse on press, finger on release.
+ *
+ * A tap a [RichSpan][com.darkrockstudios.texteditor.richstyle.RichSpan] claimed is
+ * skipped as well: the gesture handler reports those through [spanTapGate], and a
+ * keyboard sliding up over the suggestion popup it just opened is the thing to
+ * avoid.
  */
-internal fun Modifier.requestFocusOnPress(focusRequester: FocusRequester) = pointerInput(Unit) {
+internal fun Modifier.requestFocusOnPress(
+	focusRequester: FocusRequester,
+	spanTapGate: SpanTapGate,
+) = pointerInput(Unit) {
+	val touchSlop = viewConfiguration.touchSlop
 	awaitEachGesture {
 		val down = awaitFirstDown(requireUnconsumed = false)
+		spanTapGate.reset()
+
+		// Android reports an external mouse as PointerType.Touch but still fills in
+		// the buttons, so the button state is what actually separates the two.
+		val hasButton = currentEvent.buttons.isPrimaryPressed ||
+				currentEvent.buttons.isSecondaryPressed
+		if (down.type == PointerType.Mouse || hasButton) {
+			focusRequester.requestFocus()
+			return@awaitEachGesture
+		}
 
 		while (true) {
 			val event = awaitPointerEvent()
 			val change = event.changes.firstOrNull { it.id == down.id } ?: return@awaitEachGesture
+			if ((change.position - down.position).getDistance() > touchSlop) {
+				// Panning, not pointing.
+				return@awaitEachGesture
+			}
 			if (!change.pressed) {
-				if (!change.isConsumed) focusRequester.requestFocus()
+				if (!spanTapGate.claimed) focusRequester.requestFocus()
 				return@awaitEachGesture
 			}
 		}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
@@ -24,6 +24,9 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.isSecondaryPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
@@ -295,10 +298,48 @@ fun BasicTextEditor(
 	}
 }
 
+/**
+ * Focuses the editor when the user actually points at it.
+ *
+ * A mouse press is unambiguous, so it focuses immediately. A finger press is not:
+ * it may still turn into a scroll, and on Android focusing raises the soft
+ * keyboard, so focusing on the down event pops the keyboard over the text every
+ * time the user tries to pan. A finger therefore has to lift roughly where it
+ * landed before this counts as a tap, which matches how the editor already
+ * decides caret placement: mouse on press, finger on release.
+ *
+ * A tap a [RichSpan][com.darkrockstudios.texteditor.richstyle.RichSpan] claimed is
+ * skipped as well; `textEditorPointerInputHandling` consumes those, and the
+ * keyboard sliding up over a suggestion popup is the thing to avoid.
+ */
 internal fun Modifier.requestFocusOnPress(focusRequester: FocusRequester) = pointerInput(Unit) {
+	val touchSlop = viewConfiguration.touchSlop
 	awaitEachGesture {
-		awaitFirstDown(requireUnconsumed = false)
-		focusRequester.requestFocus()
+		val down = awaitFirstDown(requireUnconsumed = false)
+
+		// Android reports an external mouse as PointerType.Touch but still fills in
+		// the buttons, so the button state is what actually separates the two.
+		val hasButton = currentEvent.buttons.isPrimaryPressed ||
+				currentEvent.buttons.isSecondaryPressed
+		if (down.type == PointerType.Mouse || hasButton) {
+			focusRequester.requestFocus()
+			return@awaitEachGesture
+		}
+
+		while (true) {
+			val event = awaitPointerEvent()
+			val change = event.changes.firstOrNull { it.id == down.id } ?: return@awaitEachGesture
+			if ((change.position - down.position).getDistance() > touchSlop) {
+				// Panning, not pointing.
+				return@awaitEachGesture
+			}
+			if (!change.pressed) {
+				// A rich span that answered this tap consumes it: opening spell-check
+				// suggestions or following a link is not a request to start typing.
+				if (!change.isConsumed) focusRequester.requestFocus()
+				return@awaitEachGesture
+			}
+		}
 	}
 }
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
@@ -79,7 +79,7 @@ private const val CURSOR_BLINK_SPEED_MS = 500L
  * @param contextMenuState Drives context-menu visibility; pass your own to add
  *   custom items (e.g. spell-check suggestions), or leave `null` for the default.
  * @param onRichSpanClick Invoked when a rich span is tapped or right-clicked;
- *   return `true` to consume the event.
+ *   see [RichSpanClickListener] for what the return value does (and does not do).
  * @param decorateLine Optional per-line decorator drawn behind each line, keyed by
  *   line index — useful for gutters, current-line highlights, or diff markers.
  */
@@ -100,7 +100,6 @@ fun BasicTextEditor(
 	CaptureViewForIme(state)
 
 	val focusRequester = remember { FocusRequester() }
-	val spanTapGate = remember { SpanTapGate() }
 	val interactionSource = remember { MutableInteractionSource() }
 	val clipboard = LocalClipboard.current
 	val density = LocalDensity.current
@@ -208,7 +207,7 @@ fun BasicTextEditor(
 				modifier = editorModifier
 					.padding(horizontalPadding)
 					.focusRequester(focusRequester)
-					.requestFocusOnPress(focusRequester, spanTapGate)
+					.requestFocusOnPress(focusRequester) { effectiveContextMenuState.isVisible }
 					.then(inputModifierElement)
 					.focusable(enabled = true, interactionSource = interactionSource)
 					// Publish text-editing semantics so the node is recognized as an editable
@@ -264,7 +263,6 @@ fun BasicTextEditor(
 							state = state,
 							onSpanClick = onRichSpanClick,
 							onContextMenuRequest = { offset -> effectiveContextMenuState.showMenu(offset) },
-						spanTapGate = spanTapGate,
 						)
 						// Capture the canvas position so the desktop IME can place the
 						// composition/candidate window relative to the cursor.
@@ -310,19 +308,19 @@ fun BasicTextEditor(
  * landed before this counts as a tap, which matches how the editor already
  * decides caret placement: mouse on press, finger on release.
  *
- * A tap a [RichSpan][com.darkrockstudios.texteditor.richstyle.RichSpan] claimed is
- * skipped as well: the gesture handler reports those through [spanTapGate], and a
- * keyboard sliding up over the suggestion popup it just opened is the thing to
- * avoid.
+ * A tap that opened a popup is skipped as well, reported by [popupIsShowing]. The
+ * thing to avoid is a keyboard sliding up over the spell-check suggestions or the
+ * context menu that same tap just opened. Note this asks what the tap *did*, not
+ * whether a listener said it handled the click: a host is free to answer a rich
+ * span click and still want the editor focused, and most do.
  */
 internal fun Modifier.requestFocusOnPress(
 	focusRequester: FocusRequester,
-	spanTapGate: SpanTapGate,
+	popupIsShowing: () -> Boolean,
 ) = pointerInput(Unit) {
 	val touchSlop = viewConfiguration.touchSlop
 	awaitEachGesture {
 		val down = awaitFirstDown(requireUnconsumed = false)
-		spanTapGate.reset()
 
 		// Android reports an external mouse as PointerType.Touch but still fills in
 		// the buttons, so the button state is what actually separates the two.
@@ -341,7 +339,10 @@ internal fun Modifier.requestFocusOnPress(
 				return@awaitEachGesture
 			}
 			if (!change.pressed) {
-				if (!spanTapGate.claimed) focusRequester.requestFocus()
+				// Safe to read synchronously: the Main pass dispatches child-first, so
+				// the Canvas gesture handler has already run this tap's dispatch (which
+				// opens any menu) before this container-level handler sees the release.
+				if (!popupIsShowing()) focusRequester.requestFocus()
 				return@awaitEachGesture
 			}
 		}
@@ -351,6 +352,12 @@ internal fun Modifier.requestFocusOnPress(
 /**
  * Handles clicks on a [RichSpan]. Receives the clicked span, the [SpanClickType]
  * that distinguishes a tap from a left- or right-click, and the click [Offset] in
- * editor coordinates. Return `true` to consume the event and stop further handling.
+ * editor coordinates.
+ *
+ * The return value is a chaining protocol between listeners: `true` means "this
+ * click was answered here", which lets a wrapping listener (e.g. the spell-check
+ * editor's) decide whether to delegate a click onward to the host's listener.
+ * It does not affect the editor itself: caret placement, selection, scrolling,
+ * focus, and the soft keyboard all behave the same whatever is returned.
  */
 typealias RichSpanClickListener = ((RichSpan, SpanClickType, Offset) -> Boolean)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/BasicTextEditor.kt
@@ -262,7 +262,8 @@ fun BasicTextEditor(
 						.textEditorPointerInputHandling(
 							state = state,
 							onSpanClick = onRichSpanClick,
-							onContextMenuRequest = { offset -> effectiveContextMenuState.showMenu(offset) }
+							onContextMenuRequest = { offset -> effectiveContextMenuState.showMenu(offset) },
+							onRequestFocus = { focusRequester.requestFocus() },
 						)
 						// Capture the canvas position so the desktop IME can place the
 						// composition/candidate window relative to the cursor.
@@ -299,43 +300,22 @@ fun BasicTextEditor(
 }
 
 /**
- * Focuses the editor when the user actually points at it.
+ * Focuses the editor for a press that lands on the container but never reaches the
+ * text canvas, such as the empty space below a short document.
  *
- * A mouse press is unambiguous, so it focuses immediately. A finger press is not:
- * it may still turn into a scroll, and on Android focusing raises the soft
- * keyboard, so focusing on the down event pops the keyboard over the text every
- * time the user tries to pan. A finger therefore has to lift roughly where it
- * landed before this counts as a tap, which matches how the editor already
- * decides caret placement: mouse on press, finger on release.
- *
- * A tap a [RichSpan][com.darkrockstudios.texteditor.richstyle.RichSpan] claimed is
- * skipped as well; `textEditorPointerInputHandling` consumes those, and the
- * keyboard sliding up over a suggestion popup is the thing to avoid.
+ * Anything over the text is `textEditorPointerInputHandling`'s to decide, because
+ * that is where a gesture is classified as a tap, a pan, a long press or a span
+ * click. It consumes the release of every gesture it handles, so a consumed
+ * release here means focus has already been settled and must not be second-guessed.
  */
 internal fun Modifier.requestFocusOnPress(focusRequester: FocusRequester) = pointerInput(Unit) {
-	val touchSlop = viewConfiguration.touchSlop
 	awaitEachGesture {
 		val down = awaitFirstDown(requireUnconsumed = false)
-
-		// Android reports an external mouse as PointerType.Touch but still fills in
-		// the buttons, so the button state is what actually separates the two.
-		val hasButton = currentEvent.buttons.isPrimaryPressed ||
-				currentEvent.buttons.isSecondaryPressed
-		if (down.type == PointerType.Mouse || hasButton) {
-			focusRequester.requestFocus()
-			return@awaitEachGesture
-		}
 
 		while (true) {
 			val event = awaitPointerEvent()
 			val change = event.changes.firstOrNull { it.id == down.id } ?: return@awaitEachGesture
-			if ((change.position - down.position).getDistance() > touchSlop) {
-				// Panning, not pointing.
-				return@awaitEachGesture
-			}
 			if (!change.pressed) {
-				// A rich span that answered this tap consumes it: opening spell-check
-				// suggestions or following a link is not a request to start typing.
 				if (!change.isConsumed) focusRequester.requestFocus()
 				return@awaitEachGesture
 			}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
@@ -60,6 +60,8 @@ fun RichTextView(
 		state.density = density
 	}
 
+	val spanTapGate = remember { SpanTapGate() }
+
 	if (isSelectable) {
 		val clipboard = LocalClipboard.current
 		val focusRequester = remember { FocusRequester() }
@@ -83,13 +85,14 @@ fun RichTextView(
 				state = state,
 				modifier = modifier
 					.focusRequester(focusRequester)
-					.requestFocusOnPress(focusRequester)
+					.requestFocusOnPress(focusRequester, spanTapGate)
 					.then(inputModifierElement)
 					.focusable(enabled = true, interactionSource = interactionSource),
 				contentPadding = contentPadding,
 				style = style,
 				isSelectable = true,
 				onContextMenuRequest = { offset -> contextMenuState.showMenu(offset) },
+				spanTapGate = spanTapGate,
 			)
 		}
 	} else {
@@ -100,6 +103,7 @@ fun RichTextView(
 			style = style,
 			isSelectable = false,
 			onContextMenuRequest = null,
+			spanTapGate = spanTapGate,
 		)
 	}
 }
@@ -112,6 +116,7 @@ private fun RichTextViewBody(
 	style: TextEditorStyle,
 	isSelectable: Boolean,
 	onContextMenuRequest: ((Offset) -> Unit)?,
+	spanTapGate: SpanTapGate,
 ) {
 	val density = LocalDensity.current
 	val layoutDirection = LocalLayoutDirection.current
@@ -143,6 +148,7 @@ private fun RichTextViewBody(
 						state = state,
 						onContextMenuRequest = onContextMenuRequest,
 						readOnly = true,
+						spanTapGate = spanTapGate,
 					)
 			} else {
 				Modifier

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/RichTextView.kt
@@ -60,8 +60,6 @@ fun RichTextView(
 		state.density = density
 	}
 
-	val spanTapGate = remember { SpanTapGate() }
-
 	if (isSelectable) {
 		val clipboard = LocalClipboard.current
 		val focusRequester = remember { FocusRequester() }
@@ -85,14 +83,15 @@ fun RichTextView(
 				state = state,
 				modifier = modifier
 					.focusRequester(focusRequester)
-					.requestFocusOnPress(focusRequester, spanTapGate)
+					// A read-only view never raises a soft keyboard, and its focus exists
+					// only to route copy/select-all shortcuts, so no tap ever suppresses it.
+					.requestFocusOnPress(focusRequester, popupIsShowing = { false })
 					.then(inputModifierElement)
 					.focusable(enabled = true, interactionSource = interactionSource),
 				contentPadding = contentPadding,
 				style = style,
 				isSelectable = true,
 				onContextMenuRequest = { offset -> contextMenuState.showMenu(offset) },
-				spanTapGate = spanTapGate,
 			)
 		}
 	} else {
@@ -103,7 +102,6 @@ fun RichTextView(
 			style = style,
 			isSelectable = false,
 			onContextMenuRequest = null,
-			spanTapGate = spanTapGate,
 		)
 	}
 }
@@ -116,7 +114,6 @@ private fun RichTextViewBody(
 	style: TextEditorStyle,
 	isSelectable: Boolean,
 	onContextMenuRequest: ((Offset) -> Unit)?,
-	spanTapGate: SpanTapGate,
 ) {
 	val density = LocalDensity.current
 	val layoutDirection = LocalLayoutDirection.current
@@ -148,7 +145,6 @@ private fun RichTextViewBody(
 						state = state,
 						onContextMenuRequest = onContextMenuRequest,
 						readOnly = true,
-						spanTapGate = spanTapGate,
 					)
 			} else {
 				Modifier

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/TextEditor.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/TextEditor.kt
@@ -26,7 +26,8 @@ private val DefaultContentPadding = PaddingValues(16.dp)
  * @param autoFocus Requests focus once when first composed.
  * @param style Colors and text style for the editor and its gutter markers.
  * @param onRichSpanClick Invoked when a rich span (link, list, blockquote, code
- *   block, …) is tapped or right-clicked; return `true` to consume the event.
+ *   block, …) is tapped or right-clicked; see [RichSpanClickListener] for what
+ *   the return value does (and does not do).
  */
 @Composable
 fun TextEditor(

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
@@ -18,38 +18,15 @@ data class SelectionHandle(
 	val bounds: Offset
 )
 
-/**
- * Whether the tap in flight was answered by a [RichSpan], passed from the gesture
- * handler on the text canvas to the focus handler on the enclosing container.
- *
- * Deliberately a private object rather than pointer consumption. Consumption is
- * broadcast: it changes what every other handler in the tree sees, so using it to
- * carry this one bit also tells the ancestor scroll container its drag was taken,
- * which cancels flings and aborts scrolls.
- */
-internal class SpanTapGate {
-	var claimed: Boolean = false
-		private set
-
-	fun claim() {
-		claimed = true
-	}
-
-	fun reset() {
-		claimed = false
-	}
-}
-
 internal fun Modifier.textEditorPointerInputHandling(
 	state: TextEditorState,
 	onSpanClick: RichSpanClickListener? = null,
 	onContextMenuRequest: ((Offset) -> Unit)? = null,
 	readOnly: Boolean = false,
-	spanTapGate: SpanTapGate? = null,
 ): Modifier {
 	return this
 		.handleDragInput(state, readOnly)
-		.handleTextInteractions(state, onSpanClick, onContextMenuRequest, readOnly, spanTapGate)
+		.handleTextInteractions(state, onSpanClick, onContextMenuRequest, readOnly)
 		.detectMouseClicksImperatively(
 			onClick = { offset: Offset, isShiftPressed: Boolean ->
 				// On shift+click handleDragInput extends the selection; clearing it here
@@ -226,7 +203,6 @@ private fun Modifier.handleTextInteractions(
 	onSpanClick: RichSpanClickListener?,
 	onContextMenuRequest: ((Offset) -> Unit)?,
 	readOnly: Boolean,
-	spanTapGate: SpanTapGate?,
 ): Modifier {
 	return pointerInput(Unit) {
 		val touchSlop = viewConfiguration.touchSlop
@@ -318,18 +294,13 @@ private fun Modifier.handleTextInteractions(
 						// selection a parallel double-click handler just set.
 						if (isFingerTouchGesture && !didLongPress && !wasDrag) {
 							val position = eventChange.position
-							val claimedBySpan = handleSpanInteraction(
+							handleSpanInteraction(
 								state,
 								position,
 								SpanClickType.TAP,
 								onSpanClick,
 								readOnly,
 							)
-							// A tap a span answered opened something — spell-check suggestions,
-							// a followed link — that the keyboard would cover, so tell the focus
-							// handler on the enclosing container not to treat it as a request
-							// to start typing.
-							if (claimedBySpan) spanTapGate?.claim()
 						}
 
 						longPressJob?.cancel()

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
@@ -23,10 +23,11 @@ internal fun Modifier.textEditorPointerInputHandling(
 	onSpanClick: RichSpanClickListener? = null,
 	onContextMenuRequest: ((Offset) -> Unit)? = null,
 	readOnly: Boolean = false,
+	onRequestFocus: (() -> Unit)? = null,
 ): Modifier {
 	return this
 		.handleDragInput(state, readOnly)
-		.handleTextInteractions(state, onSpanClick, onContextMenuRequest, readOnly)
+		.handleTextInteractions(state, onSpanClick, onContextMenuRequest, readOnly, onRequestFocus)
 		.detectMouseClicksImperatively(
 			onClick = { offset: Offset, isShiftPressed: Boolean ->
 				// On shift+click handleDragInput extends the selection; clearing it here
@@ -198,11 +199,26 @@ private fun handleSpanInteraction(
 			onSpanClick.invoke(clickedSpan, clickType, offset)
 }
 
+/**
+ * Owns caret placement, span clicks, long-press selection, and the focus decision
+ * that goes with them.
+ *
+ * Focus lives here because this is where the gesture is classified. Focus is what
+ * raises the soft keyboard on Android, so it must follow what the gesture turned
+ * out to mean rather than the fact that a finger touched the screen: a pan scrolls,
+ * a long press selects, and a tap a span answered opened something the keyboard
+ * would cover. Only a plain tap, or any mouse press, is a request to start typing.
+ *
+ * [onRequestFocus] is invoked for those, and the release is consumed for every
+ * gesture this handler classified, which tells the fallback handler on the
+ * enclosing container that focus has already been decided here.
+ */
 private fun Modifier.handleTextInteractions(
 	state: TextEditorState,
 	onSpanClick: RichSpanClickListener?,
 	onContextMenuRequest: ((Offset) -> Unit)?,
 	readOnly: Boolean,
+	onRequestFocus: (() -> Unit)?,
 ): Modifier {
 	return pointerInput(Unit) {
 		val touchSlop = viewConfiguration.touchSlop
@@ -215,10 +231,17 @@ private fun Modifier.handleTextInteractions(
 			// Whether this gesture is a real finger touch (vs mouse / mouse-as-touch on Android).
 			// Set on Press; controls whether Release fires a TAP. See android_mouse_pointer_type memo.
 			var isFingerTouchGesture = false
+			// The pointer this gesture started with. A second finger or a resting palm
+			// adds changes to the same event, and acting on whichever happens to be
+			// first would place the caret at the wrong pointer and decide focus from it.
+			var gesturePointer: PointerId? = null
 
 			while (true) {
 				val event = awaitPointerEvent()
-				val eventChange = event.changes.first()
+				val eventChange = gesturePointer
+					?.let { id -> event.changes.firstOrNull { it.id == id } }
+					?: event.changes.first()
+				if (gesturePointer == null) gesturePointer = eventChange.id
 
 				when (event.type) {
 					PointerEventType.Press -> {
@@ -241,7 +264,7 @@ private fun Modifier.handleTextInteractions(
 
 						if (isMouseLike) {
 							if (hasPrimaryButton) {
-								handleSpanInteraction(
+								val claimedBySpan = handleSpanInteraction(
 									state,
 									position,
 									SpanClickType.PRIMARY_CLICK,
@@ -249,6 +272,7 @@ private fun Modifier.handleTextInteractions(
 									readOnly,
 									isShiftPressed = event.keyboardModifiers.isShiftPressed,
 								)
+								if (!claimedBySpan) onRequestFocus?.invoke()
 								didHandlePress = true
 							} else if (hasSecondaryButton) {
 								handleSpanInteraction(
@@ -301,12 +325,16 @@ private fun Modifier.handleTextInteractions(
 								onSpanClick,
 								readOnly,
 							)
-							// Consumption is how the focus handler on the enclosing Box hears
-							// that a span answered this tap. A tap that opened spell-check
-							// suggestions or followed a link is not a request to start typing,
-							// so it must not raise the soft keyboard over what it just opened.
-							if (claimedBySpan) eventChange.consume()
+							// A tap a span answered opened something — spell-check suggestions,
+							// a followed link — that the keyboard would cover.
+							if (!claimedBySpan) onRequestFocus?.invoke()
 						}
+
+						// Every gesture reaching here has been classified, and focus decided
+						// with it. Consuming the release says so, which is what stops the
+						// fallback handler on the enclosing container from focusing a long
+						// press or a pan behind this handler's back.
+						eventChange.consume()
 
 						longPressJob?.cancel()
 						longPressJob = null
@@ -317,7 +345,17 @@ private fun Modifier.handleTextInteractions(
 					}
 
 					PointerEventType.Move -> {
-						val movement = event.changes.first()
+						val movement = eventChange
+						// A scroll container taking this gesture marks the change consumed.
+						// That is the only way to notice a pan that scrolls an ancestor,
+						// which drags the editor along with the finger and so produces no
+						// local movement to measure.
+						if (movement.isConsumed) {
+							wasDrag = true
+							longPressJob?.cancel()
+							longPressJob = null
+						}
+
 						// Only consider it a drag if movement exceeds touch slop threshold
 						// This prevents high-precision touch screens from treating micro-movements as drags
 						initialPressPosition?.let { pressPosition ->

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
@@ -165,6 +165,11 @@ private fun findHandleAtPosition(
 	}
 }
 
+/**
+ * Places the caret for a click or tap and offers the event to any [RichSpan] under
+ * it. Returns true when a span (or a selection handle) claimed the event, meaning
+ * the click was answered by something other than plain caret placement.
+ */
 private fun handleSpanInteraction(
 	state: TextEditorState,
 	offset: Offset,
@@ -189,11 +194,8 @@ private fun handleSpanInteraction(
 		state.selector.clearSelection()
 	}
 
-	return if (!isShiftPressed && clickedSpan != null && onSpanClick != null) {
-		onSpanClick.invoke(clickedSpan, clickType, offset)
-	} else {
-		true
-	}
+	return !isShiftPressed && clickedSpan != null && onSpanClick != null &&
+			onSpanClick.invoke(clickedSpan, clickType, offset)
 }
 
 private fun Modifier.handleTextInteractions(
@@ -292,13 +294,18 @@ private fun Modifier.handleTextInteractions(
 						// selection a parallel double-click handler just set.
 						if (isFingerTouchGesture && !didLongPress && !wasDrag) {
 							val position = eventChange.position
-							handleSpanInteraction(
+							val claimedBySpan = handleSpanInteraction(
 								state,
 								position,
 								SpanClickType.TAP,
 								onSpanClick,
 								readOnly,
 							)
+							// Consumption is how the focus handler on the enclosing Box hears
+							// that a span answered this tap. A tap that opened spell-check
+							// suggestions or followed a link is not a request to start typing,
+							// so it must not raise the soft keyboard over what it just opened.
+							if (claimedBySpan) eventChange.consume()
 						}
 
 						longPressJob?.cancel()

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/textEditorPointerInputHandling.kt
@@ -18,16 +18,38 @@ data class SelectionHandle(
 	val bounds: Offset
 )
 
+/**
+ * Whether the tap in flight was answered by a [RichSpan], passed from the gesture
+ * handler on the text canvas to the focus handler on the enclosing container.
+ *
+ * Deliberately a private object rather than pointer consumption. Consumption is
+ * broadcast: it changes what every other handler in the tree sees, so using it to
+ * carry this one bit also tells the ancestor scroll container its drag was taken,
+ * which cancels flings and aborts scrolls.
+ */
+internal class SpanTapGate {
+	var claimed: Boolean = false
+		private set
+
+	fun claim() {
+		claimed = true
+	}
+
+	fun reset() {
+		claimed = false
+	}
+}
+
 internal fun Modifier.textEditorPointerInputHandling(
 	state: TextEditorState,
 	onSpanClick: RichSpanClickListener? = null,
 	onContextMenuRequest: ((Offset) -> Unit)? = null,
 	readOnly: Boolean = false,
-	onRequestFocus: (() -> Unit)? = null,
+	spanTapGate: SpanTapGate? = null,
 ): Modifier {
 	return this
 		.handleDragInput(state, readOnly)
-		.handleTextInteractions(state, onSpanClick, onContextMenuRequest, readOnly, onRequestFocus)
+		.handleTextInteractions(state, onSpanClick, onContextMenuRequest, readOnly, spanTapGate)
 		.detectMouseClicksImperatively(
 			onClick = { offset: Offset, isShiftPressed: Boolean ->
 				// On shift+click handleDragInput extends the selection; clearing it here
@@ -199,26 +221,12 @@ private fun handleSpanInteraction(
 			onSpanClick.invoke(clickedSpan, clickType, offset)
 }
 
-/**
- * Owns caret placement, span clicks, long-press selection, and the focus decision
- * that goes with them.
- *
- * Focus lives here because this is where the gesture is classified. Focus is what
- * raises the soft keyboard on Android, so it must follow what the gesture turned
- * out to mean rather than the fact that a finger touched the screen: a pan scrolls,
- * a long press selects, and a tap a span answered opened something the keyboard
- * would cover. Only a plain tap, or any mouse press, is a request to start typing.
- *
- * [onRequestFocus] is invoked for those, and the release is consumed for every
- * gesture this handler classified, which tells the fallback handler on the
- * enclosing container that focus has already been decided here.
- */
 private fun Modifier.handleTextInteractions(
 	state: TextEditorState,
 	onSpanClick: RichSpanClickListener?,
 	onContextMenuRequest: ((Offset) -> Unit)?,
 	readOnly: Boolean,
-	onRequestFocus: (() -> Unit)?,
+	spanTapGate: SpanTapGate?,
 ): Modifier {
 	return pointerInput(Unit) {
 		val touchSlop = viewConfiguration.touchSlop
@@ -231,17 +239,10 @@ private fun Modifier.handleTextInteractions(
 			// Whether this gesture is a real finger touch (vs mouse / mouse-as-touch on Android).
 			// Set on Press; controls whether Release fires a TAP. See android_mouse_pointer_type memo.
 			var isFingerTouchGesture = false
-			// The pointer this gesture started with. A second finger or a resting palm
-			// adds changes to the same event, and acting on whichever happens to be
-			// first would place the caret at the wrong pointer and decide focus from it.
-			var gesturePointer: PointerId? = null
 
 			while (true) {
 				val event = awaitPointerEvent()
-				val eventChange = gesturePointer
-					?.let { id -> event.changes.firstOrNull { it.id == id } }
-					?: event.changes.first()
-				if (gesturePointer == null) gesturePointer = eventChange.id
+				val eventChange = event.changes.first()
 
 				when (event.type) {
 					PointerEventType.Press -> {
@@ -264,7 +265,7 @@ private fun Modifier.handleTextInteractions(
 
 						if (isMouseLike) {
 							if (hasPrimaryButton) {
-								val claimedBySpan = handleSpanInteraction(
+								handleSpanInteraction(
 									state,
 									position,
 									SpanClickType.PRIMARY_CLICK,
@@ -272,7 +273,6 @@ private fun Modifier.handleTextInteractions(
 									readOnly,
 									isShiftPressed = event.keyboardModifiers.isShiftPressed,
 								)
-								if (!claimedBySpan) onRequestFocus?.invoke()
 								didHandlePress = true
 							} else if (hasSecondaryButton) {
 								handleSpanInteraction(
@@ -326,15 +326,11 @@ private fun Modifier.handleTextInteractions(
 								readOnly,
 							)
 							// A tap a span answered opened something — spell-check suggestions,
-							// a followed link — that the keyboard would cover.
-							if (!claimedBySpan) onRequestFocus?.invoke()
+							// a followed link — that the keyboard would cover, so tell the focus
+							// handler on the enclosing container not to treat it as a request
+							// to start typing.
+							if (claimedBySpan) spanTapGate?.claim()
 						}
-
-						// Every gesture reaching here has been classified, and focus decided
-						// with it. Consuming the release says so, which is what stops the
-						// fallback handler on the enclosing container from focusing a long
-						// press or a pan behind this handler's back.
-						eventChange.consume()
 
 						longPressJob?.cancel()
 						longPressJob = null
@@ -345,17 +341,7 @@ private fun Modifier.handleTextInteractions(
 					}
 
 					PointerEventType.Move -> {
-						val movement = eventChange
-						// A scroll container taking this gesture marks the change consumed.
-						// That is the only way to notice a pan that scrolls an ancestor,
-						// which drags the editor along with the finger and so produces no
-						// local movement to measure.
-						if (movement.isConsumed) {
-							wasDrag = true
-							longPressJob?.cancel()
-							longPressJob = null
-						}
-
+						val movement = event.changes.first()
 						// Only consider it a drag if movement exceeds touch slop threshold
 						// This prevents high-precision touch screens from treating micro-movements as drags
 						initialPressPosition?.let { pressPosition ->

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/TouchFocusE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/TouchFocusE2eTest.kt
@@ -10,10 +10,10 @@ import kotlin.test.assertTrue
 /**
  * When the editor takes focus, and when it deliberately does not.
  *
- * Focus is what raises the soft keyboard on Android, so every case here is really
- * about whether a keyboard slides up over the content. Taking focus on the down
- * event meant panning the document popped the keyboard on every scroll, and a tap
- * answered by a rich span popped it over the popup that tap had just opened.
+ * Focus is what raises the soft keyboard on Android, so every case here is about
+ * whether a keyboard slides up over the content. Only a plain tap, or a mouse
+ * press, asks to start typing; a pan scrolls, a long press selects, and a tap a
+ * rich span answered opened something the keyboard would cover.
  */
 class TouchFocusE2eTest {
 
@@ -94,6 +94,38 @@ class TouchFocusE2eTest {
 		tapAtCharacter(20)
 
 		assertTrue(state.isFocused)
+	}
+
+	/**
+	 * A long press selects a word and can open the context menu. Focusing on lift
+	 * would raise the keyboard over both.
+	 */
+	@Test
+	fun `a long press does not focus the editor`() = editorUiTest(
+		initialText = document,
+		autoFocus = false,
+	) {
+		longPressAtCharacter(4)
+
+		assertFalse(state.isFocused)
+		assertTrue(selectedText.isNotEmpty(), "expected the long press to select a word")
+	}
+
+	/**
+	 * An external mouse on Android reports as touch with buttons set, and there is a
+	 * real keyboard to raise there, so the span check has to apply to mouse too.
+	 */
+	@Test
+	fun `a mouse click claimed by a rich span does not focus the editor`() = editorUiTest(
+		initialText = document,
+		autoFocus = false,
+		onRichSpanClick = { _, _, _ -> true },
+	) {
+		state.addRichSpan(0, 5, SpellCheckStyle)
+
+		clickAtCharacter(2)
+
+		assertFalse(state.isFocused)
 	}
 
 	/** Focus survives the gesture that placed it, so typing right after a tap works. */

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/TouchFocusE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/TouchFocusE2eTest.kt
@@ -11,9 +11,9 @@ import kotlin.test.assertTrue
  * When the editor takes focus, and when it deliberately does not.
  *
  * Focus is what raises the soft keyboard on Android, so every case here is about
- * whether a keyboard slides up over the content. Only a plain tap, or a mouse
- * press, asks to start typing; a pan scrolls, a long press selects, and a tap a
- * rich span answered opened something the keyboard would cover.
+ * whether a keyboard slides up over the content. A finger has to lift near where
+ * it landed for the gesture to count as a tap, and a tap a rich span answered
+ * opened something the keyboard would cover.
  */
 class TouchFocusE2eTest {
 
@@ -97,35 +97,18 @@ class TouchFocusE2eTest {
 	}
 
 	/**
-	 * A long press selects a word and can open the context menu. Focusing on lift
-	 * would raise the keyboard over both.
+	 * Long-press-to-select must focus, or the selection cannot be typed over: the
+	 * keyboard never arrives and tapping to summon it clears the selection first.
 	 */
 	@Test
-	fun `a long press does not focus the editor`() = editorUiTest(
+	fun `a long press selects and focuses the editor`() = editorUiTest(
 		initialText = document,
 		autoFocus = false,
 	) {
 		longPressAtCharacter(4)
 
-		assertFalse(state.isFocused)
 		assertTrue(selectedText.isNotEmpty(), "expected the long press to select a word")
-	}
-
-	/**
-	 * An external mouse on Android reports as touch with buttons set, and there is a
-	 * real keyboard to raise there, so the span check has to apply to mouse too.
-	 */
-	@Test
-	fun `a mouse click claimed by a rich span does not focus the editor`() = editorUiTest(
-		initialText = document,
-		autoFocus = false,
-		onRichSpanClick = { _, _, _ -> true },
-	) {
-		state.addRichSpan(0, 5, SpellCheckStyle)
-
-		clickAtCharacter(2)
-
-		assertFalse(state.isFocused)
+		assertTrue(state.isFocused)
 	}
 
 	/** Focus survives the gesture that placed it, so typing right after a tap works. */

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/TouchFocusE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/TouchFocusE2eTest.kt
@@ -1,0 +1,111 @@
+package e2e
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.richstyle.SpellCheckStyle
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * When the editor takes focus, and when it deliberately does not.
+ *
+ * Focus is what raises the soft keyboard on Android, so every case here is really
+ * about whether a keyboard slides up over the content. Taking focus on the down
+ * event meant panning the document popped the keyboard on every scroll, and a tap
+ * answered by a rich span popped it over the popup that tap had just opened.
+ */
+class TouchFocusE2eTest {
+
+	private val document = AnnotatedString("hello world, this is the document text")
+
+	@Test
+	fun `a finger tap focuses the editor`() = editorUiTest(
+		initialText = document,
+		autoFocus = false,
+	) {
+		assertFalse(state.isFocused, "precondition: not focused before the tap")
+
+		tapAtCharacter(4)
+
+		assertTrue(state.isFocused)
+	}
+
+	/** The scroll case: a finger down that travels is a pan, not a request to type. */
+	@Test
+	fun `a finger pan does not focus the editor`() = editorUiTest(
+		initialText = document,
+		autoFocus = false,
+	) {
+		panFrom(positionOfCharacter(4))
+
+		assertFalse(state.isFocused)
+	}
+
+	/** A mouse press is unambiguous and has no keyboard to raise, so it focuses at once. */
+	@Test
+	fun `a mouse click focuses the editor`() = editorUiTest(
+		initialText = document,
+		autoFocus = false,
+	) {
+		clickAtCharacter(4)
+
+		assertTrue(state.isFocused)
+	}
+
+	@Test
+	fun `a tap claimed by a rich span does not focus the editor`() = editorUiTest(
+		initialText = document,
+		autoFocus = false,
+		onRichSpanClick = { _, _, _ -> true },
+	) {
+		state.addRichSpan(0, 5, SpellCheckStyle)
+
+		tapAtCharacter(2)
+
+		assertFalse(state.isFocused, "a span answered the tap, so it must not also raise the keyboard")
+	}
+
+	/**
+	 * The counterpart, and the case that breaks if consumption is drawn too wide:
+	 * a span that declines leaves an ordinary tap, which must still focus.
+	 */
+	@Test
+	fun `a tap a rich span declines still focuses the editor`() = editorUiTest(
+		initialText = document,
+		autoFocus = false,
+		onRichSpanClick = { _, _, _ -> false },
+	) {
+		state.addRichSpan(0, 5, SpellCheckStyle)
+
+		tapAtCharacter(2)
+
+		assertTrue(state.isFocused)
+	}
+
+	@Test
+	fun `a tap outside any span focuses even when a span exists elsewhere`() = editorUiTest(
+		initialText = document,
+		autoFocus = false,
+		onRichSpanClick = { _, _, _ -> true },
+	) {
+		state.addRichSpan(0, 5, SpellCheckStyle)
+
+		tapAtCharacter(20)
+
+		assertTrue(state.isFocused)
+	}
+
+	/** Focus survives the gesture that placed it, so typing right after a tap works. */
+	@Test
+	fun `a tap leaves the editor focused and editable`() = editorUiTest(
+		initialText = document,
+		autoFocus = false,
+	) {
+		tapAtCharacter(5)
+		typeText("X")
+
+		assertTrue(state.isFocused)
+		assertTrue(text.contains("X"), "expected the typed character to land: $text")
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/TouchFocusE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/TouchFocusE2eTest.kt
@@ -1,6 +1,8 @@
 package e2e
 
 import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.contextmenu.TextEditorContextMenuState
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
 import com.darkrockstudios.texteditor.richstyle.SpellCheckStyle
 import utils.editorUiTest
 import kotlin.test.Test
@@ -12,8 +14,10 @@ import kotlin.test.assertTrue
  *
  * Focus is what raises the soft keyboard on Android, so every case here is about
  * whether a keyboard slides up over the content. A finger has to lift near where
- * it landed for the gesture to count as a tap, and a tap a rich span answered
- * opened something the keyboard would cover.
+ * it landed for the gesture to count as a tap, and a tap focuses unless it left a
+ * popup showing that the keyboard would cover. What any span click listener
+ * returned never enters into it: hosts return `true` liberally just to observe
+ * clicks, so the listener's answer cannot mean "do not focus".
  */
 class TouchFocusE2eTest {
 
@@ -53,17 +57,49 @@ class TouchFocusE2eTest {
 		assertTrue(state.isFocused)
 	}
 
+	/**
+	 * The spell-check shape: the tap opened a suggestions popup, and a keyboard
+	 * must not slide up over it. The listener opens the menu through the editor's
+	 * own context menu state, exactly as SpellCheckingTextEditor does.
+	 */
 	@Test
-	fun `a tap claimed by a rich span does not focus the editor`() = editorUiTest(
+	fun `a tap that opens a popup does not focus the editor`() {
+		val menuState = TextEditorContextMenuState()
+		editorUiTest(
+			initialText = document,
+			autoFocus = false,
+			contextMenuState = menuState,
+			onRichSpanClick = { _, _, offset ->
+				menuState.showMenu(offset)
+				true
+			},
+		) {
+			state.addRichSpan(0, 5, SpellCheckStyle)
+
+			tapAtCharacter(2)
+
+			assertTrue(menuState.isVisible, "precondition: the tap opened the popup")
+			assertFalse(state.isFocused, "the keyboard would cover the popup this tap opened")
+		}
+	}
+
+	/**
+	 * The bullet/blockquote regression: hosts return `true` for every click just
+	 * to observe them, and list or quote lines are covered by rich spans, so a
+	 * "listener said true" gate makes those lines unfocusable by touch. A claimed
+	 * tap that opened nothing is an ordinary tap and must focus.
+	 */
+	@Test
+	fun `a tap on a span whose listener claims it but opens nothing still focuses`() = editorUiTest(
 		initialText = document,
 		autoFocus = false,
 		onRichSpanClick = { _, _, _ -> true },
 	) {
-		state.addRichSpan(0, 5, SpellCheckStyle)
+		state.addRichSpan(0, 5, BulletListSpanStyle)
 
 		tapAtCharacter(2)
 
-		assertFalse(state.isFocused, "a span answered the tap, so it must not also raise the keyboard")
+		assertTrue(state.isFocused, "no popup opened, so the tap is a request to type here")
 	}
 
 	/**
@@ -109,6 +145,33 @@ class TouchFocusE2eTest {
 
 		assertTrue(selectedText.isNotEmpty(), "expected the long press to select a word")
 		assertTrue(state.isFocused)
+	}
+
+	/**
+	 * A long press on an existing selection opens the context menu rather than
+	 * re-selecting, and the keyboard must not rise over that menu. The popup
+	 * check covers this for free: the menu is showing when the finger lifts.
+	 */
+	@Test
+	fun `a long press on an existing selection opens the menu and does not focus`() {
+		val menuState = TextEditorContextMenuState()
+		editorUiTest(
+			initialText = document,
+			autoFocus = false,
+			contextMenuState = menuState,
+		) {
+			state.selector.updateSelection(
+				state.getOffsetAtCharacter(0),
+				state.getOffsetAtCharacter(11),
+			)
+			waitForIdle()
+
+			longPressAtCharacter(4)
+
+			assertTrue(menuState.isVisible, "precondition: the long press opened the context menu")
+			assertFalse(state.isFocused, "the keyboard would cover the menu this press opened")
+			assertTrue(selectedText.isNotEmpty(), "the existing selection must survive")
+		}
 	}
 
 	/** Focus survives the gesture that placed it, so typing right after a tap works. */

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
@@ -152,6 +152,8 @@ class EditorUiTestScope(
 	fun longPressAtCharacter(charIndex: Int) {
 		val position = positionOfCharacter(charIndex)
 		test.onRoot().performTouchInput { down(position) }
+		// The long-press timer is a coroutine on the editor's scope, which the test
+		// clock drives; sleeping the thread would not move it.
 		test.mainClock.advanceTimeBy(800)
 		test.waitForIdle()
 		test.onRoot().performTouchInput { up() }

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
@@ -148,6 +148,16 @@ class EditorUiTestScope(
 	/** Taps the character at flat index [charIndex] with a finger. */
 	fun tapAtCharacter(charIndex: Int) = tapAt(positionOfCharacter(charIndex))
 
+	/** Holds a finger on the character at flat index [charIndex] past the long-press threshold. */
+	fun longPressAtCharacter(charIndex: Int) {
+		val position = positionOfCharacter(charIndex)
+		test.onRoot().performTouchInput { down(position) }
+		test.mainClock.advanceTimeBy(800)
+		test.waitForIdle()
+		test.onRoot().performTouchInput { up() }
+		test.waitForIdle()
+	}
+
 	/**
 	 * Drags a finger [dy] pixels from [position] and lifts, the shape of a scroll.
 	 * Well past touch slop, so it can never be mistaken for a tap.

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
@@ -6,10 +6,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SkikoComposeUiTest
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.doubleClick
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performMouseInput
@@ -22,6 +24,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.texteditor.BasicTextEditor
 import com.darkrockstudios.texteditor.RichSpanClickListener
+import com.darkrockstudios.texteditor.contextmenu.TextEditorContextMenuState
 import com.darkrockstudios.texteditor.input.CtrlKeyBindings
 import com.darkrockstudios.texteditor.input.KeyBindings
 import com.darkrockstudios.texteditor.input.LocalKeyBindings
@@ -51,6 +54,7 @@ internal fun editorUiTest(
 	enabled: Boolean = true,
 	keyBindings: KeyBindings = CtrlKeyBindings,
 	onRichSpanClick: RichSpanClickListener? = null,
+	contextMenuState: TextEditorContextMenuState? = null,
 	autoFocus: Boolean = enabled,
 	block: EditorUiTestScope.() -> Unit,
 ) = runSkikoComposeUiTest {
@@ -64,9 +68,10 @@ internal fun editorUiTest(
 		) {
 			BasicTextEditor(
 				state = state,
-				modifier = Modifier.size(width, height),
+				modifier = Modifier.size(width, height).testTag(EDITOR_TEST_TAG),
 				enabled = enabled,
 				autoFocus = autoFocus,
+				contextMenuState = contextMenuState,
 				onRichSpanClick = onRichSpanClick,
 			)
 		}
@@ -82,12 +87,18 @@ internal fun editorUiTest(
 	EditorUiTestScope(this, state, clipboard).block()
 }
 
+internal const val EDITOR_TEST_TAG = "editor-under-test"
+
 @OptIn(ExperimentalTestApi::class)
 class EditorUiTestScope(
 	val test: SkikoComposeUiTest,
 	val state: TextEditorState,
 	val clipboard: InMemoryClipboard,
 ) {
+	// Pointer input is injected at the tagged editor node, not onRoot(): once a
+	// context menu popup is open there are two roots and onRoot() refuses to pick.
+	private val editor get() = test.onNodeWithTag(EDITOR_TEST_TAG)
+
 	/**
 	 * Markdown extension for this editor, created on first use. Deliberately a
 	 * per-scope member: TextEditorState hashes by document content, so caching
@@ -138,7 +149,7 @@ class EditorUiTestScope(
 
 	/** Taps [position] with a finger: down and up in the same place, no buttons. */
 	fun tapAt(position: Offset) {
-		test.onRoot().performTouchInput {
+		editor.performTouchInput {
 			down(position)
 			up()
 		}
@@ -151,12 +162,12 @@ class EditorUiTestScope(
 	/** Holds a finger on the character at flat index [charIndex] past the long-press threshold. */
 	fun longPressAtCharacter(charIndex: Int) {
 		val position = positionOfCharacter(charIndex)
-		test.onRoot().performTouchInput { down(position) }
+		editor.performTouchInput { down(position) }
 		// The long-press timer is a coroutine on the editor's scope, which the test
 		// clock drives; sleeping the thread would not move it.
 		test.mainClock.advanceTimeBy(800)
 		test.waitForIdle()
-		test.onRoot().performTouchInput { up() }
+		editor.performTouchInput { up() }
 		test.waitForIdle()
 	}
 
@@ -165,7 +176,7 @@ class EditorUiTestScope(
 	 * Well past touch slop, so it can never be mistaken for a tap.
 	 */
 	fun panFrom(position: Offset, dy: Float = -120f) {
-		test.onRoot().performTouchInput {
+		editor.performTouchInput {
 			down(position)
 			moveTo(position + Offset(0f, dy))
 			up()
@@ -182,7 +193,7 @@ class EditorUiTestScope(
 	fun clickAt(position: Offset, shift: Boolean = false) {
 		defeatMultiClickDetection()
 		if (shift) test.onRoot().performKeyInput { keyDown(Key.ShiftLeft) }
-		test.onRoot().performMouseInput { click(position) }
+		editor.performMouseInput { click(position) }
 		if (shift) test.onRoot().performKeyInput { keyUp(Key.ShiftLeft) }
 		test.waitForIdle()
 	}
@@ -190,7 +201,7 @@ class EditorUiTestScope(
 	/** Double-clicks the character at flat index [charIndex] (word select). */
 	fun doubleClickAtCharacter(charIndex: Int) {
 		defeatMultiClickDetection()
-		test.onRoot().performMouseInput { doubleClick(positionOfCharacter(charIndex)) }
+		editor.performMouseInput { doubleClick(positionOfCharacter(charIndex)) }
 		test.waitForIdle()
 	}
 
@@ -199,7 +210,7 @@ class EditorUiTestScope(
 		defeatMultiClickDetection()
 		val from = positionOfCharacter(fromChar)
 		val to = positionOfCharacter(toChar)
-		test.onRoot().performMouseInput {
+		editor.performMouseInput {
 			moveTo(from)
 			press()
 			moveTo(to)

--- a/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/utils/EditorUiTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.text.AnnotatedString
@@ -50,6 +51,7 @@ internal fun editorUiTest(
 	enabled: Boolean = true,
 	keyBindings: KeyBindings = CtrlKeyBindings,
 	onRichSpanClick: RichSpanClickListener? = null,
+	autoFocus: Boolean = enabled,
 	block: EditorUiTestScope.() -> Unit,
 ) = runSkikoComposeUiTest {
 	val clipboard = InMemoryClipboard()
@@ -64,7 +66,7 @@ internal fun editorUiTest(
 				state = state,
 				modifier = Modifier.size(width, height),
 				enabled = enabled,
-				autoFocus = enabled,
+				autoFocus = autoFocus,
 				onRichSpanClick = onRichSpanClick,
 			)
 		}
@@ -74,7 +76,7 @@ internal fun editorUiTest(
 	// JVM the autoFocus request can land after the first replayed keystrokes,
 	// which are then silently dropped. Don't hand control to the test until the
 	// editor actually holds focus.
-	if (enabled) {
+	if (enabled && autoFocus) {
 		waitUntil(timeoutMillis = 5_000) { state.isFocused }
 	}
 	EditorUiTestScope(this, state, clipboard).block()
@@ -130,6 +132,31 @@ class EditorUiTestScope(
 			if (alt) keyUp(Key.AltLeft)
 			if (shift) keyUp(Key.ShiftLeft)
 			if (ctrl) keyUp(Key.CtrlLeft)
+		}
+		test.waitForIdle()
+	}
+
+	/** Taps [position] with a finger: down and up in the same place, no buttons. */
+	fun tapAt(position: Offset) {
+		test.onRoot().performTouchInput {
+			down(position)
+			up()
+		}
+		test.waitForIdle()
+	}
+
+	/** Taps the character at flat index [charIndex] with a finger. */
+	fun tapAtCharacter(charIndex: Int) = tapAt(positionOfCharacter(charIndex))
+
+	/**
+	 * Drags a finger [dy] pixels from [position] and lifts, the shape of a scroll.
+	 * Well past touch slop, so it can never be mistaken for a tap.
+	 */
+	fun panFrom(position: Offset, dy: Float = -120f) {
+		test.onRoot().performTouchInput {
+			down(position)
+			moveTo(position + Offset(0f, dy))
+			up()
 		}
 		test.waitForIdle()
 	}

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckingTextEditor.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckingTextEditor.kt
@@ -188,7 +188,9 @@ fun SpellCheckingTextEditor(
 						showContextMenu(offset, spellCheckItem)
 						true
 					} else {
-						false
+						// Not ours: a span the host put here. Offer it to their listener
+						// rather than swallowing the tap.
+						onRichSpanClick?.invoke(span, type, offset) ?: false
 					}
 				} else {
 					currentSpellCheckItem = null

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckingTextEditor.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckingTextEditor.kt
@@ -171,18 +171,25 @@ fun SpellCheckingTextEditor(
 			contextMenuState = contextMenuState,
 			onRichSpanClick = { span, type, offset ->
 				if (type == SpanClickType.SECONDARY_CLICK || type == SpanClickType.TAP) {
-					// Check if this span is a spell check span
 					val spellCheckItem: SpellCheckItem? = when (val clickResult = state.handleSpanClick(span)) {
 						is WordSegment -> SpellCheckItem.MisspelledWord(clickResult)
 						is Correction -> SpellCheckItem.SentenceIssue(clickResult)
 						else -> null
 					}
-					// Store the spell check item for context menu
 					currentSpellCheckItem = spellCheckItem
-					// Show context menu with spell suggestions
-					showContextMenu(offset, spellCheckItem)
-					// Return true to indicate we handled it
-					true
+
+					// A right-click always offers a menu, falling back to the standard
+					// one when the span has nothing to correct. A tap only opens one when
+					// there is a correction to offer: tapping a correctly spelled word
+					// means "put the caret here", and answering that with a menu is not
+					// what was asked for. Declining leaves the tap unconsumed, so it
+					// still focuses the editor and raises the keyboard.
+					if (type == SpanClickType.SECONDARY_CLICK || spellCheckItem != null) {
+						showContextMenu(offset, spellCheckItem)
+						true
+					} else {
+						false
+					}
 				} else {
 					currentSpellCheckItem = null
 					onRichSpanClick?.invoke(span, type, offset) ?: false

--- a/docs/design/touch-focus.md
+++ b/docs/design/touch-focus.md
@@ -1,0 +1,237 @@
+# Touch input, focus, and the soft keyboard
+
+Working notes for PR #88 (`touch-input-fixes`). This documents what we are trying
+to build, the constraints we have hit, three landed attempts with what each one
+broke, and the fourth attempt that settled the design. It exists because the
+problem ate three review rounds before the decision below was made.
+
+## The goal
+
+On Android, focus is what raises the soft keyboard, and the editor takes focus
+through pointer input. The keyboard should rise exactly when the user asks to
+type, and never cover something the user just opened. Concretely:
+
+1. Panning or flinging the document must not raise the keyboard. This was the
+   original complaint: touching the text to scroll popped the keyboard over the
+   content on every drag.
+2. A tap places the caret and raises the keyboard.
+3. A tap that opens the spell-check suggestion popup must not raise the keyboard
+   over the popup. Device-confirmed as the desired behaviour, including staying
+   unfocused after a suggestion is applied.
+4. A long press selects a word, and the selection must be typeable-over, which
+   means long-press-select needs focus.
+5. Fling must coast. Scrolling is handled by an ancestor `Modifier.scrollable`,
+   and it must keep receiving the gesture untouched.
+6. Everything not listed stays as it was: mouse focuses on press, right-click
+   opens the menu and focuses, `RichTextView` selection and copy work, selection
+   handle drags work.
+
+A separate fix that came along for the ride and has survived every round: the
+spell-check editor only opens a menu on tap when it actually has a correction to
+offer, and taps on spans it does not own are delegated to the host's listener.
+
+## Constraints discovered
+
+These are the facts that killed the attempts. Any future design has to satisfy
+all of them at once.
+
+**Focus is the only lever.** There is no per-gesture "do not show the keyboard"
+control in this codebase; whoever requests focus decides.
+
+**The knowledge and the decision live in different modifiers.** What a tap did
+(placed a caret, opened a popup, grabbed a handle) is known inside the gesture
+handler on the text Canvas. Focus is requested by a separate handler on the
+enclosing container, which also covers the empty space below a short document.
+Several `pointerInput` handlers plus the ancestor `scrollable` all observe the
+same events in parallel.
+
+**A finger down is ambiguous until lift.** Tap, pan, and long press only become
+distinguishable later, so focus cannot be decided at the down event. Mouse is
+unambiguous at press.
+
+**Pointer consumption is broadcast, not private.** Consuming a change to signal
+one handler also signals every other handler. In particular the ancestor
+`scrollable` treats a consumed release as its drag being taken away and cancels
+the fling instead of finishing with velocity. Consumption cannot carry a private
+bit between two of our own modifiers.
+
+**Compose dispatches the Main pass child-first.** An ancestor scroll container
+consumes moves after our Canvas-level handler has already seen them, so reading
+`isConsumed` at the Canvas can never observe an ancestor's scroll consumption.
+
+**`onRichSpanClick` returning true does not mean "do not focus".** Rich spans
+include bullets, blockquotes, links, and spell-check underlines. Hosts (including
+our own sample app) return true for every click type just to observe clicks.
+Bullet and blockquote lines are covered by spans, so any design that suppresses
+focus when the listener returns true makes list items and quotes unfocusable by
+touch. This is the bug found on device today, and it was also review finding #1
+in round two; the third attempt reintroduced it by keying its gate off the same
+return value.
+
+**Android reports external mice as `PointerType.Touch`.** Mouse-vs-finger must
+be detected from `buttons`, not pointer type (see the `android_mouse_pointer_type`
+memo). Any focus logic that branches on finger-vs-mouse inherits this.
+
+**The two costs are asymmetric.** A keyboard that fails to appear costs the user
+one extra tap. A keyboard that appears over a popup, or an editor that cannot be
+focused at all, is broken. When in doubt, focus.
+
+## Attempt log
+
+### Attempt 1, commit `393f68c`: focus on lift, consumption as the span signal
+
+Finger focuses on lift within touch slop; mouse focuses on press. A tap claimed
+by a span (judged by `onRichSpanClick` returning true) consumed the release, and
+the container's focus handler skipped consumed releases.
+
+Device-confirmed wins that all later attempts kept: pan no longer raises the
+keyboard, tapping a misspelled word shows suggestions without the keyboard.
+
+Review round two found seven distinct defects, the big ones being:
+
+- Keying "do not focus" off the listener return broke every editor whose host
+  returns true liberally, including the sample app (spans unfocusable by touch).
+- Long press still raised the keyboard over the selection handles, because the
+  focus handler re-derived tap recognition and disagreed with the gesture
+  handler about what a long press is.
+- The slop check used local coordinates, so a pan that scrolls an ancestor
+  container (which translates the editor with the finger) read as a tap.
+- `event.changes.first()` misbehaves with a second pointer down.
+
+### Attempt 2, commit `f365883`: the gesture handler owns focus
+
+Moved the focus decision into `handleTextInteractions` via an `onRequestFocus`
+callback, since that is where the gesture is classified. To tell the container
+fallback to stand down, it consumed the release of every gesture it handled.
+Added pointer-id tracking and an `isConsumed`-means-drag check for the ancestor
+pan case. Made long press deliberately not focus.
+
+Review round three found ten defects, all confirmed, and this attempt was
+reverted whole:
+
+- Consuming every release killed fling on every touch platform: the ancestor
+  scrollable saw its drag consumed and reported DragCancelled instead of
+  DragStopped with velocity.
+- `RichTextView` wires no `onRequestFocus`, so a selectable view became
+  permanently unfocusable: selection visible but Ctrl+C dead.
+- Right-click never called the callback but still consumed, so right-click could
+  no longer focus the editor.
+- The pointer-id latch was never reset, so it only worked for the first gesture
+  the node ever saw. Dead code.
+- The `isConsumed` drag check ran on the Main pass before any ancestor could
+  consume. Dead code.
+- A press on a selection handle broke out of the loop before the consume, so the
+  fallback focused anyway and raised the keyboard over the handles.
+- Long-press-no-focus was the wrong call: a selection you cannot type over is
+  useless, and tapping to summon the keyboard destroys the selection. Real
+  Android text fields keep focus on long-press-select.
+
+Lesson: centralising the decision was fine; the stand-down signal (broadcast
+consumption) was not separable from the fling and fallback machinery.
+
+### Attempt 3, commit `e8ebb1a`: revert, plus a private gate
+
+Reverted attempt 2. Replaced consumption with `SpanTapGate`, a tiny object owned
+by the composable and read by exactly two modifiers, reset at each gesture
+start, set when a span claimed the tap. Also: a handle hit no longer counts as a
+span claim, long press focuses again (with a test), and the spell-check
+delegation fix was re-applied.
+
+Fling confirmed working on device. But the gate is still keyed off
+`onRichSpanClick` returning true, which is the same broken predicate from
+attempt 1: on device today, tapping a blockquote or a bullet list item moves the
+caret but raises no keyboard. Tapping a misspelled word correctly shows
+suggestions without the keyboard, which proves the plumbing works and only the
+predicate is wrong.
+
+### Attempt 4, the settled design: ask what the tap did, not who answered
+
+The requirement was never "a span handled this"; it is "this tap opened a popup
+the keyboard would cover". The editor already knows whether a popup is showing:
+`TextEditorContextMenuState.isVisible`, which both the spell-check suggestions
+and the standard context menu go through, and which is set synchronously during
+the tap dispatch (the suggestion menu shows a loading state immediately).
+
+Shape: `SpanTapGate` is gone; `requestFocusOnPress` takes a
+`popupIsShowing: () -> Boolean`; `BasicTextEditor` passes
+`{ effectiveContextMenuState.isVisible }`. The Canvas handler signals nothing.
+Focus on lift proceeds unless a popup is visible at that moment.
+
+This also covers a case none of the previous attempts handled: a long press on
+an existing selection opens the context menu, and the popup check keeps the
+keyboard from rising over it, while a plain long-press-select still focuses.
+Both are test-pinned.
+
+The underlying principle, stated once so the next attempt does not have to
+rediscover it: a tap has three independent outcomes with three different owners.
+The text-editing default (caret placement, selection clearing) belongs to the
+gesture handler and no span vetoes it. The span reaction (open a popup, navigate
+a link, log the click) belongs to the listener chain, and the listener's Boolean
+is only a chaining protocol between listeners: it is how the spell-check
+wrapper decides whether to delegate to the host's listener, and it has no effect
+on the editor itself. Focus belongs to the container's handler and is decided
+only from editor-observable outcomes (is a popup showing), never from what any
+listener returned. Per-span "interactive" flags were considered and rejected:
+they rebuild the broken listener-return predicate one level down, and a claimed
+tap still would not answer the question the keyboard actually poses.
+
+The open questions from the draft, resolved:
+
+- Hosts with their own popups: the supported pattern is to route them through
+  the `contextMenuState` parameter, which is exactly what the spell-check
+  wrapper does, making its popup visible to the focus predicate for free. A host
+  whose dialog cannot go through the menu state gets a keyboard over it, at the
+  cost of one extra tap; if that ever hurts in practice, the escape hatch that
+  fits the design is a `suppressKeyboardWhen: () -> Boolean` parameter ORed into
+  the predicate, still "what is showing", never "who handled it". Not built
+  until someone asks.
+- `RichTextView` passes `{ false }`: it is read-only, never raises a keyboard,
+  and its focus exists only to route copy shortcuts, so no tap ever suppresses
+  it (attempt 2 proved suppression there only breaks Ctrl+C).
+- The timing holds by construction: the Main pass dispatches child-first, so the
+  Canvas handler runs the tap dispatch that opens the menu before the
+  container-level handler sees the same release and reads the lambda. Stated in
+  a comment at the read site in `requestFocusOnPress`.
+
+The `RichSpanClickListener` KDoc now states the Boolean's real contract
+(listener chaining only, no editor behavior attached), replacing the old
+"return true to consume the event" wording that three attempts took literally.
+
+## What is true on the branch right now
+
+- Focus on lift for finger, on press for mouse. Device-confirmed: no keyboard on
+  pan, fling coasts.
+- Spell-check menu policy: tap opens a menu only with a correction to offer,
+  other spans delegate to the host listener.
+- Long press selects and focuses (test-pinned).
+- Focus is skipped only when the tap or long press left a popup showing
+  (test-pinned from both sides: popup-opening tap does not focus, span-claimed
+  tap with no popup does). Bullets and blockquotes focus by touch again.
+- The markdown demo document is long enough to fling and puts blocks below the
+  fold.
+
+Deliberately not addressed, tracked as follow-ups:
+
+- Dragging a selection handle cannot restore focus once it is lost (needs the
+  same "gesture completed, restore focus" design as popup dismissal).
+- The orphaned long-press job when a second finger lands mid-gesture. Pre-dates
+  this branch; exists on `main`.
+
+## Verification assets
+
+- `TouchFocusE2eTest`: drives real touch and mouse gestures through the composed
+  editor. Each behavioural claim has a test, and the suite is A/B verified: with
+  the fixes reverted, exactly the tests pinning the fixes go red and the
+  guard-rail tests stay green. Attempt 4's A/B against attempt 3: the
+  claimed-tap-still-focuses and long-press-on-selection tests go red, the other
+  eight stay green.
+- Harness additions in `EditorUiTest`: `tapAt`, `tapAtCharacter`, `panFrom`,
+  `longPressAtCharacter`, `autoFocus` and `contextMenuState` parameters. Gotchas
+  recorded: the long-press timer is a coroutine on the editor's scope driven by
+  the virtual test clock, so tests must use `mainClock.advanceTimeBy`, never
+  `Thread.sleep`; and pointer input is injected at the tagged editor node, not
+  `onRoot()`, because an open context menu popup is a second root and makes
+  `onRoot()` ambiguous.
+- What desktop tests cannot see: the keyboard itself, fling physics, and IME
+  interaction. Every attempt so far has needed the Pixel Fold to find what the
+  suite missed, so device passes stay part of the loop.

--- a/sampleApp/src/commonMain/kotlin/DemoText.kt
+++ b/sampleApp/src/commonMain/kotlin/DemoText.kt
@@ -189,7 +189,52 @@ Numeric edges round-trip too: version 2.0, Room 1-A, and "Step 1. do this" all s
 
 When a text edit occurs, spans are adjusted to maintain consistency. If the operation is an *insertion*, spans may **expand** or **shift** depending on the location relative to the insertion point. For *deletions*, spans **shrink** or **merge** based on the removed range. Replacement operations are treated as a **combination** of deletion and insertion, ensuring spans adapt seamlessly.
 
-Span deduplication plays a significant role by merging overlapping spans to reduce redundancy. Dynamic updates ensure that any changes in text instantly reflect on spans, keeping the document visually consistent. Efficient and robust, this approach simplifies complex text operations while maintaining **visual coherence**."""
+Span deduplication plays a significant role by merging overlapping spans to reduce redundancy. Dynamic updates ensure that any changes in text instantly reflect on spans, keeping the document visually consistent. Efficient and robust, this approach simplifies complex text operations while maintaining **visual coherence**.
+
+## Scrolling and Gestures
+
+From here down the document is deliberately long, so the editor scrolls well past a phone screen and a flick can build real momentum. Fling behaviour is easy to break without noticing: a handler that consumes the pointer release takes the gesture away from the scroll container, which then cancels its drag instead of finishing it with a velocity, and scrolling stops dead the moment the finger lifts instead of coasting.
+
+Touch and mouse want different things from the same code. A mouse press is unambiguous — the button is down, the user is pointing at something. A finger press is a question that is only answered when the finger lifts: it might be a tap, or it might be the beginning of a scroll, and on a phone the difference decides whether the soft keyboard covers half the screen.
+
+> Scroll to the bottom, then flick back up. The document should keep moving after your finger leaves the glass, and the keyboard should stay down the whole time.
+
+Things worth trying on this page:
+
+- Flick hard and let go — the text should coast, not stop dead
+- Drag slowly and release without lifting off the text — no keyboard
+- Tap a word — caret lands there, keyboard rises
+- Long press a word — it selects, and you can type over it immediately
+- Tap a bullet marker line like this one — it should behave like any other tap
+
+### Wrapping and Long Paragraphs
+
+Paragraphs of real length matter here because they are what makes the document tall enough to fling, and because wrapped lines are where hanging indents and gutter markers are most likely to drift out of alignment. This paragraph exists mostly to occupy vertical space, but it also exercises the layout path that recomputes wrap points whenever the viewport width changes, which is exactly what happens when a foldable is opened or closed.
+
+Rotating the device, unfolding it, or resizing the window all re-run line layout for every line in the document. On a long document that is a lot of work, and it is worth watching for a stutter at the moment the geometry changes rather than only while scrolling.
+
+1. Scroll to here from the top in one flick
+2. Note whether the motion decelerates smoothly or halts abruptly
+3. Tap once to place the caret, then scroll again without typing
+
+### Blocks Under the Fold
+
+> A blockquote this far down the document is a convenient target for testing that block decorations are still drawn correctly after a long scroll, rather than only when the document starts at the top of the viewport.
+
+```
+// Code fences are drawn on a tinted card. Scrolling past one
+// at speed is a good check that its background and border
+// stay locked to the text rather than lagging behind it.
+fun fling(velocity: Float): Float {
+    return velocity * DECELERATION
+}
+```
+
+- A bullet near the bottom
+- Another one, for backspace-at-the-start testing far from the first line
+- And a third that wraps onto a second visual line so the hanging indent can be checked down here too
+
+The end of the document is a useful place to stop, because scrolling past the last line and releasing is where an over-scroll or a mis-computed content height would show itself. If the text springs back or leaves a gap below this paragraph, something in the height calculation is off."""
 
 const val EXAMPLE_MARKDOWN = """# ComposeTextEditor
 


### PR DESCRIPTION
Three touch-input fixes, found while QA'ing #87 on a Pixel Fold. None of them are related to that PR; this branch is off `main` and stands alone.

## The soft keyboard popped on every scroll

`Modifier.requestFocusOnPress` took focus on the pointer **down** event:

```kotlin
awaitFirstDown(requireUnconsumed = false)
focusRequester.requestFocus()
```

Focus is what raises the soft keyboard on Android, so touching the text to pan raised the keyboard over the content before Compose could know whether the gesture was a tap or a scroll. `requireUnconsumed = false` made it worse: even after the scrollable had claimed the gesture, focus was still requested.

Focus now follows the split the editor already uses for caret placement, which `ARCHITECTURE.md` describes as *"mouse-like input places the caret on press … finger input places the caret on release"*. Focus was the one thing not obeying it:

- **Mouse** (including Android's mouse-as-`PointerType.Touch`, detected from `buttons`) focuses on press, unchanged.
- **Finger** must lift within touch slop of where it landed. Travel further and it is a pan, so no focus.

## A tap answered by a rich span raised it too

Tapping a misspelled word opened the suggestion popup *and* slid the keyboard up over it.

The fix uses pointer consumption rather than a new side channel. Span handling lives on the inner Canvas and focus on the outer Box, and Compose's Main pass runs child to parent, so a `consume()` on the Canvas is visible to the Box on the same event:

```kotlin
// Canvas: tap answered by a span
if (claimedBySpan) eventChange.consume()

// Box: focus only an unclaimed tap
if (!change.isConsumed) focusRequester.requestFocus()
```

This required fixing `handleSpanInteraction`'s return value, which claimed "handled" even when there was no span under the click. It now reports whether a span actually claimed it. That value was dead — all three call sites discarded it — so nothing depended on the old meaning.

Scoped to the finger-tap path only. Consuming a mouse *down* would risk interfering with drag-select, and a mouse click has no keyboard to raise.

## Tapping a correctly spelled word opened a menu

`SpellCheckingTextEditor` answered every span tap with `showContextMenu(offset, spellCheckItem)`, and that function falls through to the standard cut/copy/paste menu when the item is null. So tapping a correctly spelled word that carried any rich span popped a menu that read like a stray long-press.

A tap now opens the menu only when there is a correction to offer. Right-click keeps its fallback to the standard menu, because that is what right-click means.

The three fixes compose: declining returns `false`, so nothing consumes the tap, so the focus handler treats it as ordinary and the editor focuses and raises the keyboard. No special-casing anywhere.

## Testing

953 desktop tests, zero failures (`946` before, plus 7 new), `:ComposeTextEditor:check` green on desktop, Android, iOS and wasm.

`TouchFocusE2eTest` drives real touch and mouse gestures through the composed editor. Reverting the two source fixes turns exactly the two tests that pin them red:

| Test | Without the fix |
| --- | --- |
| a finger pan does not focus the editor | **RED** |
| a tap claimed by a rich span does not focus the editor | **RED** |
| a finger tap focuses the editor | green |
| a mouse click focuses the editor | green |
| a tap a rich span declines still focuses the editor | green |
| a tap outside any span focuses even when a span exists elsewhere | green |
| a tap leaves the editor focused and editable | green |

The five that stay green are the point: they fail if consumption or the pan check is drawn too wide, which is the way this fix would most likely go wrong.

The harness gained an `autoFocus` parameter (defaulting to the old behaviour) plus `tapAt` / `tapAtCharacter` / `panFrom` touch helpers.

## Manual verification

On a Pixel Fold: scrolling no longer raises the keyboard; tapping text does; tapping a misspelled word shows suggestions with no keyboard; tapping a correctly spelled word places the caret and raises the keyboard with no menu.

Not covered by the automated tests: the spell-check menu policy itself, which lives inline in a composable and would need a spell-checker fixture to drive. It was verified by hand only.
