### PR TITLE
Stop the spell check guard scanning the document on every keystroke

### DIFF
--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckGuard.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckGuard.kt
@@ -98,6 +98,28 @@ internal fun SpellCheckGuard.evaluateWordRatio(checked: Int, flagged: Int): Spel
 internal fun SpellCheckGuard.evaluateSentenceRatio(checked: Int, flagged: Int): SpellCheckSuspension? =
 	evaluateRatio(checked, flagged, minSentenceSample)
 
+/**
+ * [evaluateWordRatio], but [checked] is only asked for the document's word count once
+ * [flagged] is large enough for the ratio to be reachable at all.
+ *
+ * Counting the document's words is O(document) and a partial check runs on every typing
+ * pause, so an ordinary document with a handful of typos must never pay for it.
+ */
+internal inline fun SpellCheckGuard.evaluateWordRatioIfReachable(
+	flagged: Int,
+	checked: () -> Int,
+): SpellCheckSuspension? =
+	if (ratioReachable(flagged, minWordSample)) evaluateWordRatio(checked(), flagged) else null
+
+/**
+ * Whether [flagged] is large enough for the ratio to trip on any document. Tripping needs
+ * `flagged > checked * maxFlaggedRatio` with `checked >= minSample`, so a flagged count at
+ * or below `minSample * maxFlaggedRatio` cannot trip however the document is shaped. Float
+ * arithmetic keeps [SpellCheckGuard.Disabled]'s `Int.MAX_VALUE` sample from overflowing.
+ */
+internal fun SpellCheckGuard.ratioReachable(flagged: Int, minSample: Int): Boolean =
+	flagged > minSample.toFloat() * maxFlaggedRatio
+
 private fun SpellCheckGuard.evaluateRatio(
 	checked: Int,
 	flagged: Int,

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckState.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckState.kt
@@ -355,9 +355,11 @@ class SpellCheckState(
 		// checker is caught even when the document was built up by typing. Live spans
 		// are counted rather than the bookkeeping lists: the span manager keeps their
 		// positions correct across edits, so they can't accumulate stale duplicates.
+		// The document's word count is only counted once the flagged total makes the
+		// ratio reachable; this runs on every typing pause and counting is O(document).
 		val flagged = spellCheckSpanCount()
 		val trip = guard.evaluateCount(flagged)
-			?: guard.evaluateWordRatio(documentWordCount(), flagged)
+			?: guard.evaluateWordRatioIfReachable(flagged) { documentWordCount() }
 		trip?.let { suspendSpellChecking(it) }
 	}
 
@@ -391,13 +393,20 @@ class SpellCheckState(
 
 		// Judge the whole document after folding this range in. Live spans are counted
 		// rather than the bookkeeping lists: the span manager keeps their positions
-		// correct across edits, so they can't accumulate stale duplicates.
-		val sentences = textState.sentenceSegments().toList()
-		val flaggedSentences = sentences.count { sentence ->
-			textState.getRichSpansInRange(sentence.range).any { it.style is SpellCheckStyle }
-		}
-		val trip = guard.evaluateCount(spellCheckSpanCount())
-			?: guard.evaluateSentenceRatio(sentences.size, flaggedSentences)
+		// correct across edits, so they can't accumulate stale duplicates. A flagged
+		// sentence carries at least one span, so the cheap span count gates the
+		// re-segmentation the ratio would otherwise cost on every typing pause.
+		val flagged = spellCheckSpanCount()
+		val trip = guard.evaluateCount(flagged)
+			?: if (guard.ratioReachable(flagged, guard.minSentenceSample)) {
+				val sentences = textState.sentenceSegments().toList()
+				val flaggedSentences = sentences.count { sentence ->
+					textState.getRichSpansInRange(sentence.range).any { it.style is SpellCheckStyle }
+				}
+				guard.evaluateSentenceRatio(sentences.size, flaggedSentences)
+			} else {
+				null
+			}
 		trip?.let { suspendSpellChecking(it) }
 	}
 

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckingTextEditor.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckingTextEditor.kt
@@ -214,12 +214,21 @@ private fun computeAffectedRanges(
 			else -> null
 		}
 		opRange?.let { newRange ->
-			// Merge overlapping ranges
-			val overlapping = ranges.filter { it.intersects(newRange) }
-			ranges.removeAll(overlapping)
-			val mergedRange = overlapping.fold(newRange) { acc, r -> acc.merge(r) }
+			val touching = ranges.filter { it.adjoins(newRange) }
+			ranges.removeAll(touching)
+			val mergedRange = touching.fold(newRange) { acc, r -> acc.merge(r) }
 			ranges.add(mergedRange)
 		}
 		ranges
 	}
 }
+
+/**
+ * Overlapping, or butting up against each other end to start.
+ *
+ * A typed word arrives as one insert per character, each range starting exactly where the
+ * last ended. [TextEditorRange.intersects] is exclusive at the ends and reports those as
+ * disjoint, which would re-check the same word once per character typed.
+ */
+private fun TextEditorRange.adjoins(other: TextEditorRange): Boolean =
+	intersects(other) || end == other.start || other.end == start

