### PR TITLE
Fix indented text-left positions on Compose Android

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/cursor/CursorExt.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/cursor/CursorExt.kt
@@ -3,8 +3,8 @@ package com.darkrockstudios.texteditor.cursor
 import androidx.compose.ui.geometry.Offset
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.LineWrap
-import com.darkrockstudios.texteditor.richstyle.detectLineBlock
 import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.utils.lineTextLeft
 
 fun TextEditorState.calculateCursorPosition(): CursorMetrics {
 	val (_, charIndex) = cursorPosition
@@ -19,8 +19,10 @@ fun TextEditorState.calculateCursorPosition(): CursorMetrics {
 	val textLength = layout.layoutInput.text.length
 	val safeCharIndex = charIndex.coerceIn(0, textLength)
 
-	val cursorX = layout.getHorizontalPosition(safeCharIndex, usePrimaryDirection = true) +
-			emptyLineIndent()
+	// The line's text-left is a floor, not an addition: on an empty indented line
+	// Android already reports the indented position while desktop reports 0.
+	val cursorX = layout.getHorizontalPosition(safeCharIndex, usePrimaryDirection = true)
+		.coerceAtLeast(layout.lineTextLeft(virtualLineIndex, density))
 	val cursorY = currentWrappedLine.offset.y - scrollState.value
 	val lineHeight = layout.multiParagraph.getLineHeight(virtualLineIndex)
 
@@ -37,30 +39,6 @@ fun TextEditorState.calculateCursorPosition(): CursorMetrics {
 		lineBaseline = lineBaseline,
 		lineBottom = lineBottom
 	)
-}
-
-/**
- * Compose's `getHorizontalPosition` returns 0 on an empty line because the
- * paragraph style's [androidx.compose.ui.text.style.TextIndent] doesn't apply
- * to a degenerate `[0, 0)` paragraph range. Add the indent manually so the
- * cursor sits at the indented position on an empty indented line — without
- * this it jumps from `x=0` to `x=indent` the moment the user types the first
- * character. Covers both line-block indents (bullet/quote/list/code) and the
- * editor-wide [androidx.compose.ui.text.TextStyle.textIndent]. Returns 0 if
- * the line isn't empty or no first-line indent is in effect.
- */
-private fun TextEditorState.emptyLineIndent(): Float {
-	if (cursorPosition.char != 0) return 0f
-	val line = textLines.getOrNull(cursorPosition.line) ?: return 0f
-	if (line.text.isNotEmpty()) return 0f
-	// Block lines carry their own paragraph-style indent; plain lines inherit
-	// the editor-wide textStyle indent (baked in by updateBookKeeping).
-	val block = detectLineBlock(cursorPosition.line)
-	val indent = block?.paragraphStyle?.textIndent?.firstLine
-		?: textStyle.textIndent?.firstLine
-		?: return 0f
-	val d = density ?: return 0f
-	return with(d) { indent.toPx() }
 }
 
 internal fun List<LineWrap>.getWrappedLineIndex(position: CharLineOffset): Int {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/BulletListSpanStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/BulletListSpanStyle.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.darkrockstudios.texteditor.LineWrap
 import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.utils.lineTextLeft
 
 /**
  * Decorative rich span that marks a line as a markdown bullet-list item — a small
@@ -42,7 +43,7 @@ data object BulletListSpanStyle : RichSpanStyle {
 		// line — editor-wide `TextStyle.textIndent`, the per-paragraph
 		// `BULLET_LIST_PARAGRAPH_STYLE.textIndent`, or whatever blend Compose
 		// actually produces (the merge is platform-dependent).
-		val textLeft = layoutResult.getLineLeft(lineWrap.virtualLineIndex)
+		val textLeft = layoutResult.lineTextLeft(lineWrap.virtualLineIndex, this)
 		val centerX = (textLeft - BULLET_GAP_DP.dp.toPx()).coerceAtLeast(BULLET_RADIUS_DP.dp.toPx())
 		drawCircle(
 			color = color,

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/HighlightSpanStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/HighlightSpanStyle.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
 import com.darkrockstudios.texteditor.LineWrap
 import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.utils.lineTextLeft
 
 /**
  * A [RichSpanStyle] that paints a solid rectangle behind its text. Used for
@@ -29,7 +30,7 @@ class HighlightSpanStyle(
 
 		val lineStartOffset = layoutResult.getLineStart(lineWrap.virtualLineIndex)
 		val startX = if (textRange.start <= lineStartOffset) {
-			layoutResult.getLineLeft(lineWrap.virtualLineIndex)
+			layoutResult.lineTextLeft(lineWrap.virtualLineIndex, this)
 		} else {
 			try {
 				layoutResult.getHorizontalPosition(textRange.start, usePrimaryDirection = true)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/OrderedListSpanStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/OrderedListSpanStyle.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.text.style.TextIndent
 import androidx.compose.ui.unit.sp
 import com.darkrockstudios.texteditor.LineWrap
 import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.utils.lineTextLeft
 
 /**
  * Decorative rich span that marks a line as a markdown ordered-list item — the
@@ -55,11 +56,11 @@ data object OrderedListSpanStyle : RichSpanStyle {
 		)
 
 		// Right-align numerals against the layout's actual text-left so digit
-		// columns line up (`9.` and `10.` both end at the same x). Reading
-		// `getLineLeft` rather than hardcoding the gutter makes the marker track
-		// whatever indent the platform actually applied.
+		// columns line up (`9.` and `10.` both end at the same x). Reading the
+		// laid-out text position rather than hardcoding the gutter makes the
+		// marker track whatever indent the platform actually applied.
 		val rightPad = GUTTER_RIGHT_PAD_SP.sp.toPx()
-		val textLeft = layoutResult.getLineLeft(lineWrap.virtualLineIndex)
+		val textLeft = layoutResult.lineTextLeft(lineWrap.virtualLineIndex, this)
 		val markerWidth = measured.size.width.toFloat()
 		val x = (textLeft - rightPad - markerWidth).coerceAtLeast(0f)
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/SpellCheckStyle.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/richstyle/SpellCheckStyle.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.texteditor.LineWrap
 import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.utils.lineTextLeft
 
 /**
  * A [RichSpanStyle] that draws a red wavy underline beneath misspelled text.
@@ -39,7 +40,7 @@ object SpellCheckStyle : RichSpanStyle {
 
 		val lineStartOffset = layoutResult.getLineStart(lineWrap.virtualLineIndex) + 1
 		val startX = if (textRange.start <= lineStartOffset) {
-			layoutResult.getLineLeft(lineWrap.virtualLineIndex)
+			layoutResult.lineTextLeft(lineWrap.virtualLineIndex, this)
 		} else {
 			try {
 				layoutResult.getHorizontalPosition(textRange.start, usePrimaryDirection = true)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/utils/TextLayoutResultExt.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/utils/TextLayoutResultExt.kt
@@ -4,8 +4,43 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.style.ResolvedTextDirection
+import androidx.compose.ui.unit.Density
 import kotlin.math.max
 import kotlin.math.min
+
+/**
+ * The x at which [lineIndex]'s text actually starts, including whatever
+ * first-line or hanging indent the platform applied.
+ *
+ * Thar be dragons: [TextLayoutResult.getLineLeft] is not usable for this on
+ * Compose Android — for LTR, normally-aligned text it reports 0 no matter what
+ * [androidx.compose.ui.text.style.TextIndent] is in effect, so anything anchored
+ * to it (gutter markers, span decorations) lands in the wrong place. The
+ * position of the line's first glyph is the reliable signal on every platform.
+ *
+ * An empty paragraph has no glyph to measure, and the platforms disagree about
+ * whether a first-line indent applies to a degenerate `[0, 0)` range — Android
+ * applies it, desktop doesn't — so fall back to the declared indent, which needs
+ * a [density] to resolve. Pass null when the caller has no density; the result
+ * then reflects whatever the layout itself reports.
+ */
+fun TextLayoutResult.lineTextLeft(lineIndex: Int, density: Density?): Float {
+	val lineStart = getLineStart(lineIndex)
+	if (multiParagraph.getParagraphDirection(lineStart) != ResolvedTextDirection.Ltr) {
+		return getLineLeft(lineIndex)
+	}
+
+	val measured = max(
+		getLineLeft(lineIndex),
+		getHorizontalPosition(lineStart, usePrimaryDirection = true)
+	)
+	if (layoutInput.text.isNotEmpty() || density == null) return measured
+
+	val indent = layoutInput.text.paragraphStyles.firstOrNull()?.item?.textIndent?.firstLine
+		?: layoutInput.style.textIndent?.firstLine
+		?: return measured
+	return max(measured, with(density) { indent.toPx() })
+}
 
 /**
  * Reads bounds for multiple lines. This can be removed once an
@@ -87,9 +122,7 @@ fun TextLayoutResult.getBoundingBoxes(
 					usePrimaryDirection = isLtr
 				)
 			else
-				getLineLeft(
-					lineIndex = lineNum
-				)
+				lineTextLeft(lineIndex = lineNum, density = null)
 
 		val right =
 			if (lineNum == endLineNum)

--- a/ComposeTextEditor/src/desktopTest/kotlin/texteditor/LineTextLeftTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/texteditor/LineTextLeftTest.kt
@@ -1,0 +1,96 @@
+package texteditor
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.ResolvedTextDirection
+import androidx.compose.ui.text.style.TextIndent
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.sp
+import com.darkrockstudios.texteditor.utils.lineTextLeft
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * The platforms report a line's indented text position differently, and the
+ * gutter markers, span decorations, and the cursor all have to land on the same
+ * x regardless: Compose Android reports 0 from `getLineLeft` whatever the indent
+ * is, and applies the first-line indent to an empty paragraph; desktop reports
+ * the indent from `getLineLeft` but nothing at all for an empty paragraph.
+ */
+class LineTextLeftTest {
+	private val density = Density(1f, 1f)
+	private val indent = TextIndent(firstLine = 24.sp)
+
+	private fun layout(
+		text: AnnotatedString,
+		lineLeft: Float,
+		horizontalAtLineStart: Float,
+	): TextLayoutResult = mockk<TextLayoutResult>().also { layout ->
+		every { layout.getLineStart(any()) } returns 0
+		every { layout.getLineLeft(any()) } returns lineLeft
+		every { layout.getHorizontalPosition(0, true) } returns horizontalAtLineStart
+		every { layout.multiParagraph.getParagraphDirection(any()) } returns ResolvedTextDirection.Ltr
+		every { layout.layoutInput.text } returns text
+		every { layout.layoutInput.style } returns TextStyle.Default
+	}
+
+	private fun indentedEmptyLine(): AnnotatedString = buildAnnotatedString {
+		withStyle(ParagraphStyle(textIndent = indent)) { append("") }
+	}
+
+	private fun indentedLine(): AnnotatedString = buildAnnotatedString {
+		withStyle(ParagraphStyle(textIndent = indent)) { append("hello") }
+	}
+
+	@Test
+	fun `empty line where the platform already applied the indent is not indented twice`() {
+		val layout = layout(indentedEmptyLine(), lineLeft = 0f, horizontalAtLineStart = 24f)
+
+		assertEquals(24f, layout.lineTextLeft(0, density), 0.5f)
+	}
+
+	@Test
+	fun `empty line where the platform ignored the indent falls back to the declared indent`() {
+		val layout = layout(indentedEmptyLine(), lineLeft = 0f, horizontalAtLineStart = 0f)
+
+		assertEquals(24f, layout.lineTextLeft(0, density), 0.5f)
+	}
+
+	@Test
+	fun `line start glyph wins over a lineLeft that ignores the indent`() {
+		val layout = layout(indentedLine(), lineLeft = 0f, horizontalAtLineStart = 24f)
+
+		assertEquals(24f, layout.lineTextLeft(0, density), 0.5f)
+	}
+
+	@Test
+	fun `unindented line stays at zero`() {
+		val layout = layout(AnnotatedString("hello"), lineLeft = 0f, horizontalAtLineStart = 0f)
+
+		assertEquals(0f, layout.lineTextLeft(0, density), 0.5f)
+	}
+
+	@Test
+	fun `without a density an empty line reports only what the layout measured`() {
+		val layout = layout(indentedEmptyLine(), lineLeft = 0f, horizontalAtLineStart = 0f)
+
+		assertEquals(0f, layout.lineTextLeft(0, density = null), 0.5f)
+	}
+
+	@Test
+	fun `rtl lines keep the platform's lineLeft`() {
+		val layout = mockk<TextLayoutResult>().also { layout ->
+			every { layout.getLineStart(any()) } returns 0
+			every { layout.getLineLeft(any()) } returns 12f
+			every { layout.multiParagraph.getParagraphDirection(any()) } returns ResolvedTextDirection.Rtl
+		}
+
+		assertEquals(12f, layout.lineTextLeft(0, density), 0.5f)
+	}
+}

--- a/ComposeTextEditorFind/src/commonMain/kotlin/com/darkrockstudios/texteditor/find/FindMatchStyle.kt
+++ b/ComposeTextEditorFind/src/commonMain/kotlin/com/darkrockstudios/texteditor/find/FindMatchStyle.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.TextRange
 import com.darkrockstudios.texteditor.LineWrap
 import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
 import com.darkrockstudios.texteditor.state.TextEditorState
+import com.darkrockstudios.texteditor.utils.lineTextLeft
 
 /**
  * Default highlight style for all find matches (non-current).
@@ -30,7 +31,7 @@ class FindMatchStyle(
 
 		val lineStartOffset = layoutResult.getLineStart(lineWrap.virtualLineIndex)
 		val startX = if (textRange.start <= lineStartOffset) {
-			layoutResult.getLineLeft(lineWrap.virtualLineIndex)
+			layoutResult.lineTextLeft(lineWrap.virtualLineIndex, this)
 		} else {
 			layoutResult.getHorizontalPosition(textRange.start, usePrimaryDirection = true)
 		}
@@ -70,7 +71,7 @@ class FindCurrentMatchStyle(
 
 		val lineStartOffset = layoutResult.getLineStart(lineWrap.virtualLineIndex)
 		val startX = if (textRange.start <= lineStartOffset) {
-			layoutResult.getLineLeft(lineWrap.virtualLineIndex)
+			layoutResult.lineTextLeft(lineWrap.virtualLineIndex, this)
 		} else {
 			layoutResult.getHorizontalPosition(textRange.start, usePrimaryDirection = true)
 		}

--- a/sampleApp/src/commonMain/kotlin/SpellCheckingTextEditorDemoUi.kt
+++ b/sampleApp/src/commonMain/kotlin/SpellCheckingTextEditorDemoUi.kt
@@ -89,11 +89,11 @@ fun SpellCheckingTextEditorDemoUi(
 			// `textIndent` here gives plain paragraphs (and headers) a first-line
 			// indent for a more "document-like" look. The block-style rich spans
 			// (lists, blockquotes, code fences) read the actual text-left position
-			// from `TextLayoutResult.getLineLeft` when drawing their gutter
-			// markers, so they line up correctly regardless of how this default
-			// indent merges with their own per-paragraph indents — important on
-			// Compose Android, where the per-paragraph override of
-			// `TextStyle.textIndent` doesn't reliably win the merge.
+			// from the laid-out line when drawing their gutter markers, so they
+			// line up correctly regardless of how this default indent merges with
+			// their own per-paragraph indents: important on Compose Android, where
+			// the per-paragraph override of `TextStyle.textIndent` doesn't reliably
+			// win the merge.
 			style = rememberTextEditorStyle(
 				textStyle = TextStyle.Default.copy(
 					textIndent = TextIndent(firstLine = 24.sp)


### PR DESCRIPTION
## The bugs

Two symptoms in the spell-check demo, which is the only demo that sets an editor-wide `TextStyle.textIndent`:

1. **The cursor on an empty indented line sat right of where the first typed character lands.**
2. **Bullet and ordered-list markers hugged the left edge** instead of sitting a gutter's width before their text.

## Root cause

Both come from Compose Android disagreeing with desktop about indented lines, measured on a Pixel Fold emulator:

- `getLineLeft` returns **0 for LTR, normally-aligned text no matter what indent is in effect** — logged `horiz0=39 lineLeft=0.0` for bullet lines, `horiz0=30 lineLeft=0.0` for code fences. Everything anchored to it drew at the canvas edge.
- An **empty paragraph does get the first-line indent** on Android (`horiz0=59` for a 24.sp indent), where desktop reports 0. `calculateCursorPosition` was adding the indent unconditionally, so Android applied it twice.

## The fix

One shared helper, `TextLayoutResult.lineTextLeft(lineIndex, density)`: the max of `getLineLeft` and the line's first glyph position, falling back to the declared indent when the paragraph is empty (no glyph to measure). RTL keeps the platform's `getLineLeft`.

Callers routed through it: the cursor (as a floor, not an addition), bullet and ordered-list gutter markers, highlight / spell-check / find decorations that start at a line start, and `getBoundingBoxes` for continuation lines of a wrapped selection.

## Verification

- On the emulator: the cursor on an empty plain line and on an empty bullet line now sits exactly where the typed character lands, and markers have their proper gutter gap in both the spell-check and markdown demos.
- `./gradlew check` green.
- New `LineTextLeftTest` pins both platform behaviours (Android-style "already indented", desktop-style "reports 0") so neither can regress.

## Out of scope

Block indents still don't stack on the editor-wide indent, so in the spell-check demo list text (16.sp) reads as slightly less indented than body first lines (24.sp). That's a design call about how `updateBookKeeping` composes the two paragraph styles, not a bug.