### PR TITLE
Give typed text the body style when nothing neighbours it

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -105,10 +105,8 @@ class TextEditorState(
 		}
 
 	/**
-	 * Whether a markdown or HTML extension installed [markdownConfiguration]. A
-	 * plain editor keeps the default value but never opts in, so its typed text
-	 * is left to the host's [textStyle] rather than being stamped with a body
-	 * style it never asked for.
+	 * Whether an extension installed [markdownConfiguration]. A plain editor keeps
+	 * the default value but never opts in, so its typed text stays on [textStyle].
 	 */
 	internal var hasMarkdownConfiguration: Boolean = false
 		private set

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorState.kt
@@ -99,7 +99,19 @@ class TextEditorState(
 	 * editors that do not use markdown keep the default.
 	 */
 	var markdownConfiguration: MarkdownConfiguration = MarkdownConfiguration.DEFAULT
-		internal set
+		internal set(value) {
+			field = value
+			hasMarkdownConfiguration = true
+		}
+
+	/**
+	 * Whether a markdown or HTML extension installed [markdownConfiguration]. A
+	 * plain editor keeps the default value but never opts in, so its typed text
+	 * is left to the host's [textStyle] rather than being stamped with a body
+	 * style it never asked for.
+	 */
+	internal var hasMarkdownConfiguration: Boolean = false
+		private set
 
 	/**
 	 * Theming colors for line-block gutter markers, mirrored from

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorStateSpanExt.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorStateSpanExt.kt
@@ -33,11 +33,9 @@ fun TextEditorState.getSpanStylesAtPosition(position: CharLineOffset): Set<SpanS
 
 /**
  * The character styles text inserted at [position] should adopt: those of the
- * character before it, or of the character it sits in front of when nothing precedes
- * it. Where neither exists — the start of a document, or a line whose predecessor is
- * blank, as every paragraph after the first is — a markdown editor falls back to its
- * configured body style. Without that fallback such text carries no style at all and
- * renders at the bare default size rather than the document's.
+ * character before it, or of the character it sits in front of. With neither (a
+ * blank line below a blank line, as every new paragraph starts out), a markdown
+ * editor falls back to its body style rather than leaving the text unstyled.
  */
 internal fun TextEditorState.getSpanStylesForEditAt(position: CharLineOffset): Set<SpanStyle> {
 	val styles = getSpanStylesAtPosition(precedingCharacter(position) ?: position)

--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorStateSpanExt.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorStateSpanExt.kt
@@ -34,11 +34,17 @@ fun TextEditorState.getSpanStylesAtPosition(position: CharLineOffset): Set<SpanS
 /**
  * The character styles text inserted at [position] should adopt: those of the
  * character before it, or of the character it sits in front of when nothing precedes
- * it. Without the second case, text entered at the very start of a document carries
- * no style and renders at the bare default size rather than the document's.
+ * it. Where neither exists — the start of a document, or a line whose predecessor is
+ * blank, as every paragraph after the first is — a markdown editor falls back to its
+ * configured body style. Without that fallback such text carries no style at all and
+ * renders at the bare default size rather than the document's.
  */
-internal fun TextEditorState.getSpanStylesForEditAt(position: CharLineOffset): Set<SpanStyle> =
-	getSpanStylesAtPosition(precedingCharacter(position) ?: position)
+internal fun TextEditorState.getSpanStylesForEditAt(position: CharLineOffset): Set<SpanStyle> {
+	val styles = getSpanStylesAtPosition(precedingCharacter(position) ?: position)
+	if (styles.isNotEmpty()) return styles
+	if (!hasMarkdownConfiguration) return emptySet()
+	return setOf(markdownConfiguration.defaultTextStyle)
+}
 
 /**
  * Stamps the character styling in effect at [position] onto [text], unless [text]

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/TypedTextBodyStyleTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/TypedTextBodyStyleTest.kt
@@ -1,0 +1,101 @@
+package markdown
+
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.unit.sp
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.markdown.MarkdownConfiguration
+import com.darkrockstudios.texteditor.markdown.MarkdownExtension
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Typed text adopts the styles of the character next to it. Where there is no such
+ * character — the start of a document, or a line whose predecessor is blank — a
+ * markdown editor falls back to its configured body style instead of leaving the
+ * text unstyled at the bare default size.
+ */
+class TypedTextBodyStyleTest {
+
+	private val bodyStyle = SpanStyle(fontSize = 24.sp)
+	private val config = MarkdownConfiguration.DEFAULT.copy(defaultTextStyle = bodyStyle)
+
+	private fun TestScope.editor(config: MarkdownConfiguration = this@TypedTextBodyStyleTest.config) =
+		MarkdownExtension(
+			TextEditorState(scope = this, measurer = mockk(relaxed = true)),
+			config,
+		)
+
+	private fun TextEditorState.type(text: String) = text.forEach { insertCharacterAtCursor(it) }
+
+	private fun TextEditorState.moveToEndOf(line: Int) =
+		cursor.updatePosition(CharLineOffset(line, textLines[line].length))
+
+	private fun TextEditorState.stylesOn(line: Int) = textLines[line].spanStyles.map { it.item }
+
+	@Test
+	fun `a paragraph typed after a blank line gets the body style`() = runTest {
+		val extension = editor()
+		extension.importMarkdown("Existing prose here.")
+		val state = extension.editorState
+
+		state.moveToEndOf(0)
+		state.insertNewlineAtCursor()
+		state.insertNewlineAtCursor()
+		state.type("new paragraph")
+
+		assertEquals(listOf(bodyStyle), state.stylesOn(2))
+	}
+
+	@Test
+	fun `a list typed after a blank line gets the body style`() = runTest {
+		val extension = editor()
+		extension.importMarkdown("Existing prose here.")
+		val state = extension.editorState
+
+		state.moveToEndOf(0)
+		state.insertNewlineAtCursor()
+		state.insertNewlineAtCursor()
+		extension.toggleOrderedList(2..2)
+		state.type("one")
+		state.insertNewlineAtCursor()
+		state.type("two")
+
+		assertEquals(listOf(bodyStyle), state.stylesOn(2))
+		assertEquals(listOf(bodyStyle), state.stylesOn(3))
+	}
+
+	@Test
+	fun `typing into an empty document gets the body style`() = runTest {
+		val extension = editor()
+
+		extension.editorState.type("first words")
+
+		assertEquals(listOf(bodyStyle), extension.editorState.stylesOn(0))
+	}
+
+	@Test
+	fun `neighbouring style still wins over the body style`() = runTest {
+		val extension = editor()
+		extension.importMarkdown("# Chapter One")
+		val state = extension.editorState
+
+		val before = state.stylesOn(0).toSet()
+		state.moveToEndOf(0)
+		state.type("!")
+
+		assertEquals(before, state.stylesOn(0).toSet())
+	}
+
+	@Test
+	fun `a plain editor is left to the host text style`() = runTest {
+		val state = TextEditorState(scope = this, measurer = mockk(relaxed = true))
+
+		state.type("plain text")
+
+		assertEquals(emptyList(), state.stylesOn(0))
+	}
+}

--- a/ComposeTextEditor/src/desktopTest/kotlin/markdown/TypedTextBodyStyleTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/markdown/TypedTextBodyStyleTest.kt
@@ -13,10 +13,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Typed text adopts the styles of the character next to it. Where there is no such
- * character — the start of a document, or a line whose predecessor is blank — a
- * markdown editor falls back to its configured body style instead of leaving the
- * text unstyled at the bare default size.
+ * Typed text adopts the styles of the character next to it, falling back to the
+ * markdown body style when there is no such character.
  */
 class TypedTextBodyStyleTest {
 


### PR DESCRIPTION
## The bug

Typed text adopts the styles of the character next to the caret: the one before it, or the one it sits in front of. When neither exists, `getSpanStylesForEditAt` returned nothing, so the text carried no `SpanStyle` at all and rendered at the host's bare `TextStyle` size instead of the document's body size.

That is not a rare edge case. Paragraphs are separated by a blank line, so every paragraph after the first starts at column 0 with an empty line above it: no preceding character, and none in front either. Any newly typed paragraph came out at the default size while the imported text around it stayed correct.

Found in Hammer, which passes `TextStyle.Default` as the editor style and carries the real (user-scalable) font size as a span on every character. A list typed between two loaded paragraphs rendered noticeably smaller than the prose around it.

## The fix

When nothing neighbouring supplies a style, fall back to `markdownConfiguration.defaultTextStyle`.

That configuration is only meaningful once a markdown or HTML extension installs it, so `TextEditorState` now tracks whether that happened. A plain editor never opts in and keeps the previous behaviour: its typed text is left to the host's `TextStyle` rather than being stamped with a 16sp body style it never asked for.

## Tests

`TypedTextBodyStyleTest` covers a paragraph typed after a blank line, a list typed after a blank line, typing into an empty document, a neighbouring style still winning over the fallback, and a plain editor staying untouched.

Full `:ComposeTextEditor:desktopTest` passes.