--- a/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/SpellCheckGuardTest.kt
+++ b/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/SpellCheckGuardTest.kt
@@ -302,6 +302,43 @@ class SpellCheckGuardTest {
 		assertEquals(0, spellCheckSpanCount(), "No decorations while suspended")
 	}
 
+	@Test
+	fun `a partial check does not count the document when the ratio cannot trip`() = runTest {
+		val words = words(300)
+		textState.setText(words.joinToString(" "))
+		spellChecker.correctWords = words.drop(2).toSet() // 2 real typos
+		val state = SpellCheckState(textState, spellChecker)
+		state.runFullSpellCheck()
+
+		var counted = 0
+		val guard = SpellCheckGuard.Default
+		val trip = guard.evaluateWordRatioIfReachable(spellCheckSpanCount()) {
+			counted++
+			300
+		}
+
+		// Counting words walks the whole document, and this runs on every typing pause.
+		assertNull(trip)
+		assertEquals(0, counted, "A handful of typos must not pay for a document-wide scan")
+	}
+
+	@Test
+	fun `deferring the count leaves the ratio verdict unchanged at its boundary`() {
+		val guard = SpellCheckGuard.Default
+		val sample = guard.minWordSample
+		// The ratio needs flagged > checked * maxFlaggedRatio with checked >= minWordSample,
+		// so minWordSample * maxFlaggedRatio is exactly where deferral must stop.
+		val boundary = (sample * guard.maxFlaggedRatio).toInt()
+
+		for (flagged in (boundary - 1)..(boundary + 2)) {
+			assertEquals(
+				guard.evaluateWordRatio(sample, flagged),
+				guard.evaluateWordRatioIfReachable(flagged) { sample },
+				"Deferral changed the verdict at flagged=$flagged",
+			)
+		}
+	}
+
 	private fun spellCheckSpanCount(): Int =
 		textState.richSpanManager.getAllRichSpans().count { it.style is SpellCheckStyle }
 

--- a/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/e2e/SpellCheckGuardE2eTest.kt
+++ b/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/e2e/SpellCheckGuardE2eTest.kt
@@ -111,6 +111,31 @@ class SpellCheckGuardE2eTest {
 		}
 	}
 
+	@Test
+	fun `a typed word is checked once, not once per character`() {
+		val words = words(60)
+		val checker = CountingSpellChecker(correctWords = words.toSet())
+
+		spellCheckUiTest(
+			spellChecker = checker,
+			initialText = words.joinToString(" "),
+		) {
+			val lookupsAfterFullCheck = checker.lookups
+
+			// Each character arrives as its own insert, and their ranges butt end to
+			// start; uncoalesced, every one re-checks the same word.
+			typeText(" brokenword ")
+			letSpellCheckSettle()
+
+			assertEquals(1, spellCheckSpanCount)
+			assertEquals(
+				2,
+				checker.lookups - lookupsAfterFullCheck,
+				"One pass over the typed word and the one it was appended to",
+			)
+		}
+	}
+
 	@OptIn(ExperimentalTestApi::class)
 	@Test
 	fun `swapping in a laxer guard on recomposition lifts the suspension`() = runSkikoComposeUiTest {


### PR DESCRIPTION
The guard added in `130819c` / `118af3e` is correct but expensive on the hot path, enough that spell checking reads as broken while you type.

## What was wrong

**Every partial check became O(document).** `runPartialWordCheck` ended with `guard.evaluateWordRatio(documentWordCount(), flagged)`, and `documentWordCount()` re-segments the whole document. On a 20k-word document that was 1.36ms of the 1.46ms each check cost, spent computing a ratio that cannot trip when three words are flagged.

**That check ran once per typed character.** `computeAffectedRanges` merged with `intersects()`, which is exclusive at the ends, so consecutive single-character insert ranges `(58,59) (59,60) (60,61)…` were treated as disjoint. A nine-letter word produced nine ranges and nine full-document scans.

Together that is roughly 12ms of guard bookkeeping per word typed on a chapter-length document, plus 9x the checker lookups. On a platform whose checker is out of process, that is the difference between responsive and dead.

For the record, the guard was never actually tripping in the sample app's demo: 465 words with 3 flagged, against a 500 count cap and a 70%-of-document ratio.

## What changed

- `evaluateWordRatioIfReachable` only asks for the document's word count once `flagged > minWordSample * maxFlaggedRatio` (28 with the defaults). Below that the ratio cannot trip on any document, so the verdict is provably identical.
- Sentence mode gates its re-segmentation on the span count, since a flagged sentence always carries at least one span.
- `computeAffectedRanges` merges ranges that touch end to start, not only ones that overlap.

## Result

A partial check on a 20k-word document goes from **1.46ms to 3.4us**, and no longer scales with document size. A typed word costs one check rather than one per character.

## Tests

- `a typed word is checked once, not once per character` pins the merge through the real composed editor and real key events. Verified it fails when the merge is reverted to `intersects()`.
- `a partial check does not count the document when the ratio cannot trip` and `deferring the count leaves the ratio verdict unchanged at its boundary` pin the deferral and its exactness.
- Both module suites green; wasm, iOS, and Android targets compile.