### PR TITLE
Keep caret typing styles across updates that neither move the caret nor edit the document

### DIFF
--- a/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorCursorState.kt
+++ b/ComposeTextEditor/src/commonMain/kotlin/com/darkrockstudios/texteditor/state/TextEditorCursorState.kt
@@ -28,6 +28,13 @@ class TextEditorCursorState(
 			_stylesFlow.tryEmit(value)
 		}
 
+	/**
+	 * The document revision [styles] was last derived from. [updatePosition] skips the
+	 * recompute when neither the caret nor this changed since then. Starts as the
+	 * revision seen at construction, matching the empty [styles].
+	 */
+	private var stylesDerivedFrom: DocumentSnapshot = editorState.workingContent
+
 	private val _stylesFlow = MutableSharedFlow<Set<SpanStyle>>(
 		extraBufferCapacity = 1,
 		onBufferOverflow = BufferOverflow.DROP_OLDEST
@@ -41,12 +48,22 @@ class TextEditorCursorState(
 	val positionFlow: SharedFlow<CharLineOffset> = _cursorPositionFlow
 
 	fun updatePosition(position: CharLineOffset, updateStyles: Boolean = true) {
+		val oldPosition = _position
 		val newPosition = position.coerceInto(editorState.textLines)
 		_position = newPosition
 		_cursorPositionFlow.tryEmit(newPosition)
 
-		// Update styles based on surrounding text (skip during text operations to preserve manually-set styles)
-		if (updateStyles) {
+		// Recompute the typing style from the surrounding text only when something it
+		// derives from changed: the caret moved, or an edit altered the text under it
+		// (an edit can leave the caret offset untouched, e.g. styling a selection).
+		// Focus handlers and pointer taps re-assert the position the caret already
+		// has; recomputing then would wipe styles toggled onto the caret
+		// ([toggleStyle]) before the user gets to type with them.
+		// (Skip during text operations to preserve manually-set styles still applies
+		// via [updateStyles].)
+		if (updateStyles &&
+			(newPosition != oldPosition || editorState.workingContent !== stylesDerivedFrom)
+		) {
 			updateStylesFromPosition(newPosition)
 		}
 
@@ -95,6 +112,7 @@ class TextEditorCursorState(
 	}
 
 	private fun updateStylesFromPosition(position: CharLineOffset) {
+		stylesDerivedFrom = editorState.workingContent
 		styles = editorState.getSpanStylesForEditAt(position)
 	}
 

--- a/ComposeTextEditor/src/desktopTest/kotlin/state/CursorTypingStylePreservationTest.kt
+++ b/ComposeTextEditor/src/desktopTest/kotlin/state/CursorTypingStylePreservationTest.kt
@@ -1,0 +1,104 @@
+package state
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.font.FontWeight
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.state.TextEditorState
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The caret's typing style ([TextEditorCursorState.styles]) must survive events that
+ * re-assert the position the caret already has — focus, pointer taps, arrow keys into
+ * an edge — because those wipe styles the user toggled onto the caret before they
+ * could type with them. It must still be re-derived whenever the caret genuinely
+ * moves or an edit changes the text under an unmoved caret.
+ */
+class CursorTypingStylePreservationTest {
+
+	private val bold = SpanStyle(fontWeight = FontWeight.Bold)
+
+	private fun TestScope.editor(text: String = "hello") = TextEditorState(
+		scope = this,
+		measurer = mockk(relaxed = true),
+		initialText = AnnotatedString(text),
+	)
+
+	@Test
+	fun `re-asserting the caret position keeps toggled styles`() = runTest {
+		val state = editor()
+		state.cursor.updatePosition(CharLineOffset(0, 0))
+		state.cursor.addStyle(bold)
+
+		// Focus handlers and taps re-assert the current caret position
+		repeat(3) { state.cursor.updatePosition(CharLineOffset(0, 0)) }
+
+		assertTrue(bold in state.cursor.styles, "toggled style was wiped by a same-position update")
+	}
+
+	@Test
+	fun `arrowing into a document edge keeps toggled styles`() = runTest {
+		val state = editor()
+		state.cursor.updatePosition(CharLineOffset(0, 0))
+		state.cursor.addStyle(bold)
+
+		// moveLeft at the very start coerces back to (0,0) — the position does not change
+		state.cursor.moveLeft()
+		state.cursor.moveLeft()
+
+		assertTrue(bold in state.cursor.styles, "toggled style was wiped by moving into the edge")
+	}
+
+	@Test
+	fun `moving the caret re-derives the style from the surrounding text`() = runTest {
+		val state = editor()
+		state.cursor.updatePosition(CharLineOffset(0, 0))
+		state.cursor.addStyle(bold)
+
+		state.cursor.updatePosition(CharLineOffset(0, 5))
+
+		assertFalse(bold in state.cursor.styles, "manual style should not follow a real caret move")
+	}
+
+	@Test
+	fun `typing with a toggled caret style stamps it onto the text`() = runTest {
+		val state = editor("")
+		state.cursor.addStyle(bold)
+
+		state.insertCharacterAtCursor('B')
+
+		val boldRanges = state.textLines[0].spanStyles.filter { it.item == bold }
+		assertEquals(listOf(0 to 1), boldRanges.map { it.start to it.end })
+	}
+
+	@Test
+	fun `styling a selection that leaves the caret in place updates the typing style`() = runTest {
+		val state = editor()
+		state.cursor.updatePosition(CharLineOffset(0, 5))
+
+		// addStyleSpan keeps the caret offset; only the text under it changed
+		state.addStyleSpan(TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 5)), bold)
+
+		assertTrue(bold in state.cursor.styles, "typing style should follow an edit under an unmoved caret")
+	}
+
+	@Test
+	fun `undo re-derives the typing style`() = runTest {
+		val state = editor()
+		state.cursor.updatePosition(CharLineOffset(0, 5))
+		state.cursor.addStyle(bold)
+		state.insertCharacterAtCursor('B')
+		assertTrue(bold in state.cursor.styles)
+
+		state.undo()
+
+		assertFalse(bold in state.cursor.styles, "typing style should not survive undo as a stale manual style")
+	}
+}


### PR DESCRIPTION
## Problem

Styles toggled onto the caret (`cursor.addStyle` / `cursor.toggleStyle`) are wiped by events that re-assert the caret position it already has — focus handlers and pointer taps both call `updatePosition` with the current offset. `updatePosition` recomputed the typing style from the surrounding text on **every** call, so the toggled style was gone before the user could type with it. On an empty document (nothing to inherit from) the style set ends up empty, which makes e.g. a "type in double width" toolbar toggle impossible to use without first selecting text.

## Repro

```kotlin
state.cursor.updatePosition(CharLineOffset(0, 0))
state.cursor.addStyle(SpanStyle(fontWeight = FontWeight.Bold))
state.cursor.updatePosition(CharLineOffset(0, 0)) // e.g. editor gained focus
state.cursor.styles // {} on main — bold is gone
```

## Fix

`updatePosition` now re-derives the typing style only when something it derives from actually changed:

- the caret offset moved, **or**
- the document revision changed — tracked as the identity of `workingContent` (draft-aware, so edits inside `withAtomicEdit` are seen even though `content` is not yet published).

Cases that must still re-derive are covered:

- **Edits that leave the caret offset untouched** (e.g. `addStyleSpan` on a selection — `cursorAfter == cursorBefore`): these publish a new `DocumentSnapshot`, so the revision check triggers. Covered by `styling a selection that leaves the caret in place updates the typing style`.
- **Undo/redo**: same mechanism, covered by an explicit test.
- **Wholesale document replacement**: unchanged, still goes through `refreshStyles()`.

## Tests

New `CursorTypingStylePreservationTest` (6 tests):

- re-asserting the caret position keeps toggled styles
- arrowing into a document edge keeps toggled styles (`moveLeft` at column 0 coerces back to the same offset)
- moving the caret re-derives the style from the surrounding text
- typing with a toggled caret style stamps it onto the text
- styling a selection that leaves the caret in place updates the typing style
- undo re-derives the typing style

Verified: the new test class fails on `main` and passes with this change; the full `desktopTest` suite is green with the change.

## Credit

Found while wiring a print-preview editor that pre-selects styles on the caret (thanks @Wavesonics for the span-merging tweak in 3b8399c — that one already fixed our second issue).
