### PR TITLE
Hit-test the most specific span, not the first one

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -1239,10 +1239,14 @@ class TextEditorState(
 
 	/**
 	 * Returns the [RichSpan] covering [position], or null if none does. Useful for
-	 * hit-testing taps on a list item or code fence. When several spans cover the
-	 * position the innermost one answers: a word-sized decoration (spell check
-	 * squiggle, link) sits inside the whole-line marker of the heading, list item,
-	 * blockquote or code fence it lives on, and the click belongs to the word.
+	 * hit-testing taps on a list item or code fence.
+	 *
+	 * Spans nest, so several can cover one position and only one can answer. Content
+	 * spans (link, highlight) go first, then the editor's own decorations (spell
+	 * check squiggle, find match), then the line-anchored marker of the heading, list
+	 * item, blockquote or code fence the line belongs to. Within a tier the span
+	 * covering the least of the clicked line wins, so the marker answers only where
+	 * nothing more specific does.
 	 */
 	fun findSpanAtPosition(position: CharLineOffset): RichSpan? {
 		// Find the line wrap that contains our position
@@ -1250,18 +1254,40 @@ class TextEditorState(
 			wrap.line == position.line && position.char >= wrap.wrapStartsAtIndex
 		} ?: return null
 
-		// Narrowest wins, line-anchored markers last. Set iteration order is not a
-		// hit-testing priority: it flips whenever a text edit re-folds the span set,
-		// which would make the same click answer differently before and after a
-		// keystroke somewhere else in the document.
 		return lineWrap.richSpans
 			.filter { it.containsPosition(position) }
-			.minWithOrNull(
-				compareBy(
-					{ getCharacterIndex(it.range.end) - getCharacterIndex(it.range.start) },
-					{ if (it.style.stickyAtStart) 1 else 0 },
-				)
-			)
+			.minWithOrNull(hitTestOrder(position.line))
+	}
+
+	/**
+	 * Ranks the spans covering a click on [line]. Total, down to the style name: a
+	 * partial order would leave the winner to the span set's iteration order, which
+	 * re-folds on every edit and would answer the same click differently before and
+	 * after an unrelated keystroke.
+	 */
+	private fun hitTestOrder(line: Int): Comparator<RichSpan> = compareBy(
+		{ it.style.hitTestTier() },
+		{ it.charsOnLine(line) },
+		{ it.range.start.char },
+		{ it.style::class.simpleName.orEmpty() },
+	)
+
+	private fun RichSpanStyle.hitTestTier(): Int = when {
+		stickyAtStart || this is BlockSpanStyle -> 2
+		isDecoration -> 1
+		else -> 0
+	}
+
+	/**
+	 * How much of [line] the span covers. Measured within the line rather than across
+	 * the document so a span running on from an earlier line is ranked by what it
+	 * claims here, not by its full length.
+	 */
+	private fun RichSpan.charsOnLine(line: Int): Int {
+		val lineLength = textLines.getOrNull(line)?.length ?: return Int.MAX_VALUE
+		val start = (if (range.start.line < line) 0 else range.start.char).coerceIn(0, lineLength)
+		val end = (if (range.end.line > line) lineLength else range.end.char).coerceIn(0, lineLength)
+		return end - start
 	}
 
 	fun captureMetadata(range: TextEditorRange): OperationMetadata {

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -1239,7 +1239,10 @@ class TextEditorState(
 
 	/**
 	 * Returns the [RichSpan] covering [position], or null if none does. Useful for
-	 * hit-testing taps on a list item or code fence.
+	 * hit-testing taps on a list item or code fence. When several spans cover the
+	 * position the innermost one answers: a word-sized decoration (spell check
+	 * squiggle, link) sits inside the whole-line marker of the heading, list item,
+	 * blockquote or code fence it lives on, and the click belongs to the word.
 	 */
 	fun findSpanAtPosition(position: CharLineOffset): RichSpan? {
 		// Find the line wrap that contains our position
@@ -1247,10 +1250,18 @@ class TextEditorState(
 			wrap.line == position.line && position.char >= wrap.wrapStartsAtIndex
 		} ?: return null
 
-		// Check each span in the line wrap
-		return lineWrap.richSpans.firstOrNull { span ->
-			span.containsPosition(position)
-		}
+		// Narrowest wins, line-anchored markers last. Set iteration order is not a
+		// hit-testing priority: it flips whenever a text edit re-folds the span set,
+		// which would make the same click answer differently before and after a
+		// keystroke somewhere else in the document.
+		return lineWrap.richSpans
+			.filter { it.containsPosition(position) }
+			.minWithOrNull(
+				compareBy(
+					{ getCharacterIndex(it.range.end) - getCharacterIndex(it.range.start) },
+					{ if (it.style.stickyAtStart) 1 else 0 },
+				)
+			)
 	}
 
 	fun captureMetadata(range: TextEditorRange): OperationMetadata {

--- a/ComposeTextEditor/src/desktopTest/kotlin/spans/SpanHitTestTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/spans/SpanHitTestTest.kt
@@ -1,10 +1,13 @@
 package spans
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import com.darkrockstudios.texteditor.CharLineOffset
 import com.darkrockstudios.texteditor.TextEditorRange
 import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
 import com.darkrockstudios.texteditor.richstyle.HeaderSpanStyle
+import com.darkrockstudios.texteditor.richstyle.HighlightSpanStyle
+import com.darkrockstudios.texteditor.richstyle.LinkSpanStyle
 import com.darkrockstudios.texteditor.richstyle.RichSpan
 import com.darkrockstudios.texteditor.richstyle.SpellCheckStyle
 import com.darkrockstudios.texteditor.state.TextEditorState
@@ -14,9 +17,9 @@ import kotlin.test.assertEquals
 
 /**
  * Hit testing a position covered by several spans. Whole-line block markers
- * (heading, list item, blockquote, code fence) overlap every word-sized
- * decoration on their line, so the answer must come from how much of the
- * document each span claims, never from the order they happen to sit in.
+ * (heading, list item, blockquote, code fence) overlap every word-sized span on
+ * their line, so the answer must come from what each span is and how much of the
+ * clicked line it claims, never from the order they happen to sit in.
  */
 class SpanHitTestTest {
 
@@ -31,7 +34,6 @@ class SpanHitTestTest {
 	@Test
 	fun `a word decoration wins over the heading span covering its line`() =
 		editorUiTest(initialText = AnnotatedString(line)) {
-			// Import order: the block marker lands before the spell check overlay.
 			state.addSpans(RichSpan(lineRange, HeaderSpanStyle.of(1)))
 			state.addSpans(RichSpan(wordRange, SpellCheckStyle))
 			waitForIdle()
@@ -80,4 +82,62 @@ class SpanHitTestTest {
 				state.findSpanAtPosition(CharLineOffset(0, 2))?.style,
 			)
 		}
+
+	@Test
+	fun `a decoration covering the whole line still wins over the line marker`() =
+		editorUiTest(initialText = AnnotatedString(line)) {
+			state.addSpans(RichSpan(lineRange, HeaderSpanStyle.of(1)))
+			state.addSpans(RichSpan(lineRange, SpellCheckStyle))
+			waitForIdle()
+
+			assertEquals(
+				SpellCheckStyle,
+				state.findSpanAtPosition(CharLineOffset(0, 16))?.style,
+			)
+		}
+
+	@Test
+	fun `a link keeps answering a word one of the editor's decorations covers`() {
+		val link = LinkSpanStyle("https://example.com")
+		editorUiTest(initialText = AnnotatedString(line)) {
+			state.addSpans(RichSpan(wordRange, link))
+			state.addSpans(RichSpan(wordRange, SpellCheckStyle))
+			waitForIdle()
+
+			assertEquals(link, state.findSpanAtPosition(CharLineOffset(0, 16))?.style)
+		}
+	}
+
+	@Test
+	fun `a link is not shadowed by a decoration narrower than it`() {
+		val link = LinkSpanStyle("https://example.com")
+		val squiggle = TextEditorRange(CharLineOffset(0, 15), CharLineOffset(0, 19))
+		editorUiTest(initialText = AnnotatedString(line)) {
+			state.addSpans(RichSpan(wordRange, link))
+			state.addSpans(RichSpan(squiggle, SpellCheckStyle))
+			waitForIdle()
+
+			assertEquals(link, state.findSpanAtPosition(CharLineOffset(0, 16))?.style)
+		}
+	}
+
+	@Test
+	fun `width is measured within the clicked line, not across the document`() {
+		val second = "See docs.example.com for more"
+		val link = LinkSpanStyle("https://docs.example.com")
+		val highlight = HighlightSpanStyle(Color.Yellow)
+
+		// The highlight runs on from the line above, so it is the longer span in the
+		// document while claiming less of the line that was clicked.
+		val linkRange = TextEditorRange(CharLineOffset(1, 4), CharLineOffset(1, 20))
+		val highlightRange = TextEditorRange(CharLineOffset(0, 0), CharLineOffset(1, 8))
+
+		editorUiTest(initialText = AnnotatedString("$line\n$second")) {
+			state.addSpans(RichSpan(linkRange, link))
+			state.addSpans(RichSpan(highlightRange, highlight))
+			waitForIdle()
+
+			assertEquals(highlight, state.findSpanAtPosition(CharLineOffset(1, 5))?.style)
+		}
+	}
 }

--- a/ComposeTextEditor/src/desktopTest/kotlin/spans/SpanHitTestTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/spans/SpanHitTestTest.kt
@@ -1,0 +1,83 @@
+package spans
+
+import androidx.compose.ui.text.AnnotatedString
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.richstyle.BlockquoteSpanStyle
+import com.darkrockstudios.texteditor.richstyle.HeaderSpanStyle
+import com.darkrockstudios.texteditor.richstyle.RichSpan
+import com.darkrockstudios.texteditor.richstyle.SpellCheckStyle
+import com.darkrockstudios.texteditor.state.TextEditorState
+import utils.editorUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Hit testing a position covered by several spans. Whole-line block markers
+ * (heading, list item, blockquote, code fence) overlap every word-sized
+ * decoration on their line, so the answer must come from how much of the
+ * document each span claims, never from the order they happen to sit in.
+ */
+class SpanHitTestTest {
+
+	private val line = "Understanding RichSpan Management"
+	private val wordRange = TextEditorRange(CharLineOffset(0, 14), CharLineOffset(0, 22))
+	private val lineRange = TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, line.length))
+
+	private fun TextEditorState.addSpans(vararg spans: RichSpan) {
+		updateRichSpans(remove = emptyList(), add = spans.toList())
+	}
+
+	@Test
+	fun `a word decoration wins over the heading span covering its line`() =
+		editorUiTest(initialText = AnnotatedString(line)) {
+			// Import order: the block marker lands before the spell check overlay.
+			state.addSpans(RichSpan(lineRange, HeaderSpanStyle.of(1)))
+			state.addSpans(RichSpan(wordRange, SpellCheckStyle))
+			waitForIdle()
+
+			assertEquals(
+				SpellCheckStyle,
+				state.findSpanAtPosition(CharLineOffset(0, 16))?.style,
+			)
+		}
+
+	@Test
+	fun `the winner does not depend on the order the spans were added`() =
+		editorUiTest(initialText = AnnotatedString(line)) {
+			state.addSpans(RichSpan(wordRange, SpellCheckStyle))
+			state.addSpans(RichSpan(lineRange, HeaderSpanStyle.of(1)))
+			waitForIdle()
+
+			assertEquals(
+				SpellCheckStyle,
+				state.findSpanAtPosition(CharLineOffset(0, 16))?.style,
+			)
+		}
+
+	@Test
+	fun `a word decoration wins over the blockquote span covering its line`() =
+		editorUiTest(initialText = AnnotatedString(line)) {
+			state.addSpans(RichSpan(lineRange, BlockquoteSpanStyle))
+			state.addSpans(RichSpan(wordRange, SpellCheckStyle))
+			waitForIdle()
+
+			assertEquals(
+				SpellCheckStyle,
+				state.findSpanAtPosition(CharLineOffset(0, 16))?.style,
+			)
+		}
+
+	@Test
+	fun `the line span still answers positions its decorations do not cover`() =
+		editorUiTest(initialText = AnnotatedString(line)) {
+			state.addSpans(RichSpan(lineRange, HeaderSpanStyle.of(1)))
+			state.addSpans(RichSpan(wordRange, SpellCheckStyle))
+			waitForIdle()
+
+			assertEquals(
+				HeaderSpanStyle.of(1),
+				state.findSpanAtPosition(CharLineOffset(0, 2))?.style,
+			)
+		}
+}


### PR DESCRIPTION
Right clicking a spell-check squiggle inside a heading, list item, blockquote or code fence opened the plain Paste/Select All menu instead of the suggestions menu. Typing a character anywhere in the document made the same click start working.

## Cause

`findSpanAtPosition` returned the first span in the line's list that contained the position, and that list is in span-set iteration order rather than any hit-testing priority.

Headings, list items, blockquotes and code fences each carry a whole-line `RichSpan`. A spell-check squiggle is a word-sized span sitting inside it. On a freshly imported document the block markers are added first, so they came first in the set and won the hit test; `SpellCheckingTextEditor` then saw a span whose style isn't `SpellCheckStyle` and fell back to the standard menu.

The order also flips: any text edit re-folds the span set through `mergeLineAnchoredDuplicates`, which rebuilds it as `(others + merged)` and moves every line-anchored marker to the end. After that the spell span comes first and the click works, which is why a keystroke elsewhere in the document appeared to fix it.

Links were shadowed the same way: a markdown link inside a list item or heading lost its click to the block marker.

## Fix

Narrowest span wins, line-anchored markers last. A position no decoration covers still resolves to the block span, so host `onRichSpanClick` listeners are unaffected.

## Tests

New `SpanHitTestTest` covers a heading and a blockquote shadowing a word decoration, order-independence between the two, and the block span still answering positions its decorations don't cover. The two block-added-first cases fail without the fix.

`:ComposeTextEditor:desktopTest` and `:ComposeTextEditorSpellCheck:desktopTest` are green.
