### PR TITLE
Carry block structure through the clipboard

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,5 +1,6 @@
 ---
-# Design documents are prose references, not shipped artifacts; markdownlint's
-# 80-column and table rules fight their long table rows.
+# Design and QA documents are prose references, not shipped artifacts;
+# markdownlint's 80-column and table rules fight their long table rows.
 exclude_paths:
   - "docs/design/**"
+  - "docs/qa/**"

--- a/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.android.kt
+++ b/ComposeTextEditor/src/androidMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.android.kt
@@ -27,6 +27,7 @@ actual object ClipboardHelper {
 		text: AnnotatedString,
 		configuration: MarkdownConfiguration,
 		copyId: Long?,
+		html: String?,
 	) {
 		val clipData = ClipData.newPlainText("text", text.text)
 		clipboard.setClipEntry(clipData.toClipEntry())

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.kt
@@ -38,12 +38,17 @@ expect object ClipboardHelper {
 	 * exact copy within this process; [copyId] rides along so a later paste can
 	 * prove the clipboard content is still this copy.
 	 * On other platforms, writes plain text only and [copyId] is ignored.
+	 *
+	 * [html] is the markup to offer, which callers copying out of an editor supply
+	 * so the fragment carries the selection's block structure. Null falls back to
+	 * markup derived from [text] alone, which describes its character styling only.
 	 */
 	suspend fun setText(
 		clipboard: Clipboard,
 		text: AnnotatedString,
 		configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT,
 		copyId: Long? = null,
+		html: String? = null,
 	)
 
 	/**

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
@@ -52,27 +52,18 @@ class HtmlExtension(
 	fun exportAsHtml(): String {
 		val content = editorState.content
 		val blocks = documentBlocksOf(content.richSpans, configuration)
-		// Semantic heading levels, read from the spans rather than by matching
-		// font sizes, so a heading keeps its tag under any configuration.
-		val headerLevels = content.richSpans
-			.mapNotNull { span ->
-				(span.style as? HeaderSpanStyle)?.let { span.range.start.line to it.level }
-			}
-			.toMap()
+		val headerLevels = headerLevelsOf(content.richSpans)
 		val lines = content.lines
 		if (lines.size == 1 && lines[0].isEmpty() && blocks.isEmpty() && headerLevels.isEmpty()) {
 			return ""
 		}
 
-		val writer = HtmlWriter()
-		lines.forEachIndexed { index, line ->
-			writer.openContainers(containersFor(index, blocks))
-			writer.appendLine(
-				lineHtml(index, line, blocks, headerLevels[index]),
-				inCodeFence = blocks.has(index, CodeFence),
-			)
-		}
-		return writer.finish()
+		return renderHtmlFragment(
+			lines = lines.mapIndexed { index, line -> HtmlLine(line, index) },
+			blocks = blocks,
+			headerLevels = headerLevels,
+			configuration = configuration,
+		)
 	}
 
 	/**
@@ -106,60 +97,95 @@ class HtmlExtension(
 		}
 	}
 
-	/** The elements wrapping [line], outermost first. */
-	private fun containersFor(line: Int, blocks: DocumentBlocks): List<String> {
-		val containers = mutableListOf<String>()
-		if (blocks.has(line, Blockquote)) containers += "blockquote"
-		when {
-			blocks.has(line, OrderedList) -> containers += "ol"
-			blocks.has(line, BulletList) -> containers += "ul"
-			// `<code>` nests inside `<pre>` so a reader that only understands one of
-			// the two still sees a code block.
-			blocks.has(line, CodeFence) -> containers += listOf("pre", "code")
+}
+
+/** A line to serialize, paired with the document line its decorations come from. */
+internal class HtmlLine(val text: AnnotatedString, val docLine: Int)
+
+/** The semantic heading level of each line that carries a [HeaderSpanStyle]. */
+internal fun headerLevelsOf(spans: Set<com.darkrockstudios.texteditor.richstyle.RichSpan>): Map<Int, Int> =
+	spans
+		.mapNotNull { span ->
+			(span.style as? HeaderSpanStyle)?.let { span.range.start.line to it.level }
 		}
-		return containers
+		.toMap()
+
+/**
+ * Writes [lines] as an HTML fragment, taking each line's block structure from
+ * [blocks] by its [HtmlLine.docLine]. Shared by whole-document export and by the
+ * clipboard, so a copied selection carries the same markup a save would.
+ */
+internal fun renderHtmlFragment(
+	lines: List<HtmlLine>,
+	blocks: DocumentBlocks,
+	headerLevels: Map<Int, Int>,
+	configuration: MarkdownConfiguration,
+): String {
+	val writer = HtmlWriter()
+	lines.forEach { line ->
+		writer.openContainers(containersFor(line.docLine, blocks))
+		writer.appendLine(
+			lineHtml(line.docLine, line.text, blocks, headerLevels[line.docLine], configuration),
+			inCodeFence = blocks.has(line.docLine, CodeFence),
+		)
+	}
+	return writer.finish()
+}
+
+/** The elements wrapping [line], outermost first. */
+private fun containersFor(line: Int, blocks: DocumentBlocks): List<String> {
+	val containers = mutableListOf<String>()
+	if (blocks.has(line, Blockquote)) containers += "blockquote"
+	when {
+		blocks.has(line, OrderedList) -> containers += "ol"
+		blocks.has(line, BulletList) -> containers += "ul"
+		// `<code>` nests inside `<pre>` so a reader that only understands one of
+		// the two still sees a code block.
+		blocks.has(line, CodeFence) -> containers += listOf("pre", "code")
+	}
+	return containers
+}
+
+private fun lineHtml(
+	index: Int,
+	line: AnnotatedString,
+	blocks: DocumentBlocks,
+	headerLevel: Int?,
+	configuration: MarkdownConfiguration,
+): String {
+	// Fenced lines are literal code: running them through `toHtml` would see the
+	// baked-in monospace as an inline code run and wrap every line in `<code>`.
+	if (blocks.has(index, CodeFence)) return line.text.escapeHtmlText()
+
+	val image = blocks.imageLines[index]
+	val isRule = index in blocks.horizontalRuleLines
+	// A heading's span carries its level; font-size matching remains only as
+	// the fallback for spanless content. A uniformly styled heading line has
+	// no inner formatting left to render, so the tag is written here rather
+	// than by `toHtml`, which declines any heading level it cannot tell
+	// apart from bold body text.
+	val heading = when {
+		isRule || image != null -> null
+		headerLevel != null -> HtmlTag.entries[headerLevel - 1]
+		else -> line.uniformHeadingTag(configuration)
+	}
+	val content = when {
+		isRule -> "<hr>"
+		image != null -> "<img src=\"${image.source.escapeHtmlAttribute()}\"" +
+			" alt=\"${image.alt.escapeHtmlAttribute()}\">"
+
+		heading != null -> "<${heading.tag}>${line.text.escapeHtmlText()}</${heading.tag}>"
+		else -> line.toHtml(configuration)
 	}
 
-	private fun lineHtml(
-		index: Int,
-		line: AnnotatedString,
-		blocks: DocumentBlocks,
-		headerLevel: Int?,
-	): String {
-		// Fenced lines are literal code: running them through `toHtml` would see the
-		// baked-in monospace as an inline code run and wrap every line in `<code>`.
-		if (blocks.has(index, CodeFence)) return line.text.escapeHtmlText()
-
-		val image = blocks.imageLines[index]
-		val isRule = index in blocks.horizontalRuleLines
-		// A heading's span carries its level; font-size matching remains only as
-		// the fallback for spanless content. A uniformly styled heading line has
-		// no inner formatting left to render, so the tag is written here rather
-		// than by `toHtml`, which declines any heading level it cannot tell
-		// apart from bold body text.
-		val heading = when {
-			isRule || image != null -> null
-			headerLevel != null -> HtmlTag.entries[headerLevel - 1]
-			else -> line.uniformHeadingTag(configuration)
-		}
-		val content = when {
-			isRule -> "<hr>"
-			image != null -> "<img src=\"${image.source.escapeHtmlAttribute()}\"" +
-				" alt=\"${image.alt.escapeHtmlAttribute()}\">"
-
-			heading != null -> "<${heading.tag}>${line.text.escapeHtmlText()}</${heading.tag}>"
-			else -> line.toHtml(configuration)
-		}
-
-		val inList = blocks.has(index, BulletList) || blocks.has(index, OrderedList)
-		return when {
-			inList -> "<li>$content</li>"
-			// Rules, images and headings are block elements in their own right;
-			// wrapping one in `<p>` is invalid and browsers close the paragraph
-			// before it anyway.
-			isRule || image != null || heading != null -> content
-			else -> "<p>$content</p>"
-		}
+	val inList = blocks.has(index, BulletList) || blocks.has(index, OrderedList)
+	return when {
+		inList -> "<li>$content</li>"
+		// Rules, images and headings are block elements in their own right;
+		// wrapping one in `<p>` is invalid and browsers close the paragraph
+		// before it anyway.
+		isRule || image != null || heading != null -> content
+		else -> "<p>$content</p>"
 	}
 }
 

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/HtmlExtension.kt
@@ -10,6 +10,7 @@ import com.darkrockstudios.texteditor.richstyle.HeaderSpanStyle
 import com.darkrockstudios.texteditor.richstyle.ImageBlockSpanStyle
 import com.darkrockstudios.texteditor.richstyle.ImageProvider
 import com.darkrockstudios.texteditor.richstyle.OrderedList
+import com.darkrockstudios.texteditor.richstyle.RichSpan
 import com.darkrockstudios.texteditor.richstyle.applyDocumentBlocks
 import com.darkrockstudios.texteditor.richstyle.documentBlocksOf
 import com.darkrockstudios.texteditor.state.TextEditorState
@@ -99,11 +100,22 @@ class HtmlExtension(
 
 }
 
-/** A line to serialize, paired with the document line its decorations come from. */
-internal class HtmlLine(val text: AnnotatedString, val docLine: Int)
+/**
+ * A line to serialize, paired with the document line its decorations come from.
+ *
+ * [isWholeLine] is false for the partly covered first and last lines of a copied
+ * selection. Only a whole line can be read as a heading by how it is styled: any
+ * fragment of a bold run is uniformly styled, and the default h4 is bold at the
+ * body size, so the size match cannot tell the two apart.
+ */
+internal class HtmlLine(
+	val text: AnnotatedString,
+	val docLine: Int,
+	val isWholeLine: Boolean = true,
+)
 
 /** The semantic heading level of each line that carries a [HeaderSpanStyle]. */
-internal fun headerLevelsOf(spans: Set<com.darkrockstudios.texteditor.richstyle.RichSpan>): Map<Int, Int> =
+internal fun headerLevelsOf(spans: Set<RichSpan>): Map<Int, Int> =
 	spans
 		.mapNotNull { span ->
 			(span.style as? HeaderSpanStyle)?.let { span.range.start.line to it.level }
@@ -125,7 +137,14 @@ internal fun renderHtmlFragment(
 	lines.forEach { line ->
 		writer.openContainers(containersFor(line.docLine, blocks))
 		writer.appendLine(
-			lineHtml(line.docLine, line.text, blocks, headerLevels[line.docLine], configuration),
+			lineHtml(
+				index = line.docLine,
+				line = line.text,
+				blocks = blocks,
+				headerLevel = headerLevels[line.docLine],
+				isWholeLine = line.isWholeLine,
+				configuration = configuration,
+			),
 			inCodeFence = blocks.has(line.docLine, CodeFence),
 		)
 	}
@@ -151,6 +170,7 @@ private fun lineHtml(
 	line: AnnotatedString,
 	blocks: DocumentBlocks,
 	headerLevel: Int?,
+	isWholeLine: Boolean,
 	configuration: MarkdownConfiguration,
 ): String {
 	// Fenced lines are literal code: running them through `toHtml` would see the
@@ -160,14 +180,16 @@ private fun lineHtml(
 	val image = blocks.imageLines[index]
 	val isRule = index in blocks.horizontalRuleLines
 	// A heading's span carries its level; font-size matching remains only as
-	// the fallback for spanless content. A uniformly styled heading line has
-	// no inner formatting left to render, so the tag is written here rather
-	// than by `toHtml`, which declines any heading level it cannot tell
+	// the fallback for spanless content, and only for a whole line, since any
+	// fragment of a styled run is uniform on its own. A uniformly styled heading
+	// line has no inner formatting left to render, so the tag is written here
+	// rather than by `toHtml`, which declines any heading level it cannot tell
 	// apart from bold body text.
 	val heading = when {
 		isRule || image != null -> null
 		headerLevel != null -> HtmlTag.entries[headerLevel - 1]
-		else -> line.uniformHeadingTag(configuration)
+		isWholeLine -> line.uniformHeadingTag(configuration)
+		else -> null
 	}
 	val content = when {
 		isRule -> "<hr>"

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/SelectionHtml.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/SelectionHtml.kt
@@ -1,0 +1,41 @@
+package com.darkrockstudios.texteditor.html
+
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.richstyle.documentBlocksOf
+import com.darkrockstudios.texteditor.state.TextEditorState
+
+/**
+ * Serializes [range] as an HTML fragment carrying the block structure of the lines
+ * it covers, the same markup [HtmlExtension.exportAsHtml] would write for them.
+ *
+ * A copy's `AnnotatedString` holds character styling alone: lists, blockquotes,
+ * headings and fences live in line-anchored rich spans, which do not travel with
+ * it. Without this the clipboard's HTML flavor described a selection with no
+ * blocks at all, so pasting anywhere the in-process span buffer does not reach —
+ * another application, or after any edit invalidated it — dropped every block.
+ *
+ * A partially covered line keeps its block: a fragment of a list item is still a
+ * list item, and [applyHtmlPasteBlocks] independently declines to place a block
+ * on the first or last pasted line when the paste splices into an existing one.
+ *
+ * Text and blocks come from one snapshot, so a concurrent edit cannot pair the
+ * text of one revision with the line indices of another.
+ */
+internal fun TextEditorState.selectionAsHtml(range: TextEditorRange): String {
+	val content = content
+	val blocks = documentBlocksOf(content.richSpans, markdownConfiguration)
+	val lines = (range.start.line..range.end.line).mapNotNull { docLine ->
+		val line = content.lines.getOrNull(docLine) ?: return@mapNotNull null
+		val from = if (docLine == range.start.line) range.start.char else 0
+		val to = if (docLine == range.end.line) range.end.char else line.length
+		val start = from.coerceIn(0, line.length)
+		val end = to.coerceIn(start, line.length)
+		HtmlLine(line.subSequence(start, end), docLine)
+	}
+	return renderHtmlFragment(
+		lines = lines,
+		blocks = blocks,
+		headerLevels = headerLevelsOf(content.richSpans),
+		configuration = markdownConfiguration,
+	)
+}

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/SelectionHtml.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/html/SelectionHtml.kt
@@ -17,25 +17,37 @@ import com.darkrockstudios.texteditor.state.TextEditorState
  * A partially covered line keeps its block: a fragment of a list item is still a
  * list item, and [applyHtmlPasteBlocks] independently declines to place a block
  * on the first or last pasted line when the paste splices into an existing one.
+ * Such a line is not whole, though, so it is never read as a heading by how it is
+ * styled: every fragment of a styled run is uniform on its own.
  *
  * Text and blocks come from one snapshot, so a concurrent edit cannot pair the
  * text of one revision with the line indices of another.
  */
 internal fun TextEditorState.selectionAsHtml(range: TextEditorRange): String {
 	val content = content
-	val blocks = documentBlocksOf(content.richSpans, markdownConfiguration)
-	val lines = (range.start.line..range.end.line).mapNotNull { docLine ->
+	val coveredLines = range.start.line..range.end.line
+	val lines = coveredLines.mapNotNull { docLine ->
 		val line = content.lines.getOrNull(docLine) ?: return@mapNotNull null
 		val from = if (docLine == range.start.line) range.start.char else 0
 		val to = if (docLine == range.end.line) range.end.char else line.length
 		val start = from.coerceIn(0, line.length)
 		val end = to.coerceIn(start, line.length)
-		HtmlLine(line.subSequence(start, end), docLine)
+		HtmlLine(
+			text = line.subSequence(start, end),
+			docLine = docLine,
+			isWholeLine = start == 0 && end == line.length,
+		)
 	}
+	// Only the lines being written can contribute a decoration, and a line-anchored
+	// span starts on the line it decorates, so the block scan reads the spans on
+	// those lines rather than every span in the document.
+	val spans = coveredLines
+		.flatMap { content.richSpansByLine[it].orEmpty() }
+		.filterTo(mutableSetOf()) { it.range.start.line in coveredLines }
 	return renderHtmlFragment(
 		lines = lines,
-		blocks = blocks,
-		headerLevels = headerLevelsOf(content.richSpans),
+		blocks = documentBlocksOf(spans, markdownConfiguration),
+		headerLevels = headerLevelsOf(spans),
 		configuration = markdownConfiguration,
 	)
 }

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/BuiltinEditorActions.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/input/BuiltinEditorActions.kt
@@ -7,6 +7,7 @@ import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.clipboard.ClipboardHelper
 import com.darkrockstudios.texteditor.clipboard.applyHtmlPasteBlocks
 import com.darkrockstudios.texteditor.clipboard.readHtmlPasteDocument
+import com.darkrockstudios.texteditor.html.selectionAsHtml
 import com.darkrockstudios.texteditor.input.EditorCommand.Action
 import com.darkrockstudios.texteditor.state.TextEditorState
 import com.darkrockstudios.texteditor.state.applyStyleForEditAt
@@ -76,9 +77,10 @@ internal fun EditorActionRegistry.registerBuiltinActions() {
 private fun EditorActionContext.copySelection() {
 	state.selector.selection?.let { selection ->
 		val selectedText = state.selector.getSelectedText()
+		val html = state.selectionAsHtml(selection)
 		val copyId = state.copyRichSpans(selection)
 		scope.launch {
-			ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
+			ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId, html)
 		}
 	}
 }
@@ -86,11 +88,14 @@ private fun EditorActionContext.copySelection() {
 private fun EditorActionContext.cutSelection() {
 	state.selector.selection?.let { selection ->
 		val selectedText = state.selector.getSelectedText()
+		// Both reads describe the document as it stands, so they have to happen
+		// before the delete takes the selection out from under them.
+		val html = state.selectionAsHtml(selection)
 		val copyId = state.copyRichSpans(selection)
 		state.preserveCopiedRichSpansThroughNextEdit()
 		state.selector.deleteSelection()
 		scope.launch {
-			ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId)
+			ClipboardHelper.setText(clipboard, selectedText, state.markdownConfiguration, copyId, html)
 		}
 	}
 }

--- a/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.desktop.kt
+++ b/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.desktop.kt
@@ -31,8 +31,11 @@ actual object ClipboardHelper {
 		text: AnnotatedString,
 		configuration: MarkdownConfiguration,
 		copyId: Long?,
+		html: String?,
 	) {
-		clipboard.setClipEntry(ClipEntry(AnnotatedStringTransferable(text, configuration, copyId)))
+		clipboard.setClipEntry(
+			ClipEntry(AnnotatedStringTransferable(text, configuration, copyId, html))
+		)
 	}
 
 	actual suspend fun readCopyId(clipboard: Clipboard): Long? {
@@ -73,17 +76,23 @@ actual object ClipboardHelper {
  * [copyId] identifies the copy that produced this content: pasting consults it
  * before re-applying the in-editor rich-span buffer, so identical text written
  * by any other source can never resurrect stale spans.
+ *
+ * [blockHtml] is the markup to offer. An [AnnotatedString] carries character
+ * styling alone, so deriving the fragment from it describes a selection with no
+ * lists, quotes or headings; a caller copying out of an editor passes markup
+ * built from the document's line-anchored spans instead.
  */
 internal class AnnotatedStringTransferable(
 	private val annotatedString: AnnotatedString,
 	private val configuration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT,
 	private val copyId: Long? = null,
+	private val blockHtml: String? = null,
 ) : Transferable {
 
 	private val annotatedStringFlavor = DataFlavor(AnnotatedString::class.java, "AnnotatedString")
 	private val htmlFlavor = DataFlavor("text/html;class=java.lang.String;charset=Unicode")
 
-	private val html by lazy { annotatedString.toHtml(configuration) }
+	private val html by lazy { blockHtml ?: annotatedString.toHtml(configuration) }
 
 	override fun getTransferDataFlavors(): Array<DataFlavor> = buildList {
 		add(annotatedStringFlavor)

--- a/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHtml.desktop.kt
+++ b/ComposeTextEditor/src/desktopMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHtml.desktop.kt
@@ -2,19 +2,16 @@ package com.darkrockstudios.texteditor.clipboard
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.Clipboard
-import androidx.compose.ui.text.AnnotatedString
-import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
 
 @OptIn(ExperimentalComposeUiApi::class)
 internal actual suspend fun readClipboardHtml(clipboard: Clipboard): String? {
 	val transferable = clipboard.getClipEntry()?.nativeClipEntry as? Transferable ?: return null
-	// An in-process copy carries its blocks through the editor's own rich-span
-	// buffer, and its AnnotatedString flavor is what `getText` returns, so the
-	// HTML it also offers would describe text the caller never received.
-	if (transferable.isDataFlavorSupported(DataFlavor(AnnotatedString::class.java, "AnnotatedString"))) {
-		return null
-	}
+	// An in-process copy is read here too, not just foreign markup. Its rich-span
+	// buffer only survives as far as the next edit, and the HTML is what carries
+	// its blocks after that; the two agree, and applying a block a line already
+	// carries is a no-op. The caller still checks the markup re-parses to the text
+	// it was handed, which is what rejects a flavor describing something else.
 	return runCatching {
 		val flavor = transferable.transferDataFlavors.firstOrNull {
 			it.mimeType.startsWith("text/html") && it.representationClass == String::class.java

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/ClipboardBlockStructureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/ClipboardBlockStructureE2eTest.kt
@@ -1,0 +1,167 @@
+package e2e
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
+import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import kotlinx.coroutines.runBlocking
+import utils.EditorUiTestScope
+import utils.editorUiTest
+import java.awt.datatransfer.Transferable
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The block structure of a copied selection, which lives in line-anchored rich
+ * spans rather than in the copied `AnnotatedString`.
+ *
+ * The in-process span buffer covers a copy pasted straight back into the same
+ * editor, and nothing else: it is invalidated by any intervening edit and cannot
+ * reach another application at all. These specs pin the clipboard's HTML flavor,
+ * which is what carries blocks everywhere the buffer does not.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class ClipboardBlockStructureE2eTest {
+
+	private val document = "Intro line\n\n- First item\n- Second item\n\n> A quoted line\n\nEnd."
+
+	private fun TextEditorState.linesWith(style: RichSpanStyle): List<Int> =
+		richSpanManager.getAllRichSpans()
+			.filter { it.style === style }
+			.map { it.range.start.line }
+			.sorted()
+
+	/** The markup the clipboard offers other applications. */
+	private fun EditorUiTestScope.clipboardHtml(): String = runBlocking {
+		val transferable = clipboard.getClipEntry()?.nativeClipEntry as? Transferable
+			?: error("clipboard holds nothing")
+		val flavor = transferable.transferDataFlavors.firstOrNull {
+			it.mimeType.startsWith("text/html") && it.representationClass == String::class.java
+		} ?: error("clipboard offers no text/html flavor")
+		transferable.getTransferData(flavor) as String
+	}
+
+	private fun EditorUiTestScope.selectRange(from: Int, to: Int) {
+		clickAtCharacter(from)
+		clickAtCharacter(to, shift = true)
+	}
+
+	@Test
+	fun `copied html carries list and quote markup`() = editorUiTest(width = 600.dp, height = 500.dp) {
+		markdown.importMarkdown(document)
+		waitForIdle()
+
+		val from = text.indexOf("First item")
+		val to = text.indexOf("A quoted line") + "A quoted line".length
+		selectRange(from, to)
+		press(Key.C, ctrl = true)
+		waitForIdle()
+
+		val html = clipboardHtml()
+		assertTrue(
+			"<ul>" in html && "<li>First item</li>" in html && "<li>Second item</li>" in html,
+			"copied HTML must carry the list, got: $html",
+		)
+		assertTrue(
+			"<blockquote>" in html,
+			"copied HTML must carry the blockquote, got: $html",
+		)
+	}
+
+	@Test
+	fun `a partially copied list item is still a list item`() =
+		editorUiTest(width = 600.dp, height = 500.dp) {
+			markdown.importMarkdown(document)
+			waitForIdle()
+
+			// Mid-way through the first item to mid-way through the quote line: every
+			// covered line is a fragment, which is what a mouse drag usually produces.
+			val from = text.indexOf("First item") + 3
+			val to = text.indexOf("A quoted line") + 5
+			selectRange(from, to)
+			press(Key.C, ctrl = true)
+			waitForIdle()
+
+			val html = clipboardHtml()
+			assertTrue("<li>st item</li>" in html, "partial item must stay a list item, got: $html")
+			assertTrue("<blockquote>" in html, "partial quote must stay quoted, got: $html")
+		}
+
+	@Test
+	fun `blocks survive a paste after an intervening edit invalidated the span buffer`() =
+		editorUiTest(width = 600.dp, height = 500.dp) {
+			markdown.importMarkdown(document)
+			waitForIdle()
+
+			val from = text.indexOf("First item")
+			val to = text.indexOf("A quoted line") + "A quoted line".length
+			selectRange(from, to)
+			press(Key.C, ctrl = true)
+			waitForIdle()
+
+			// Open a fresh line at the end. This edit clears the in-process rich-span
+			// buffer, leaving the clipboard's HTML as the only carrier of the blocks.
+			clickAtCharacter(text.length)
+			press(Key.Enter)
+			press(Key.V, ctrl = true)
+			waitForIdle()
+
+			assertEquals(
+				listOf(2, 3, 8, 9),
+				state.linesWith(BulletListSpanStyle),
+				"pasted list items must keep their bullets",
+			)
+			assertEquals(
+				listOf(5, 11),
+				state.linesWith(BlockquoteSpanStyle),
+				"the pasted quote must keep its blockquote",
+			)
+		}
+
+	@Test
+	fun `pasting the copied markup into a second editor keeps the blocks`() {
+		// Copy in one editor, capture what it put on the clipboard.
+		var copied: Transferable? = null
+		editorUiTest(width = 600.dp, height = 500.dp) {
+			markdown.importMarkdown(document)
+			waitForIdle()
+			val from = text.indexOf("First item")
+			val to = text.indexOf("A quoted line") + "A quoted line".length
+			selectRange(from, to)
+			press(Key.C, ctrl = true)
+			waitForIdle()
+			copied = runBlocking { clipboard.getClipEntry()?.nativeClipEntry as? Transferable }
+		}
+
+		// Offer only the HTML to a fresh editor, the way another application would:
+		// no AnnotatedString flavor, no copy id, no in-process span buffer.
+		val flavor = copied!!.transferDataFlavors.first {
+			it.mimeType.startsWith("text/html") && it.representationClass == String::class.java
+		}
+		val html = copied!!.getTransferData(flavor) as String
+
+		editorUiTest(width = 600.dp, height = 500.dp) {
+			clipboard.seed(
+				androidx.compose.ui.platform.ClipEntry(utils.ForeignHtmlTransferable(html))
+			)
+			waitForIdle()
+			press(Key.V, ctrl = true)
+			waitForIdle()
+
+			assertEquals(
+				listOf(0, 1),
+				state.linesWith(BulletListSpanStyle),
+				"a list pasted from foreign markup must arrive as a list, document was: $lines",
+			)
+			assertEquals(
+				listOf(3),
+				state.linesWith(BlockquoteSpanStyle),
+				"a quote pasted from foreign markup must arrive quoted, document was: $lines",
+			)
+		}
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/e2e/ClipboardBlockStructureE2eTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/e2e/ClipboardBlockStructureE2eTest.kt
@@ -3,12 +3,15 @@ package e2e
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.ClipEntry
 import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
 import com.darkrockstudios.texteditor.richstyle.BulletListSpanStyle
+import com.darkrockstudios.texteditor.richstyle.HeaderSpanStyle
 import com.darkrockstudios.texteditor.richstyle.RichSpanStyle
 import com.darkrockstudios.texteditor.state.TextEditorState
 import kotlinx.coroutines.runBlocking
 import utils.EditorUiTestScope
+import utils.ForeignHtmlTransferable
 import utils.editorUiTest
 import java.awt.datatransfer.Transferable
 import kotlin.test.Test
@@ -123,6 +126,56 @@ class ClipboardBlockStructureE2eTest {
 		}
 
 	@Test
+	fun `copying part of a styled run does not make it a heading`() =
+		editorUiTest(width = 600.dp, height = 500.dp) {
+			markdown.importMarkdown("Some **bold** text.")
+			waitForIdle()
+
+			// Every fragment of a styled run is uniformly styled, and the default h4
+			// is bold at the body size, so a size match cannot tell the two apart.
+			val from = text.indexOf("bold")
+			selectRange(from, from + "bold".length)
+			press(Key.C, ctrl = true)
+			waitForIdle()
+
+			val html = clipboardHtml()
+			assertTrue("<h4>" !in html, "a bold fragment must not serialize as a heading, got: $html")
+			assertTrue("<strong>bold</strong>" in html, "expected bold markup, got: $html")
+
+			// And it must not turn into one on the way back in either.
+			clickAtCharacter(text.length)
+			press(Key.Enter)
+			press(Key.V, ctrl = true)
+			waitForIdle()
+
+			assertTrue(
+				state.richSpanManager.getAllRichSpans().none { it.style is HeaderSpanStyle },
+				"pasting a bold fragment must not add a heading, got: ${markdown.exportAsMarkdown()}",
+			)
+		}
+
+	@Test
+	fun `cut captures the markup before the delete`() =
+		editorUiTest(width = 600.dp, height = 500.dp) {
+			markdown.importMarkdown(document)
+			waitForIdle()
+
+			val from = text.indexOf("First item")
+			val to = text.indexOf("Second item") + "Second item".length
+			selectRange(from, to)
+			press(Key.X, ctrl = true)
+			waitForIdle()
+
+			// The selection is gone from the document, so markup gathered after the
+			// delete would describe lines that no longer carry the list.
+			val html = clipboardHtml()
+			assertTrue(
+				"<li>First item</li>" in html && "<li>Second item</li>" in html,
+				"cut must put the pre-delete list on the clipboard, got: $html",
+			)
+		}
+
+	@Test
 	fun `pasting the copied markup into a second editor keeps the blocks`() {
 		// Copy in one editor, capture what it put on the clipboard.
 		var copied: Transferable? = null
@@ -145,9 +198,7 @@ class ClipboardBlockStructureE2eTest {
 		val html = copied!!.getTransferData(flavor) as String
 
 		editorUiTest(width = 600.dp, height = 500.dp) {
-			clipboard.seed(
-				androidx.compose.ui.platform.ClipEntry(utils.ForeignHtmlTransferable(html))
-			)
+			clipboard.seed(ClipEntry(ForeignHtmlTransferable(html)))
 			waitForIdle()
 			press(Key.V, ctrl = true)
 			waitForIdle()

--- a/ComposeTextEditor/src/iosMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.ios.kt
+++ b/ComposeTextEditor/src/iosMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.ios.kt
@@ -24,6 +24,7 @@ actual object ClipboardHelper {
 		text: AnnotatedString,
 		configuration: MarkdownConfiguration,
 		copyId: Long?,
+		html: String?,
 	) {
 		UIPasteboard.generalPasteboard.string = text.text
 	}

--- a/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.wasmJs.kt
+++ b/ComposeTextEditor/src/wasmJsMain/kotlin/com/darkrockstudios/texteditor/clipboard/ClipboardHelper.wasmJs.kt
@@ -28,6 +28,7 @@ actual object ClipboardHelper {
 		text: AnnotatedString,
 		configuration: MarkdownConfiguration,
 		copyId: Long?,
+		html: String?,
 	) {
 		try {
 			writeClipboardText(text.text).await<JsAny?>()

--- a/docs/qa/manual-qa-plan.md
+++ b/docs/qa/manual-qa-plan.md
@@ -1,0 +1,395 @@
+# Manual QA plan: v2.3.1 → next release
+
+Covers the 47 commits landed on `main` since `v2.3.1`. Each section names the PRs it
+guards so a failure can be traced back to the change that introduced the risk.
+
+Run everything in the **sample app** (`:sampleApp`) unless a step says otherwise. The
+demos referenced by name are the buttons on the home menu: Rich Text Editor, Markdown
+Text Editor, Markdown Editor (Blank), Spell Check, Code Editor, Find Demo,
+RichTextView.
+
+## 0. Pre-flight (automated, before any manual work)
+
+| Check | Command | Gate |
+| --- | --- | --- |
+| Full multiplatform build + tests | `./gradlew check` | Green. Catches iOS/wasm breakage that desktop tests miss. |
+| Desktop e2e/torture suites | `./gradlew :ComposeTextEditor:desktopTest` | Green, no flakes on a second run. |
+| Spell check module | `./gradlew :ComposeTextEditorSpellCheck:desktopTest` | Green. |
+| Wasm demo builds | `./gradlew :sampleApp:updateDemo` | Produces a loadable demo. |
+
+If any of these are red, stop: the manual pass is not meaningful yet.
+
+## 1. Platform matrix
+
+The changes are not evenly distributed across platforms. Suggested effort:
+
+| Platform | Depth | Why |
+| --- | --- | --- |
+| **Desktop (Windows)** | Full pass | Only platform with the HTML clipboard flavor and the copy-id provenance check (#38, #50, #79). AltGr fix is Windows-specific (#53). |
+| **Desktop (macOS)** | Full pass of §2 + §3, smoke the rest | Cmd-based key bindings (#45) and Option chords have no other coverage. |
+| **Android** | Full pass of §3, §4, §7 + smoke the rest | Touch focus rework (#88), IME routing through the behavior chain (#87), and the indented text-left fix (#91) are all Android-only paths. |
+| **Desktop (Linux)** | Smoke | Shares the desktop code path with Windows minus AltGr. |
+| **iOS** | Smoke | Only clipboard `expect/actual` and key-binding stubs changed. |
+| **wasmJs** | Smoke | Same. Run against the built demo, not a dev server, so the release artifact is what gets tested. |
+
+Smoke = §8 only.
+
+## 2. Clipboard and rich copy/paste
+
+Guards #38, #50, #79, #74, #49, #48.
+
+**Highest-risk area in this release.** Desktop copy now attaches a process-unique copy
+id, and paste only re-applies the in-editor span buffer when that id matches.
+
+### 2.1 Round-trip inside the editor (desktop, Android)
+1. Markdown demo. Select a range covering a bold word, a bulleted list item, and a
+   blockquote line.
+2. Ctrl/Cmd+C, click at the end of the document, Ctrl/Cmd+V.
+3. **Expect:** styling, bullets, and the quote marker all survive. Nothing is stacked
+   twice on a line.
+4. Repeat with Ctrl/Cmd+X instead of copy: original range is removed cleanly, with no
+   orphaned gutter markers left on the line.
+
+### 2.2 Partial-span copy does not drag markers (#74)
+1. Markdown demo. Select **part of the text inside** a bullet list item (not the whole
+   item).
+2. Copy, then paste **into the middle of** a plain paragraph line, and into the middle
+   of a line that is already a blockquote.
+3. **Expect:** pasted content is plain text. No bullet appears on the target line, and
+   the blockquote line does not gain a stacked bullet marker.
+4. Now paste the same fragment onto an **empty line of its own**. **Expect:** it
+   arrives as a bullet item. A block is applied only when the pasted text becomes a
+   whole line; spliced into an existing line it never is.
+
+### 2.2b Blocks survive an edit between copy and paste
+The in-editor rich-span buffer is cleared by any edit that is not the paste's own, so
+this exercises the clipboard's HTML as the block carrier.
+1. Markdown demo. Select whole lines covering two bullet items and a blockquote line.
+   Copy.
+2. Click at the end of the document and press **Enter** to open a fresh line.
+3. Paste.
+4. **Expect:** the bullets and the blockquote all arrive intact. Getting plain text
+   here is the regression this guards.
+
+### 2.3 Foreign clipboard cannot resurrect the span buffer (#79)
+1. Desktop. In the editor, copy a styled run (say a bold, bulleted line).
+2. Switch to Notepad / TextEdit / a browser, type the **exact same characters** as the
+   copied text, and copy them there.
+3. Return to the editor and paste.
+4. **Expect:** plain, unstyled text. The earlier in-editor styling must not come back.
+5. Variant: open **two** sample app instances, copy in one, paste in the other.
+   **Expect:** the text arrives (via HTML/plain flavors) but the second instance does
+   not reapply the first instance's span buffer verbatim.
+
+### 2.4 Cross-application rich paste (desktop) (#38, #50)
+1. Copy a bulleted list from a browser page (a Wikipedia list works).
+2. Paste into the Markdown demo. **Expect:** arrives as a bulleted list, not as literal
+   `-` characters or as a single paragraph.
+3. Copy a heading + bold paragraph from a word processor. **Expect:** heading level and
+   bold survive.
+4. Reverse direction: copy a selection covering **bullets, a blockquote and a heading**
+   out of the editor and paste into a browser rich-text field or word processor.
+   **Expect:** the list arrives as a list, the quote as a quote, the heading at its
+   level; no raw HTML markup text. Blocks arriving as flat paragraphs is the
+   regression this guards.
+5. Bold body text pasted out must **not** land as an `<h4>` in the target app.
+
+### 2.5 Paste font size (#49)
+1. Markdown demo. Place the caret at **offset 0** (very start of the document) and
+   paste some copied text.
+2. **Expect:** pasted text renders at the same size as the surrounding body text, not
+   smaller.
+3. Select the entire first paragraph and paste over it. **Expect:** same, correctly
+   sized.
+4. In the Blank Markdown demo (empty document, never typed into), paste immediately.
+   **Expect:** correctly sized.
+
+### 2.6 Context menu parity (#87, #50)
+1. Right-click in the editor with a selection: Cut / Copy / Paste / Select All.
+2. **Expect:** each does exactly what its keyboard chord does, including keeping list
+   and quote styling on copy.
+3. Right-click with **no** selection. **Expect:** Cut/Copy appear disabled (or hidden)
+   rather than doing something destructive; the menu is never empty.
+4. RichTextView demo (read-only): right-click. **Expect:** Copy and Select All work,
+   editing actions are absent or disabled. Typing changes nothing.
+
+### 2.7 Export while editing (#48)
+1. Markdown demo. Hold down a key to type continuously and click **Roundtrip** during
+   the typing burst (or trigger export from another thread if you have a harness).
+2. **Expect:** no `ConcurrentModificationException`, no interleaved/garbled export.
+
+## 3. Key bindings and input
+
+Guards #45, #53, #87.
+
+### 3.1 macOS bindings (#45)
+On macOS, verify each:
+
+| Chord | Expected |
+| --- | --- |
+| Cmd+C / Cmd+V / Cmd+X | Copy / paste / cut |
+| Cmd+A | Select all |
+| Cmd+Z / Cmd+Shift+Z | Undo / redo |
+| Option+Left / Option+Right | Word-wise motion |
+| Cmd+Left / Cmd+Right | Line start / line end |
+| Cmd+Up / Cmd+Down | Document start / end |
+| Option+Backspace | Delete previous word |
+| Cmd+Backspace | Delete to line start |
+| Option+8 | Types `{` (unclaimed Option chords must fall through to text) |
+
+After **Option+Backspace** and **Cmd+Backspace**, press Cmd+Z. **Expect:** the deleted
+text returns *and the caret lands at the correct end of it* (this was the undo defect
+fixed alongside #45).
+
+### 3.2 AltGr on Windows (#53)
+Requires a layout with AltGr: switch the Windows input to Hungarian or Polish.
+1. Hungarian: AltGr+X, AltGr+V. **Expect:** the accented characters are typed. Nothing
+   is cut or pasted.
+2. Polish: AltGr+Z. **Expect:** `ż` typed, not an undo.
+3. With the US layout restored, plain Ctrl+X/V/Z still work.
+
+### 3.3 Custom action binding (#87)
+The sample app registers Ctrl+B (Cmd+B on macOS) for bold as the worked example.
+1. Markdown demo. Select a word, press Ctrl/Cmd+B. **Expect:** bold toggles on; the
+   toolbar Bold button lights up.
+2. Press it again. **Expect:** bold toggles off.
+3. Toggle bold from the **toolbar button** and confirm the chord and the button agree
+   (they share one implementation).
+4. Navigate back to the home menu and re-enter the demo a few times. **Expect:** the
+   chord still works and is registered exactly once (the `DisposableEffect`
+   unregister path).
+5. Press an unbound Ctrl chord (say Ctrl+J). **Expect:** nothing happens and the editor
+   does not become unresponsive; the keystroke is not silently swallowed into text.
+
+### 3.4 Read-only enforcement (#87)
+1. RichTextView demo. Attempt paste (Ctrl+V), Ctrl+B, backspace, Enter.
+2. **Expect:** the document is unchanged by every one of them. Copy and selection still
+   work.
+
+## 4. Touch, focus and the soft keyboard (Android)
+
+Guards #88, #91. **Android device or emulator required.** Use the Markdown demo, which
+was lengthened specifically so it can be scrolled and flung.
+
+### 4.1 Pan does not raise the keyboard
+1. Fresh entry into the demo, keyboard down.
+2. Drag a finger on the **text** to scroll. **Expect:** the document scrolls and the
+   keyboard stays down.
+3. Fling hard. **Expect:** momentum scrolling works, i.e. the fling is not cancelled
+   mid-flight.
+4. Scroll to the bullets / blockquote / code fence far below the fold and confirm they
+   render correctly after a long scroll.
+
+### 4.2 Tap focuses
+1. Tap on a plain paragraph. **Expect:** caret placed, keyboard rises.
+2. Tap on a **bulleted list item** and on a **blockquote line**. **Expect:** both focus
+   and raise the keyboard (these were unfocusable at one point during the PR).
+3. Long-press a word. **Expect:** the word selects, handles appear, and the keyboard
+   does **not** slide up over the selection handles. Then type: the selection is
+   replaced.
+4. Tap right next to a selection handle. **Expect:** focus and caret placement, not a
+   swallowed tap.
+
+### 4.3 Spans do not fight the keyboard
+1. Spell Check demo. Tap a **misspelled** word. **Expect:** the suggestion popup opens
+   and the keyboard does not rise over it.
+2. Tap a **correctly spelled** word. **Expect:** ordinary caret placement + keyboard.
+   No context menu appears for a word with nothing to suggest.
+3. Markdown demo: tap a **link** span. **Expect:** the host click listener fires; no
+   keyboard slides up over whatever it opened.
+
+### 4.4 Indented lines draw correctly (#91)
+This is the Android-only `getLineLeft` fix. Compare side by side with desktop.
+1. Markdown demo, on Android: place the caret on an **empty** bulleted list item (press
+   Enter at the end of an item to make one).
+2. **Expect:** the caret sits just after the bullet marker, indented **once**, not
+   double-indented.
+3. **Expect:** the bullet and ordered-list numbers draw in the gutter at the correct
+   indent, not flush against the left canvas edge.
+4. Check the same for: highlight decorations, spell-check squiggles, and Find match
+   highlights on indented lines (use the Find demo, search for a term inside a list
+   item).
+5. Tap-to-place-caret on an indented line lands where you tapped (bounding boxes go
+   through the same helper).
+
+### 4.5 IME edits behave like hardware keys (#87)
+Soft keyboard only:
+1. Backspace at **column 0** of a bulleted list item. **Expect:** the item demotes to a
+   plain line (same as the hardware key), and Ctrl+Z / the Undo button restores it.
+2. Backspace at column 0 of an item **on the first line** of the document. **Expect:**
+   same demotion, no no-op.
+3. Press Enter on an **empty** list item. **Expect:** the block exits to a plain line.
+4. Type a word, let autocorrect replace it. **Expect:** the replacement lands correctly
+   and the caret/keyboard state stays in sync (no doubled or dropped characters).
+5. Use the keyboard's forward-delete if available. **Expect:** it deletes forward.
+6. Type with a swipe/gesture keyboard across a list item boundary. **Expect:** no
+   duplicated text, no caret jumping backwards.
+
+## 5. Line blocks, markdown and HTML semantics
+
+Guards #57, #63, #66–#74, #78, #80.
+
+### 5.1 Round-trip fidelity (the Roundtrip button)
+Markdown demo has a **Roundtrip** button that exports to markdown and re-imports.
+Press it after each of these and confirm the document is unchanged:
+
+1. Baseline demo document, untouched.
+2. A **bold run with trailing whitespace** (select `word ` including the space, bold
+   it). Roundtrip: **expect** the bold survives and no literal `**` characters appear
+   (#70).
+3. A **bold run overlapping an inline code span**. Roundtrip: **expect** no asterisks
+   leak inside the backticks, and a second roundtrip is stable (#73).
+4. **Headings**: set H1 through H6 with the toolbar `H` cycle button. Roundtrip:
+   **expect** every level preserved.
+5. Headings + font size change: apply H2, then press the font-size **increase** button
+   twice, then Roundtrip. **Expect:** the line is still an H2 (headings no longer
+   reverse-match on font size) (#78).
+6. **Links**: select text, click the Link toolbar button, enter `https://example.com`.
+   Roundtrip: **expect** the link text *and* URL survive. Click the Link button again
+   on that text: **expect** the dialog pre-fills the existing URL (#80).
+7. Underline some text with **no** link. Roundtrip: **expect** no empty `[]()` link is
+   fabricated (#80).
+8. Lists, nested-looking lists, blockquotes, code fences, horizontal rules, and images
+   all survive a roundtrip.
+
+### 5.2 Block stacking and joins (#57, #63, #72)
+1. Put the caret on a bulleted item, click Blockquote. **Expect:** a consistent result
+   (quote + list resolved by one rule), identical to what importing the equivalent
+   markdown produces.
+2. Place the caret at the **start** of a list item and press Backspace to join it with
+   the line above (a plain paragraph). **Expect:** the joined line does not keep the
+   bullet marker.
+3. Join two **adjacent items of the same kind** (delete the newline between them).
+   **Expect:** they rejoin as one item, marker intact.
+4. Delete an item's **last character** without deleting the line. **Expect:** the item
+   survives as an empty item with its marker.
+5. Select across a **code fence and a blockquote** and delete. **Expect:** the joined
+   line has one block kind, not two stacked, and no crash.
+6. Forward-delete (Del) at the end of a plain line whose next line is a list item.
+   **Expect:** the marker is not dragged onto the plain line.
+
+### 5.3 Editing at block boundaries (#67, #68, #66)
+1. Create a code fence directly above a blockquote. Delete the newline between them to
+   join. Then **type a character exactly at the join point**. **Expect:** no crash
+   (this was an `AnnotatedString` overlapping-paragraph exception).
+2. Select a range **spanning multiple lines** inside a list and type over it (replace).
+   **Expect:** the typed text appears; the replacement is not dropped. Then Undo:
+   **expect** the original returns with no crash.
+3. Select an entire list item's text (within the line) and paste over it. **Expect:**
+   the bullet marker stays anchored at column 0.
+4. Select from the start of an item and replace. **Expect:** the marker does not detach
+   from column 0.
+
+### 5.4 Style span adjacency (#69)
+1. Type `bold X bold` where the two `bold` words are already bold and `X` is not.
+2. Apply bold anywhere else on the same line.
+3. **Expect:** the single unstyled character between the two bold runs stays unstyled
+   (styles must not bridge a one-character gap).
+
+## 6. Undo and redo
+
+Guards #75, #71, #55, #45.
+
+### 6.1 Wordwise coalescing (#75)
+1. Blank Markdown demo. Type `the quick brown fox` in one go.
+2. Press Ctrl/Cmd+Z once. **Expect:** one *word* disappears, not one character.
+3. Keep undoing to empty, then redo back up. **Expect:** redo restores word by word and
+   ends at exactly the typed text.
+4. Type a word, press Enter, type another word. Undo. **Expect:** the newline breaks
+   the run (undo does not swallow across it).
+5. Type a word, **click elsewhere with the mouse**, type another word. Undo. **Expect:**
+   the click broke the run.
+6. Type a word, then **paste**. Undo. **Expect:** the paste undoes as its own entry and
+   is not merged with the typing.
+7. Hold Backspace across several words. Undo. **Expect:** the deletion returns
+   word-wise, not character-by-character.
+
+### 6.2 History depth (#75)
+1. Blank demo. Type continuously for ~30 seconds (or paste-and-edit repeatedly to build
+   well over 100 entries).
+2. Undo repeatedly. **Expect:** you can get back to the empty document; early edits
+   were not silently dropped (the cap is now 1000).
+
+### 6.3 Undo of block operations (#71, #55)
+1. Backspace at column 0 of a list item (smart demotion). Ctrl/Cmd+Z. **Expect:** the
+   item comes back. Undo must **not** skip past to an earlier edit.
+2. Press Enter on an empty list item (block exit). Undo. **Expect:** the empty item is
+   restored.
+3. Load the demo document (rich, with bullets, quotes, fences, a rule, and an image).
+   Type a character somewhere, then Undo.
+   **Expect:** every rich span in the document is still there. This is the #55
+   regression: undo of an insert previously wiped all of them.
+4. Redo the same insert. **Expect:** spans still intact.
+
+## 7. Spell check
+
+Guards #89, #90, #65, #83.
+
+1. Spell Check demo. Type a misspelled word. **Expect:** a squiggle appears after the
+   normal debounce.
+2. Fix the word. **Expect:** the squiggle clears.
+3. Right-click (desktop) / tap (Android) the misspelled word. **Expect:** suggestions;
+   picking one replaces the word and clears the squiggle.
+4. Toggle spell checking off and immediately back on while typing. **Expect:** no stuck
+   squiggles on correct words, no missing squiggles on wrong ones.
+5. **Guard removal check (#90):** paste a large block of text that is almost entirely
+   nonsense words (or switch the checker to a language the text is not in).
+   **Expect:** every word gets squiggled and the editor stays responsive. Checking must
+   **not** suspend itself, and there is no "resume" state to get stuck in.
+6. Scroll a long spell-checked document quickly. **Expect:** smooth scrolling; squiggles
+   render correctly deep in the document, not just near the top (#65).
+
+## 8. Performance and smoke pass
+
+Guards #83, #84, #85, #86, #56, #60, #65. This is also the **smoke list** for the
+lower-depth platforms in §1.
+
+1. App launches, home menu renders, every demo opens and closes without error.
+2. Markdown demo: typing feels immediate. Type a long paragraph at the **bottom** of a
+   long document. **Expect:** no growing per-keystroke lag as the document gets longer.
+3. Scroll a long document top to bottom. **Expect:** no jank, block decorations
+   (bullets, numbers, quote bars, fences, rules, images) all draw at the right place at
+   every scroll position.
+4. Load / roundtrip a large markdown document (a few hundred lines with many list
+   items). **Expect:** import is fast and does not visibly hitch (this was quadratic
+   before #56).
+5. Import a document with **no** blocks at all (plain paragraphs only). **Expect:**
+   fast, no second layout pass.
+6. Resize the window (desktop) / rotate the device (Android). **Expect:** re-wrap is
+   correct, decorations follow the new wrap, caret stays with its character.
+7. Code Editor demo: syntax decorations render and follow edits.
+8. Find demo: Ctrl+F, search a term with many hits, step through matches. **Expect:**
+   highlights land on the right characters, including on indented lines.
+9. Undo/redo toolbar buttons enable and disable correctly as history is consumed.
+10. Dark mode toggle: everything remains legible.
+
+## 9. Consumer API sanity
+
+Guards #82, #48, #87, #90. Not strictly manual UI testing, but worth one pass before
+tagging, since these change what downstream code compiles against.
+
+1. `TextEditorState` now has **identity** equality; content comparison moved to
+   `contentEquals()` (#82). Check the release notes call this out: any consumer using a
+   state as a `remember` key, a map key, or in an `==` comparison changes behavior.
+2. `DocumentSnapshot` and `TextEditorState.snapshot()` are public (#48): confirm they
+   are documented and appear in the Dokka output.
+3. New public surface to spot-check in the API docs: `KeyBindings`, `LocalKeyBindings`,
+   `platformKeyBindings`, `isCtrlShortcut`, `EditorCommand.Action` + `Builtins`,
+   `EditorActionRegistry`, `EditBehavior`, the `keyBindings` parameter on both editor
+   composables, `LinkSpanStyle` / `setLink` / `linkAt`, `HeaderSpanStyle`.
+4. `SpellCheckState` / `rememberSpellCheckState` lost their guard parameters and
+   `resumeSpellChecking` (#90). None of it shipped in a release, so no migration note
+   is needed, but confirm nothing in the sample app or docs still references them.
+5. Run `./gradlew updateDocs` and confirm Dokka generates cleanly with the new symbols.
+
+## Sign-off
+
+| Area | Windows | macOS | Linux | Android | iOS | wasm |
+| --- | --- | --- | --- | --- | --- | --- |
+| §2 Clipboard | | | | | | |
+| §3 Key bindings | | | | | | |
+| §4 Touch / focus | n/a | n/a | n/a | | | n/a |
+| §5 Blocks / markdown | | | | | | |
+| §6 Undo / redo | | | | | | |
+| §7 Spell check | | | | | | |
+| §8 Perf / smoke | | | | | | |

--- a/docs/qa/manual-qa-plan.md
+++ b/docs/qa/manual-qa-plan.md
@@ -42,6 +42,7 @@ Guards #38, #50, #79, #74, #49, #48.
 id, and paste only re-applies the in-editor span buffer when that id matches.
 
 ### 2.1 Round-trip inside the editor (desktop, Android)
+
 1. Markdown demo. Select a range covering a bold word, a bulleted list item, and a
    blockquote line.
 2. Ctrl/Cmd+C, click at the end of the document, Ctrl/Cmd+V.
@@ -51,6 +52,7 @@ id, and paste only re-applies the in-editor span buffer when that id matches.
    orphaned gutter markers left on the line.
 
 ### 2.2 Partial-span copy does not drag markers (#74)
+
 1. Markdown demo. Select **part of the text inside** a bullet list item (not the whole
    item).
 2. Copy, then paste **into the middle of** a plain paragraph line, and into the middle
@@ -62,8 +64,10 @@ id, and paste only re-applies the in-editor span buffer when that id matches.
    whole line; spliced into an existing line it never is.
 
 ### 2.2b Blocks survive an edit between copy and paste
+
 The in-editor rich-span buffer is cleared by any edit that is not the paste's own, so
 this exercises the clipboard's HTML as the block carrier.
+
 1. Markdown demo. Select whole lines covering two bullet items and a blockquote line.
    Copy.
 2. Click at the end of the document and press **Enter** to open a fresh line.
@@ -72,6 +76,7 @@ this exercises the clipboard's HTML as the block carrier.
    here is the regression this guards.
 
 ### 2.3 Foreign clipboard cannot resurrect the span buffer (#79)
+
 1. Desktop. In the editor, copy a styled run (say a bold, bulleted line).
 2. Switch to Notepad / TextEdit / a browser, type the **exact same characters** as the
    copied text, and copy them there.
@@ -82,6 +87,7 @@ this exercises the clipboard's HTML as the block carrier.
    not reapply the first instance's span buffer verbatim.
 
 ### 2.4 Cross-application rich paste (desktop) (#38, #50)
+
 1. Copy a bulleted list from a browser page (a Wikipedia list works).
 2. Paste into the Markdown demo. **Expect:** arrives as a bulleted list, not as literal
    `-` characters or as a single paragraph.
@@ -95,6 +101,7 @@ this exercises the clipboard's HTML as the block carrier.
 5. Bold body text pasted out must **not** land as an `<h4>` in the target app.
 
 ### 2.5 Paste font size (#49)
+
 1. Markdown demo. Place the caret at **offset 0** (very start of the document) and
    paste some copied text.
 2. **Expect:** pasted text renders at the same size as the surrounding body text, not
@@ -105,6 +112,7 @@ this exercises the clipboard's HTML as the block carrier.
    **Expect:** correctly sized.
 
 ### 2.6 Context menu parity (#87, #50)
+
 1. Right-click in the editor with a selection: Cut / Copy / Paste / Select All.
 2. **Expect:** each does exactly what its keyboard chord does, including keeping list
    and quote styling on copy.
@@ -114,6 +122,7 @@ this exercises the clipboard's HTML as the block carrier.
    editing actions are absent or disabled. Typing changes nothing.
 
 ### 2.7 Export while editing (#48)
+
 1. Markdown demo. Hold down a key to type continuously and click **Roundtrip** during
    the typing burst (or trigger export from another thread if you have a harness).
 2. **Expect:** no `ConcurrentModificationException`, no interleaved/garbled export.
@@ -123,6 +132,7 @@ this exercises the clipboard's HTML as the block carrier.
 Guards #45, #53, #87.
 
 ### 3.1 macOS bindings (#45)
+
 On macOS, verify each:
 
 | Chord | Expected |
@@ -142,14 +152,18 @@ text returns *and the caret lands at the correct end of it* (this was the undo d
 fixed alongside #45).
 
 ### 3.2 AltGr on Windows (#53)
+
 Requires a layout with AltGr: switch the Windows input to Hungarian or Polish.
+
 1. Hungarian: AltGr+X, AltGr+V. **Expect:** the accented characters are typed. Nothing
    is cut or pasted.
 2. Polish: AltGr+Z. **Expect:** `ż` typed, not an undo.
 3. With the US layout restored, plain Ctrl+X/V/Z still work.
 
 ### 3.3 Custom action binding (#87)
+
 The sample app registers Ctrl+B (Cmd+B on macOS) for bold as the worked example.
+
 1. Markdown demo. Select a word, press Ctrl/Cmd+B. **Expect:** bold toggles on; the
    toolbar Bold button lights up.
 2. Press it again. **Expect:** bold toggles off.
@@ -162,6 +176,7 @@ The sample app registers Ctrl+B (Cmd+B on macOS) for bold as the worked example.
    does not become unresponsive; the keystroke is not silently swallowed into text.
 
 ### 3.4 Read-only enforcement (#87)
+
 1. RichTextView demo. Attempt paste (Ctrl+V), Ctrl+B, backspace, Enter.
 2. **Expect:** the document is unchanged by every one of them. Copy and selection still
    work.
@@ -172,6 +187,7 @@ Guards #88, #91. **Android device or emulator required.** Use the Markdown demo,
 was lengthened specifically so it can be scrolled and flung.
 
 ### 4.1 Pan does not raise the keyboard
+
 1. Fresh entry into the demo, keyboard down.
 2. Drag a finger on the **text** to scroll. **Expect:** the document scrolls and the
    keyboard stays down.
@@ -181,6 +197,7 @@ was lengthened specifically so it can be scrolled and flung.
    render correctly after a long scroll.
 
 ### 4.2 Tap focuses
+
 1. Tap on a plain paragraph. **Expect:** caret placed, keyboard rises.
 2. Tap on a **bulleted list item** and on a **blockquote line**. **Expect:** both focus
    and raise the keyboard (these were unfocusable at one point during the PR).
@@ -191,6 +208,7 @@ was lengthened specifically so it can be scrolled and flung.
    swallowed tap.
 
 ### 4.3 Spans do not fight the keyboard
+
 1. Spell Check demo. Tap a **misspelled** word. **Expect:** the suggestion popup opens
    and the keyboard does not rise over it.
 2. Tap a **correctly spelled** word. **Expect:** ordinary caret placement + keyboard.
@@ -199,7 +217,9 @@ was lengthened specifically so it can be scrolled and flung.
    keyboard slides up over whatever it opened.
 
 ### 4.4 Indented lines draw correctly (#91)
+
 This is the Android-only `getLineLeft` fix. Compare side by side with desktop.
+
 1. Markdown demo, on Android: place the caret on an **empty** bulleted list item (press
    Enter at the end of an item to make one).
 2. **Expect:** the caret sits just after the bullet marker, indented **once**, not
@@ -213,7 +233,9 @@ This is the Android-only `getLineLeft` fix. Compare side by side with desktop.
    through the same helper).
 
 ### 4.5 IME edits behave like hardware keys (#87)
+
 Soft keyboard only:
+
 1. Backspace at **column 0** of a bulleted list item. **Expect:** the item demotes to a
    plain line (same as the hardware key), and Ctrl+Z / the Undo button restores it.
 2. Backspace at column 0 of an item **on the first line** of the document. **Expect:**
@@ -230,11 +252,12 @@ Soft keyboard only:
 Guards #57, #63, #66–#74, #78, #80.
 
 ### 5.1 Round-trip fidelity (the Roundtrip button)
+
 Markdown demo has a **Roundtrip** button that exports to markdown and re-imports.
 Press it after each of these and confirm the document is unchanged:
 
 1. Baseline demo document, untouched.
-2. A **bold run with trailing whitespace** (select `word ` including the space, bold
+2. A **bold run with trailing whitespace** (select `word` including the space, bold
    it). Roundtrip: **expect** the bold survives and no literal `**` characters appear
    (#70).
 3. A **bold run overlapping an inline code span**. Roundtrip: **expect** no asterisks
@@ -253,6 +276,7 @@ Press it after each of these and confirm the document is unchanged:
    all survive a roundtrip.
 
 ### 5.2 Block stacking and joins (#57, #63, #72)
+
 1. Put the caret on a bulleted item, click Blockquote. **Expect:** a consistent result
    (quote + list resolved by one rule), identical to what importing the equivalent
    markdown produces.
@@ -269,6 +293,7 @@ Press it after each of these and confirm the document is unchanged:
    **Expect:** the marker is not dragged onto the plain line.
 
 ### 5.3 Editing at block boundaries (#67, #68, #66)
+
 1. Create a code fence directly above a blockquote. Delete the newline between them to
    join. Then **type a character exactly at the join point**. **Expect:** no crash
    (this was an `AnnotatedString` overlapping-paragraph exception).
@@ -281,6 +306,7 @@ Press it after each of these and confirm the document is unchanged:
    from column 0.
 
 ### 5.4 Style span adjacency (#69)
+
 1. Type `bold X bold` where the two `bold` words are already bold and `X` is not.
 2. Apply bold anywhere else on the same line.
 3. **Expect:** the single unstyled character between the two bold runs stays unstyled
@@ -291,6 +317,7 @@ Press it after each of these and confirm the document is unchanged:
 Guards #75, #71, #55, #45.
 
 ### 6.1 Wordwise coalescing (#75)
+
 1. Blank Markdown demo. Type `the quick brown fox` in one go.
 2. Press Ctrl/Cmd+Z once. **Expect:** one *word* disappears, not one character.
 3. Keep undoing to empty, then redo back up. **Expect:** redo restores word by word and
@@ -305,12 +332,14 @@ Guards #75, #71, #55, #45.
    word-wise, not character-by-character.
 
 ### 6.2 History depth (#75)
+
 1. Blank demo. Type continuously for ~30 seconds (or paste-and-edit repeatedly to build
    well over 100 entries).
 2. Undo repeatedly. **Expect:** you can get back to the empty document; early edits
    were not silently dropped (the cap is now 1000).
 
 ### 6.3 Undo of block operations (#71, #55)
+
 1. Backspace at column 0 of a list item (smart demotion). Ctrl/Cmd+Z. **Expect:** the
    item comes back. Undo must **not** skip past to an earlier edit.
 2. Press Enter on an empty list item (block exit). Undo. **Expect:** the empty item is


### PR DESCRIPTION
Copying a selection covering lists, blockquotes or headings lost every block. Pasting into another application flattened them to paragraphs, and pasting back into the editor kept them only when nothing had been edited in between.

Found while working through the pre-release manual QA plan; §2.1 failed on the first attempt.

## Why

Two independent defects, the second only visible once the first was fixed.

**The clipboard HTML was derived from the copied `AnnotatedString`**, which carries character styling alone. Block structure lives in line-anchored rich spans that never travel with it, so copying two bullet items and a quote line offered:

```
st item<br>Second item<br><br>A quo
```

**`readClipboardHtml` then refused to read that flavor anyway** whenever the in-process `AnnotatedString` flavor was present, on the stated grounds that "an in-process copy carries its blocks through the editor's own rich-span buffer". That buffer is cleared by any edit that is not the paste's own, so opening a fresh line before pasting was enough to lose the blocks with nothing to fall back to.

## What changed

- The fragment renderer (`renderHtmlFragment`, `containersFor`, `lineHtml`) moves out of `HtmlExtension` to the file's top level, so whole-document export and the clipboard write the same markup. `exportAsHtml()` calls the shared renderer.
- New `TextEditorState.selectionAsHtml(range)` serializes a selection's lines with the blocks they carry, taken from one `content` snapshot so text and line indices cannot come from different revisions.
- `ClipboardHelper.setText` gains an optional `html: String?`. Copy and cut pass the block-aware markup, computed before the delete in cut's case. Android, iOS and wasm accept and ignore it.
- `readClipboardHtml` no longer skips an in-process copy. The markup and the buffer agree, applying a block a line already carries is a no-op via `resolveLineBlock`, and `readHtmlPasteDocument` still checks the markup re-parses to the text the caller was handed.

## Partially covered lines

A partially copied line keeps its block: a fragment of a list item is still a list item. `applyHtmlPasteBlocks` independently declines to place a block on the first or last pasted line when the paste splices into an existing line, so a block only lands where the pasted text becomes a whole line. #74's rule for the in-editor span buffer is untouched, so the plain-text-only platforms are unaffected.

One behavior change to note: pasting a bullet fragment onto an **empty** line now yields a bullet, where it previously yielded plain text. Pasting into the middle of an existing line still yields plain text.

## Tests

`ClipboardBlockStructureE2eTest`, four specs:

- copied HTML carries `<ul>` / `<li>` / `<blockquote>`
- a partially copied list item stays a list item
- blocks survive a paste after an intervening edit cleared the span buffer
- copy in one editor, paste into a second through an HTML-only foreign transferable

That last one is the gap that let this ship: `InMemoryClipboard` hands back the identical `Transferable`, so the span buffer always hit and the HTML was never exercised as the block carrier.

`./gradlew check` green, full desktop and spell-check suites green.

## Still worth a manual pass

Cross-application copy is only verified here through a synthetic foreign transferable. Worth pasting into a real browser and word processor before release (§2.4 of the QA plan).

## Also included

`docs/qa/manual-qa-plan.md`, the manual QA plan for everything landed since v2.3.1, updated for the behavior above. Happy to split it into its own PR if you would rather keep this one to the fix.