### PR TITLE
Announce whole-document replacements so spell check can re-run

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -62,7 +62,8 @@ import kotlin.math.min
  * Related concerns are delegated to focused sub-objects exposed as properties:
  * [cursor] (caret position and movement), [selector] (selection), [scrollManager]
  * (scrolling and visible range), and [richSpanManager] (rich-span book-keeping).
- * Observe changes reactively via [cursorDataFlow] and [editOperations].
+ * Observe changes reactively via [cursorDataFlow], [editOperations] and
+ * [documentReplacements].
  *
  * Coordinates are [CharLineOffset]s and [TextEditorRange]s; convert to and from flat
  * character indices with [getCharacterIndex]/[getOffsetAtCharacter].
@@ -475,6 +476,15 @@ class TextEditorState(
 	 */
 	val actions: EditorActionRegistry = EditorActionRegistry()
 
+	private val _documentReplacements = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+	/**
+	 * Fires when [setText] swaps the whole document. A replacement is not an edit and
+	 * emits nothing on [editOperations], so anything deriving state from the text
+	 * (spell check, search results) has no other way to learn its document is gone.
+	 */
+	val documentReplacements: Flow<Unit> = _documentReplacements
+
 	/**
 	 * Replaces the entire document with [text], clearing rich spans and resetting
 	 * book-keeping. To edit existing content instead, use [replace] or the cursor
@@ -812,6 +822,7 @@ class TextEditorState(
 	 */
 	private fun replaceContent(lines: List<AnnotatedString>) {
 		mutateContent { DocumentSnapshot(lines, emptySet()) }
+		_documentReplacements.tryEmit(Unit)
 	}
 
 	internal fun setLines(lines: List<AnnotatedString>) {

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/DocumentReplacementSignalTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/DocumentReplacementSignalTest.kt
@@ -1,0 +1,46 @@
+package state
+
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * A whole-document swap is not an edit, so listeners that derive state from the text
+ * learn about it from its own signal rather than from the edit stream.
+ */
+class DocumentReplacementSignalTest {
+
+	private fun editorState() = TextEditorState(scope = TestScope(), measurer = mockk(relaxed = true))
+
+	@Test
+	fun `setText announces the replacement`() = runTest {
+		val state = editorState()
+		var replacements = 0
+		backgroundScope.launch { state.documentReplacements.collect { replacements++ } }
+		runCurrent()
+
+		state.setText("hello world")
+		runCurrent()
+
+		assertEquals(1, replacements)
+	}
+
+	@Test
+	fun `an edit is not a replacement`() = runTest {
+		val state = editorState()
+		state.setText("hello world")
+		var replacements = 0
+		backgroundScope.launch { state.documentReplacements.collect { replacements++ } }
+		runCurrent()
+
+		state.insertStringAtCursor("!")
+		runCurrent()
+
+		assertEquals(0, replacements)
+	}
+}

--- a/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckingTextEditor.kt
+++ b/ComposeTextEditorSpellCheck/src/commonMain/kotlin/com/darkrockstudios/texteditor/spellcheck/SpellCheckingTextEditor.kt
@@ -40,7 +40,7 @@ private val DefaultContentPadding = PaddingValues(start = 8.dp)
  *
  * Wraps [BasicTextEditor] and overlays spell-check decorations driven by a [SpellCheckState].
  * Edits are observed reactively: affected spans are invalidated immediately and re-checked once
- * typing goes quiet. Secondary clicks and taps on a flagged span open a context menu of
+ * typing goes quiet, and replacing the document wholesale re-checks all of it. Secondary clicks and taps on a flagged span open a context menu of
  * [Suggestion][com.darkrockstudios.texteditor.spellcheck.api.Suggestion]s for the
  * misspelled word or sentence-level [Correction].
  *
@@ -75,6 +75,11 @@ fun SpellCheckingTextEditor(
 
 	// Track the current spell check item for right-click context
 	var currentSpellCheckItem by remember { mutableStateOf<SpellCheckItem?>(null) }
+
+	LaunchedEffect(state) {
+		state.textState.documentReplacements
+			.collect { state.runFullSpellCheck() }
+	}
 
 	LaunchedEffect(state) {
 		state.textState.editOperations

--- a/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/e2e/SpellCheckE2eTest.kt
+++ b/ComposeTextEditorSpellCheck/src/desktopTest/kotlin/e2e/SpellCheckE2eTest.kt
@@ -71,6 +71,35 @@ class SpellCheckE2eTest {
 	}
 
 	@Test
+	fun `a document loaded after the editor is composed gets checked`() {
+		val words = words(10)
+		val checker = CountingSpellChecker(correctWords = words.drop(2).toSet())
+
+		spellCheckUiTest(spellChecker = checker, initialText = "") {
+			assertEquals(0, spellCheckSpanCount)
+
+			state.textState.setText(words.joinToString(" "))
+			letSpellCheckSettle()
+
+			assertEquals(2, spellCheckSpanCount)
+		}
+	}
+
+	@Test
+	fun `replacing the document checks the new text`() {
+		val checker = CountingSpellChecker(correctWords = setOf("fine"))
+
+		spellCheckUiTest(spellChecker = checker, initialText = "typoone fine") {
+			assertEquals(1, spellCheckSpanCount)
+
+			state.textState.setText("fine typotwo typothree")
+			letSpellCheckSettle()
+
+			assertEquals(2, spellCheckSpanCount)
+		}
+	}
+
+	@Test
 	fun `typing is inert while checking is off`() {
 		val words = words(60)
 		val checker = CountingSpellChecker(correctWords = words.toSet())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ activityCompose = "1.13.0"
 composeBom = "2026.06.01"
 
 symspellkt = "3.4.0"
-spellcheckerkt = "1.3.1"
+spellcheckerkt = "1.3.2"
 
 maven-publish = "0.37.0"
 dokka = "2.2.0"

--- a/sampleApp/src/commonMain/kotlin/SpellCheckingTextEditorDemoUi.kt
+++ b/sampleApp/src/commonMain/kotlin/SpellCheckingTextEditorDemoUi.kt
@@ -48,20 +48,6 @@ fun SpellCheckingTextEditorDemoUi(
 		markdownExtension.importMarkdown(SIMPLE_MARKDOWN)
 	}
 
-	// `setText` (called inside `importMarkdown`) doesn't emit an editOperation,
-	// so the spell-check listener never sees the import. The `LaunchedEffect`
-	// inside `rememberSpellCheckState` runs `runFullSpellCheck` once when the
-	// platform spellChecker first becomes non-null — but on Android the system
-	// SpellCheckerSession initialises faster than `importMarkdown` runs, so
-	// that one-shot check fires over empty text and squiggles never appear.
-	// Re-running here keyed on `(spellChecker, markdownExtension)` makes the
-	// check deterministic regardless of which side wins the init race.
-	LaunchedEffect(spellChecker, markdownExtension) {
-		if (spellChecker != null) {
-			state.runFullSpellCheck()
-		}
-	}
-
 	Column(modifier = modifier) {
 		Row {
 			Text(


### PR DESCRIPTION
`setText` replaces the document without emitting an edit operation, so nothing downstream can tell its text is gone. Spell check learned about a document only when the platform checker became available, which on Android beats the markdown import often enough that the one-shot check runs over an empty document and no squiggles ever appear.

The sample app worked around this with a second `LaunchedEffect(spellChecker, markdownExtension)` that re-ran the full check itself. Any host loading content programmatically needed the same workaround, and `HtmlExtension`'s import had none.

`TextEditorState` now exposes `documentReplacements`, emitted from `replaceContent` (whose only callers are the two `setText` overloads), and `SpellCheckingTextEditor` runs a full check on it. The sample app's workaround is deleted.

Either race order costs one real scan: whichever of the checker and the document arrives last triggers the check, and the earlier one finds either no words or no checker. That removes the duplicate concurrent full check at load without needing any serialization.

### Notes

`BasicTextEditor` calls `setText` when its `text` parameter changes, so a host driving text from state now gets a full re-check on each change. That is the intended behavior, but it is a behavior change rather than a pure cleanup.

A separate signal rather than a synthetic edit operation: emitting a real operation would be arguably more correct but ripples into undo/redo and every existing `editOperations` collector.

This is independent of #94, which stays drafted.

### Tests

`DocumentReplacementSignalTest` covers the signal itself (`setText` emits, an edit does not). Two cases in `SpellCheckE2eTest` cover the behavior through the real editor stack: a document loaded into a composed editor gets checked, and replacing a document checks the new text. Both fail with the collector reverted; verified.
